### PR TITLE
feat(web): deepen workspace editor workflows

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,7 +24,13 @@ Product implementation is governed by the
 - A compact, grouped Code Task Library with on-demand search and one
   current-task workspace; rename and delete stay inline in the affected row.
 - A continuous task conversation with Workspace and Activity opened as
-  contextual right-side views.
+  contextual right-side views that can expand in place to a full content-area
+  presentation without remounting the editor or losing drafts. Conversation
+  headers expose launch actions only while no context panel is open; the
+  mounted panel then owns switching, presentation, and close actions so a
+  responsive overlay never leaves covered duplicate controls in the focus
+  order. Opening moves keyboard focus into the active panel mode, while closing
+  returns it to the control that opened the panel.
 - Natural-language task composition with a searchable recent-workspace picker,
   native local-folder selection, a lazy color-coded `@` workspace tree,
   searchable highlighted Skill suggestions, safe file/folder drop import, and
@@ -50,10 +56,21 @@ Product implementation is governed by the
   instead of blocking the workspace.
 - A VS Code-aligned Web IDE with a compact explorer, color-coded file and Git
   decorations, pointer and keyboard context menus with in-place file-operation
-  flows, lazy-loaded Monaco editing, independent dirty file tabs, keyboard
-  save/close/tab switching, search, replace, conflict protection, config
-  validation, and saved-file Code Intelligence for document symbols, semantic
-  navigation, and diagnostics.
+  flows, one roving tree tab stop with visual-order and hierarchical arrow-key
+  navigation, focused-row `F2` rename and confirmed `Delete` with focus
+  recovery, a global `Cmd/Ctrl+P` file picker with fuzzy name/path ranking,
+  lazy-loaded Monaco editing, independent dirty file tabs with shortest-unique
+  parent labels for same-named files, a semantic roving tab strip with
+  post-close focus recovery and editor-to-editor `Ctrl+Tab` focus handoff,
+  keyboard save/close/tab switching scoped to workspace focus, an editor-safe
+  `Cmd/Ctrl+B` task-sidebar toggle, bounded
+  back/forward location history,
+  a task-scoped full-screen workspace with Escape restoration,
+  source-focused search with an explicit dependency/build scope, reviewed
+  replacement, conflict protection, config validation,
+  and saved-file Code Intelligence for document symbols, semantic navigation,
+  and diagnostics, with one visible toolbar menu for definition, declaration,
+  references, implementations, and the file outline.
 - Workspace-wide Git review with complete original/modified Monaco diff tabs,
   stage, unstage, and commit.
 - A complete local configuration center for A3S OS account and endpoint,
@@ -67,8 +84,8 @@ Product implementation is governed by the
 - A source-grouped task model switcher that combines configured Provider models
   with valid local Claude Code, Codex, and WorkBuddy account models through the
   same runtime discovery and client routing used by the TUI.
-- A browser-native command palette (`Cmd/Ctrl+K`) for existing pages and
-  contextual actions.
+- Browser-native command (`Cmd/Ctrl+K`) and file (`Cmd/Ctrl+P`) palettes for
+  existing pages, contextual actions, and bounded workspace navigation.
 - Wide and compact desktop layouts, plus system, light, and dark themes.
 
 The primary journey is:
@@ -82,19 +99,103 @@ Create task → add context → execute → decide permissions
 ## Code Intelligence
 
 Monaco shares the workspace-scoped native Code Intelligence runtime owned by
-the CLI backend. Go to Symbol in Editor uses the saved document outline;
-definition, declaration, references, and implementations are editor actions;
-diagnostics appear as Monaco markers. Dirty buffers remain browser-local, and
-the status bar says when semantic results use the saved version.
+the CLI backend. The file toolbar exposes definition, declaration, references,
+implementations, and Go to Symbol in Editor together with their keyboard
+shortcuts. The same navigation commands remain available from Monaco's context
+menu; diagnostics appear as Monaco markers. The editor toolbar keeps a bounded,
+workspace-scoped location history: `Ctrl+-` returns to the previous file and
+caret, while `Ctrl+Shift+-` moves forward. Open drafts are reused rather than
+reread, a new navigation clears the forward branch, and file rename/delete
+operations reconcile stored locations. Dirty buffers remain browser-local, and
+the status bar says when semantic results use the saved version while also
+following the live cursor, selection, and Monaco model line ending. Its line
+ending control converts between LF and CRLF through Monaco's undo history and
+normal dirty-file protection. Files without a native language profile keep
+Monaco's local editing and outline features without exposing backend protocol
+errors; the document-symbol bridge always uses the mounted Monaco model's
+concrete language identifier, including plaintext fallback, so an unfamiliar
+extension cannot corrupt Monaco's provider registry. Genuine runtime failures
+remain visible as concise status messages.
+
+`Cmd/Ctrl+P` opens a keyboard-first workspace file picker from Monaco or the
+surrounding task surface. It ranks exact filenames, path fragments, and fuzzy
+subsequences, keeps open tabs at the top before a query, ignores dependency and
+build outputs, and reports bounded or truncated catalogs without blocking the
+current draft. Selecting an already-open file reuses that tab and its unsaved
+content. Explorer directory entries and quick-open results share one file-type
+contract: common source, configuration, and lockfile formats remain editable;
+known binary formats use extension hints and unfamiliar extensions are sampled
+before either entry point labels them as binary.
+
+The editor and diff viewer share one lazy local Monaco runtime. It retains the
+complete standalone editing surface and the JSON, CSS, HTML, JavaScript, and
+TypeScript language services, while registering tokenizers only for the file
+types the product opens as source text. The runtime does not import Monaco's
+broad package entry, so unused bundled languages and protocol clients stay out
+of the editor activation graph without weakening find, folding, suggestions,
+diagnostics, navigation, themes, workers, or diff behavior.
+
+Explorer mutations preserve the visible tree as well as open editors. Renaming
+an expanded directory rebases its loaded descendants, expansion state, and
+retry state; deleting a path evicts its entire cached subtree immediately.
+Late directory responses are ignored, so a failed parent refresh cannot bring
+back an old name or a deleted child. New files use the backend's atomic
+create-only operation, so a conflicting path reports an error in place without
+truncating the existing file.
+
+Text reads also return a content revision. A normal save sends that revision as
+its server-side precondition and performs no client-side read-before-write
+request. Restored legacy tabs without a revision use their last saved content as
+the precondition. A mismatch returns HTTP 412 without changing the file, after
+which the editor fetches the latest disk version and offers reload or explicit
+unconditional overwrite. Successful saves and both conflict resolutions update
+the tab's revision before the next edit.
+
+The entire editor workspace is task-scoped rather than repository-scoped.
+Switching tasks snapshots tabs, dirty drafts, the active selection and view,
+explorer and search state, Git review state, conflicts, and load errors, then
+restores the destination task even when both tasks use the same repository.
+Within one live page, every text document has a task-isolated Monaco model URI.
+The mounted editor switches models instead of remounting, so each open document
+keeps its undo/redo history, cursor and selections, folding, and scroll state
+across file and task switches. An explicit search or semantic location is
+consumed once; later tab returns restore the document's own view rather than
+replaying a stale jump. A successful file or parent-directory rename rebinds
+the new logical path to the document's existing immutable model URI before its
+tab path changes, preserving that same editing session and live status. If a
+different file is later opened at the old path while the renamed document is
+still retained, it receives a distinct URI instead of sharing undo or view
+state. Models remain retained only while referenced by an open tab in the
+active task or an inactive task snapshot. Cancelling a guarded dirty close
+keeps the model, while confirmed close and snapshot removal dispose the
+orphaned model deterministically. A page refresh restores persisted drafts and
+tabs but starts a new in-memory Monaco undo history.
+Because the switch does not discard content, dirty drafts do not interrupt it;
+destructive close, reload, replacement, and overwrite operations still require
+explicit resolution. Workspace reads and mutations carry a monotonic task
+generation guard, so responses from a previously selected task cannot write
+into the current editor. Versioned browser-local snapshots are debounced during
+editing and flushed synchronously on `pagehide`, so a normal refresh restores
+the active task as well as inactive task snapshots. Malformed data is ignored;
+if browser storage cannot fit the complete caches and clean documents, the
+fallback snapshot preserves dirty drafts and restores other tabs with an
+explicit retry state.
 
 The first release supports Rust through `rust-analyzer` and
 TypeScript/JavaScript through `typescript-language-server --stdio`. See the
 [Code Intelligence guide](../../crates/cli/docs/code-intelligence.md) for
 installation, shortcuts, saved-file behavior, and the typed local API.
 
-Text search, replace, file loading, and writes continue through the existing
-workspace APIs. Code Intelligence returns only semantic metadata and locations,
-then reuses the normal file-selection flow to open a target.
+Text search excludes repository metadata, dependency caches, and common build
+outputs by default so source matches remain useful. The Search panel can opt
+into those directories and reruns the current query immediately; query, scope,
+or workspace changes make the displayed replacement set stale until a search
+succeeds. Search renders at most 300 matches and probes one additional match;
+when that sentinel exists, the panel reports truncation and keeps replacement
+disabled until the user narrows the search. Search, replace, file loading, and
+writes continue through the existing workspace APIs. Code Intelligence returns
+only semantic metadata and locations, then reuses the normal file-selection
+flow to open a target.
 
 Memory browsing and consolidation, Knowledge, task branching, automation
 assets, plugins, and global processes are deliberately excluded until they

--- a/apps/web/docs/COMPONENT_SPEC.md
+++ b/apps/web/docs/COMPONENT_SPEC.md
@@ -113,9 +113,14 @@ the row action saves and Escape cancels. Delete replaces the same row with a
 compact confirmation and keeps recoverable errors there. No centered dialog or
 success toast interrupts either operation.
 
-**Continuity:** selecting another task saves the current draft and safe Result
-Workspace state. A running task retains its own status. An unresolved dirty
-artifact blocks selection before the active task changes.
+**Continuity:** selecting another task snapshots the complete task-scoped
+Composer and Result Workspace state, including dirty drafts, then restores the
+destination task. A running task retains its own status. Task switching is
+non-destructive and does not require a dirty-file prompt; close, reload,
+replace, and overwrite retain their explicit discard guards. A debounced,
+versioned browser-local snapshot plus a synchronous `pagehide` flush provides
+the same restoration across refresh; malformed state is discarded and a
+capacity fallback retains dirty drafts before rebuildable content.
 
 **Next action:** a selected task opens its Conversation; a new task focuses the
 preparation Composer.
@@ -169,17 +174,23 @@ itself.
 
 ### `TaskHeader`
 
-**Role:** show task identity, workspace, execution state, and the action that
-reopens the task's last Result Workspace state.
+**Role:** show task identity, workspace, execution state, and conversation-only
+launch actions for the task's Workspace and Activity context.
 
 **Contract:** the active header is 44 px high, keeps title and workspace on one
 line, and subscribes to the same persisted title source as the Task Library so
 an inline rename updates both surfaces immediately.
 
-**Actions:** reopen Results and task activity.
+**Actions:** open Workspace or Activity while Conversation owns the foreground.
+Once either context panel is mounted, its header exclusively owns mode
+switching, full-screen presentation, and close. The task header removes its
+redundant launchers so responsive overlays cannot cover focusable background
+controls. Opening moves keyboard focus to the active panel mode unless mounted
+content already established a more specific focus target. Closing returns
+focus to the original launcher even after switching modes inside the panel.
 
-**Guards:** rendered only for an existing task. It does not expose a separate
-Activity right panel; operational detail stays in the execution stream.
+**Guards:** rendered only for an existing task. It never duplicates context
+navigation while a context panel is open.
 
 ### `ExecutionStream`
 
@@ -514,7 +525,12 @@ workspace.
 **Actions:** select tab, close tab, toggle full screen, and close workspace.
 
 **Contract:** mode selection does not live as four permanent header buttons.
-In-progress destructive mutations can guard close.
+In-progress destructive mutations can guard close. Full screen expands the
+same mounted workspace, marks the obscured Conversation inert, persists in the
+task-scoped snapshot, and exits through the header action or Escape. Closing
+returns presentation to docked before restoring Conversation and keyboard
+focus to the control that opened the workspace. Opening establishes focus
+inside the workspace without overriding a child editor's own mounted focus.
 
 ### `ArtifactTabs`
 
@@ -611,11 +627,72 @@ pointer context-menu gesture or `Shift+F10` opens one viewport-bounded,
 keyboard-operable menu at the row; tree whitespace opens root create and refresh
 actions. Menu selection moves create, rename, copy, or delete into the affected
 tree location's in-place editor or confirmation state. Escape restores focus to
-the invoking row, and outside click dismisses without changing selection.
+the invoking row, and outside click dismisses without changing selection. With
+a row focused, `F2` enters the same in-place rename flow and `Delete` enters the
+same explicit confirmation state; neither shortcut bypasses validation or the
+destructive-action guard. Rename focuses its name input; delete focuses the safe
+Cancel action. Cancelling either operation restores the originating row, while
+a successful mutation falls back to the rebased active path or nearest
+surviving row instead of the document body.
+
+**Keyboard navigation contract:** expose exactly one tree-row tab stop. Arrow
+Up/Down move through the currently rendered rows without opening a file;
+Home/End reach the first and last row. Arrow Right expands a closed directory
+or enters its first child, while Arrow Left collapses an open directory or
+returns to its parent. Filter-matched ancestors participate in the same visual
+order but navigation does not persist their temporary expansion. Every move
+scrolls the focused row into view and keeps focus distinct from editor
+selection.
+
+**File-type contract:** directory rows receive authoritative binary status from
+the workspace service and pass it unchanged through pointer, keyboard, and
+context-menu selection. Explorer and quick open use the same extension hints
+and bounded content sampling, so choosing the same path cannot alternate
+between text loading and binary metadata.
+
+**Tree-state contract:** a successful rename rebases loaded directory keys,
+entry paths, expanded nodes, loading flags, and retryable errors for the whole
+subtree. A successful delete removes the target from parent rows and evicts all
+descendant caches before the parent refresh returns. Only the newest read for a
+directory may publish state, so an older response cannot recreate a renamed or
+deleted path; confirmed mutations remain visible even when the parent refresh
+fails.
 
 **Guards:** unchanged rename is rejected; in-tree confirmation cannot be
-resubmitted while a mutation runs; rename and delete rebase or close every
-affected editor tab.
+resubmitted while a mutation runs; rename and delete reconcile both the cached
+tree and every affected editor tab. File creation uses a create-only backend
+operation; an existing path remains byte-for-byte unchanged and the inline form
+retains the recoverable conflict.
+
+### `WorkspaceQuickOpen`
+
+**Role:** provide keyboard-first file navigation without requiring the
+workspace tree to be expanded or loaded.
+
+**Entry points:** `Cmd/Ctrl+P`, the Explorer toolbar, the empty editor action,
+and the command palette. The shortcut is captured before Monaco stops keydown
+propagation, but only while an active task has a workspace.
+
+**Behavior:** query the local workspace catalog after a short input debounce;
+rank exact filenames, path matches, and fuzzy subsequences. Before a query,
+show open file tabs first and mark them without duplicating catalog rows. Keep
+only the newest request authoritative, expose loading, empty, retryable error,
+binary, and truncated states, and close only after the selected file opens
+successfully. A selected open tab reuses its draft through normal workspace
+selection.
+
+**Keyboard and accessibility contract:** focus the combobox on open; expose a
+listbox with `aria-activedescendant`; wrap Arrow Up/Down selection; support
+Home, End, Enter, repeated `Cmd/Ctrl+P`, Escape, and a trapped Tab cycle; scroll
+the active option into view and restore prior focus when that element still
+exists.
+
+**Catalog contract:** return absolute and workspace-relative paths, basename,
+binary status, total count, and truncation. Skip symlink traversal, repository
+metadata, dependency caches, and common generated output directories. Limit a
+response to 500 files server-side even if a larger value is requested. Preserve
+common source, configuration, module, and lockfile formats as text; classify
+known binary extensions directly and content-sample unfamiliar extensions.
 
 ### `EditorTabStrip`
 
@@ -627,16 +704,78 @@ per-file loading and dirty state.
 
 **Contract:** opening another file never discards a draft. A dirty close offers
 Save and Close, Don't Save, and Cancel. `Cmd/Ctrl+W` follows the same guard.
+Unique filenames stay compact; collisions add the shortest unique parent-path
+suffix, including in the tab and close-action accessible names, so monorepo
+files never depend on hover text for identity. Each tab is a real
+`button[role="tab"]`; its close button is a sibling rather than an interactive
+descendant. Exactly one selected tab participates in the tab order. Arrow
+Left/Right wrap and activate, Home/End reach the boundary tabs, and Delete uses
+the same guarded close path. If removal disconnects the current focus, focus
+moves to the surviving active tab or the empty editor's Quick Open action; a
+still-connected control elsewhere keeps focus. Any active-tab change that
+disconnects its invoking control falls back to the newly active tab.
 
 ### `MonacoFileEditor`
 
 **Role:** provide the local VS Code editing engine for the active text tab,
 including syntax highlighting, folding, indentation, exact line/column reveal,
-and model view state.
+model view state, saved-document diagnostics, and semantic navigation.
+
+**Actions:** one visible file-toolbar menu exposes definition, declaration,
+references, implementations, and file outline. Monaco shortcuts and its editor
+context menu invoke the same navigation boundary.
 
 **Contract:** Monaco and its language workers are bundled locally and loaded on
-demand. `Cmd/Ctrl+S` saves the active tab. Binary files never create a Monaco
-text model.
+demand. The shared editor/diff runtime keeps Monaco's complete standalone
+contribution surface, four worker-backed language-service families (JSON, CSS,
+HTML, and TypeScript/JavaScript), and only the tokenizers needed by the
+product's ACL/HCL, shell, C/C++, JavaScript/TypeScript, CSS, Go, HTML, JSON,
+Markdown, Python, Rust, SQL, INI/TOML, XML, and YAML mappings. It starts from
+the scoped editor API rather than the package-wide entry, so unsupported
+language tokenizers and unused protocol code are not part of editor activation.
+Semantic targets reuse normal workspace file selection; dirty buffers remain
+local and navigation labels results that come from the saved document.
+One mounted editor switches between models whose virtual URI combines task
+scope and the normalized path first assigned to the document. A referenced
+model owns its live undo/redo stack, cursor and selections, folding, scroll,
+readiness, and editor status. File switches and task switches save and restore
+that state without copying it into another task that opened the same path.
+Before a successful file or parent-directory rename mutates an open tab, the
+model registry rebinds the new logical path to the document's existing
+immutable URI. Reopening the old path while that document remains retained
+allocates a distinct URI, preventing model and history collisions. Search or
+semantic line/column input is applied and consumed once; subsequent activation
+restores the model-owned view. The model registry retains exactly the models
+referenced by active-task tabs or inactive task snapshots. Cancelling a dirty
+close keeps the reference; confirmed close, workspace replacement, and
+task-snapshot removal dispose orphaned models.
+Browser-local snapshot restoration recreates drafts after refresh but does not
+claim to serialize Monaco's in-memory undo history.
+The document-symbol provider registers against the mounted model's concrete
+language identifier, never an optional path mapping; modern JavaScript and
+TypeScript module extensions map to their native Monaco languages and unknown
+extensions use the model's plaintext fallback without corrupting the provider
+registry.
+An unsupported native language clears only native diagnostics and returns no
+native symbols so Monaco-local providers can continue. Unsupported responses
+stay out of the status bar, and a missing document language profile is retained
+for the active editor session to avoid repeated native queries. Genuine service
+failures use concise labels. Save, close-tab, and tab-switch shortcuts are
+scoped to focus within the workspace and never intercept Conversation input.
+`Ctrl+Tab` and `Ctrl+Shift+Tab` preserve continuous editing by handing focus to
+the target file or modified diff editor only when the shortcut originated in
+an editor surface. The handoff waits for the keyed Monaco instance to mount and
+does not let a diff editor steal focus from a connected toolbar or tab control.
+`Cmd/Ctrl+B` remains available while Monaco owns focus so compact desktop users
+can reclaim the task-sidebar width; the same chord remains untouched in the
+Conversation Composer and other editable text surfaces.
+The status observer reads cursor, selections, and line endings from the active
+Monaco model and updates only when that compact status changes. The line-ending
+status opens an accessible radio menu and converts through Monaco's undoable
+`pushEOL` operation; the resulting model change follows the normal draft and
+save path. Read-only context review disables conversion. `Cmd/Ctrl+S` saves the
+active tab. Binary files never create a Monaco text model or expose text-model
+metadata in the status bar.
 
 ### `FileArtifactView`
 
@@ -648,21 +787,53 @@ binary state, load failure, and editor status bar.
 - selecting the same dirty file activates its existing model without rereading;
 - read failure remains attached to the failed tab with a retry;
 - binary files cannot enter the text save path;
-- disk changes trigger an explicit reload or overwrite decision;
+- every text read and successful write refreshes the tab's content revision;
+- normal saves send that revision, or legacy saved content, as a server-side
+  precondition without first rereading the file;
+- HTTP 412 preserves the draft, reads the current disk version, and triggers an
+  explicit reload or overwrite decision; only overwrite is unconditional;
 - editing a validated configuration invalidates stale validation.
 
 **Navigation input:** optional line and column from Search.
+
+**Location-history contract:** the workspace controller records the live caret
+before file, search-result, or semantic navigation and exposes toolbar Back and
+Forward actions. History is bounded and workspace-scoped. Restoring an open tab
+reuses its draft, a new navigation clears the forward branch, rename and delete
+reconcile paths, and a closed target is activated only after it loads
+successfully. `Ctrl+-` and `Ctrl+Shift+-` are consumed only while focus is
+inside the workspace editor.
+
+**Status contract:** show the active line and column, selected characters or
+multiple cursors, model-reported `LF` or `CRLF`, encoding, dirty
+state, and native-navigation state. Hide model-derived fields while Monaco is
+not mounted. Selecting another line ending returns focus to Monaco and marks
+the tab dirty; Escape from the menu returns focus to the status trigger.
 
 ### `WorkspaceSearch`
 
 **Role:** search text, group matches by file, open exact results, and perform
 bounded replacement inside Files mode.
 
-**State:** typed query, searched query, result set, replacement, searching, and
-replacing are separate values.
+**State:** typed query, searched query, selected directory scope, successful
+result scope and workspace, result set, replacement, searching, and replacing
+are separate values. The selected scope survives closing and reopening the
+panel.
 
-**Guards:** stale results disable Replace. Replacement uses the displayed result
-set's query and is blocked by affected unsaved content.
+**Behavior:** source scope excludes repository metadata, dependency caches, and
+common build outputs. Including those directories reruns a non-empty query;
+only the newest in-flight request may publish results. Each match carries
+bounded context, UTF-16 offsets within that context, and a one-based UTF-16
+column that can be passed directly to Monaco. The client also bounds legacy
+full-line responses before rendering and highlights the selected occurrence.
+Search requests one sentinel beyond the 300-match presentation limit, renders
+at most 300 matches, and marks the result set as truncated when the sentinel is
+present.
+
+**Guards:** a changed query, scope, or workspace and an in-flight search disable
+Replace. Replacement uses the displayed result set's query and is blocked by
+affected unsaved content. A truncated result set displays an explicit narrowing
+prompt and cannot be replaced, including through a direct controller call.
 
 ## Browser mode
 

--- a/apps/web/docs/FUNCTIONAL_SPEC.md
+++ b/apps/web/docs/FUNCTIONAL_SPEC.md
@@ -90,17 +90,25 @@ does not create a disabled Browser mode.
 - Present new-task preparation as a focused Composer with concise guidance and
   editable Code scenario starters.
 - Hide task identity, result actions, and operational status until a task exists.
-- Create a task from the current new-task draft on first send.
+- Create a task from the current new-task draft on first send, promote the
+  prepared Composer and Result Workspace state into that task, and leave the
+  next new-task slot empty.
 - Search and select tasks; rename and delete directly inside the affected row
   with keyboard save/cancel and inline failure recovery.
 - Persist active task, titles, drafts, queues, and task-scoped Result Workspace
-  state on a best-effort basis.
+  state across a normal browser refresh on a best-effort basis. Flush the active
+  snapshot on `pagehide`, reject malformed stored state, and prioritize dirty
+  drafts over rebuildable caches if browser capacity is constrained.
 - Keep running status scoped to the real running task.
 - Preserve the current draft when switching tasks.
 
 Acceptance: opening another task while one runs offers a direct return to the
-running task and never marks the selected idle task as running. An unresolved
-dirty artifact blocks the task switch before selection changes.
+running task and never marks the selected idle task as running. Switching tasks
+captures and restores dirty drafts inside the originating task, including when
+both tasks use the same workspace, so selection changes without a destructive
+prompt. Close, reload, replace, or overwrite still requires explicit resolution
+when it would discard unsaved content. Refresh restores the active task's dirty
+tabs without writing them to disk.
 
 ## F3 — Compose and execute
 
@@ -180,6 +188,13 @@ entry cannot open an unrelated task's state.
 
 - Keep the Result Workspace closed until a task action opens a meaningful result.
 - Provide one shared header with artifact tabs, full-screen, and close actions.
+- Remove the Conversation header's context launchers while the shared workspace
+  header owns navigation, presentation, and close, including at overlay widths.
+- Expand the mounted workspace in place, keep the obscured Conversation out of
+  the focus order, persist presentation per task, and let Escape restore the
+  docked layout.
+- Move keyboard focus into the active workspace mode when it opens unless its
+  mounted content already owns a more specific focus target.
 - Provide one compact mode switcher for Overview, Files, Browser, and Changes.
 - Give each mode a mode-specific navigator and a dominant artifact viewport.
 - Focus an existing tab when the same artifact is opened twice.
@@ -191,31 +206,139 @@ entry cannot open an unrelated task's state.
 
 Acceptance: a task with no artifacts shows no empty Result Workspace; close and
 full-screen are reversible; switching modes never discards unrelated open tabs
-or unsaved edits; keyboard focus returns to the opening control on close.
+or unsaved edits; keyboard focus enters the opened workspace and returns to the
+opening control on close.
 
 ## F6 — Overview and Files
 
 - Group task results by files, changes, previews, and verification in Overview.
 - Browse directories and open text files in Files.
+- Open a keyboard-first file picker with `Cmd/Ctrl+P` from Monaco or the task
+  surface. Rank exact filenames, path fragments, and fuzzy subsequences; place
+  already-open tabs first before a query and reuse their browser-local drafts.
+  Bound every response, report truncation, ignore repository metadata,
+  dependency caches, and common build outputs, and let a failed lookup retry
+  without replacing the active editor.
 - Use a locally bundled, lazy-loaded Monaco editor with syntax highlighting,
   folding, exact line/column reveal, and per-document view state.
+- Keep the editor activation graph scoped to Monaco's complete standalone
+  editor/diff surface, the existing JSON/CSS/HTML/TypeScript language services,
+  and tokenizers for product-supported source files. Do not import the broad
+  package entry or ship unused bundled language registrations and protocol
+  clients as part of editor activation.
+- Keep one mounted code editor while file tabs switch between task-isolated
+  Monaco models. Within a live page, retain each referenced model's undo/redo
+  stack, cursor and selections, folding, and scroll state across file and task
+  switches. Consume an explicit navigation location once so a later tab return
+  restores model view state instead of repeating an old jump.
+- Before rebasing an open tab for a successful file or parent-directory rename,
+  bind its new logical path to the same immutable Monaco model URI. Preserve
+  editor readiness, live status, undo/redo, cursor and selections, folding, and
+  scroll state. If the old path is opened again while that model is retained,
+  allocate a distinct model URI so the two documents cannot share state.
+- Retain a model only while an active-task tab or inactive-task snapshot owns
+  it. Cancelling a dirty-close guard keeps that ownership; confirmed close,
+  task-snapshot removal, or workspace replacement must dispose every orphaned
+  model without affecting another task that opened the same path. Browser
+  refresh restores persisted drafts, not the previous in-memory undo stack.
+- Expose saved-document definition, declaration, references, implementations,
+  and file outline from one visible editor-toolbar menu while retaining Monaco
+  shortcuts and context-menu actions.
+- Keep a bounded location history for normal file selection, exact search
+  matches, and semantic targets. Toolbar controls and `Ctrl+-` / `Ctrl+Shift+-`
+  move backward and forward to the exact saved caret without rereading an open
+  draft. A new navigation clears the forward branch; rename rebases stored
+  paths, delete prunes them, and an unreadable closed target never replaces the
+  active editor.
+- Fall back to Monaco-local language features when native Code Intelligence has
+  no profile for the selected file, without presenting the unsupported response
+  as a runtime failure or hiding genuine service failures.
 - Open files and Git comparisons in one multi-tab strip; preserve independent
-  drafts while switching and guard only dirty tab closure.
-- Search workspace text and open an exact line and column.
+  drafts while switching tabs or tasks, and require explicit resolution only
+  when an operation would discard or overwrite a dirty draft.
+- Keep unique filenames compact, but add the shortest unique workspace-parent
+  suffix when two open tabs have the same visible name. Apply the same
+  disambiguation to the tab, its accessible name, and its close action.
+- Keep the tab and close actions as separate semantic buttons. Use one roving
+  tab stop with automatic Arrow Left/Right, Home, and End activation; let Delete
+  follow the normal close guard. When closing removes the focused document,
+  move focus to the surviving active tab or the empty editor's Quick Open
+  action. Never steal focus from a still-connected Explorer or dialog control.
+- Apply save, close-tab, and tab-switch keyboard commands only while focus is
+  inside the Result Workspace so the Conversation composer keeps its own input
+  behavior. When `Ctrl+Tab` or `Ctrl+Shift+Tab` starts in Monaco, move focus
+  into the newly active file or diff editor after that editor mounts. Preserve
+  a still-connected workspace control instead; if switching replaces that
+  control, fall back to the newly active tab rather than the document body.
+- Let `Cmd/Ctrl+B` collapse or restore the task sidebar while Monaco owns focus,
+  while preserving the same chord for editable Conversation content.
+- Reserve `Cmd/Ctrl+P` for file quick open only when an active task and
+  workspace exist; otherwise preserve the browser's print shortcut.
+- Report the active Monaco cursor, selected-character count, multiple cursors,
+  and actual model line ending in the editor status bar. Do not claim text
+  encoding or line-ending metadata before a text model exists.
+- Let an editable text tab convert between LF and CRLF from the status bar.
+  Conversion must use Monaco's undo history, update the browser-local draft,
+  and follow normal dirty/save guards; read-only review keeps the control
+  visible but disabled.
+- Search workspace text and open an exact line and column. Exclude repository
+  metadata, dependency caches, and common build outputs by default; expose one
+  explicit control that includes them and reruns the current query. Search
+  responses use bounded match context and Monaco-compatible UTF-16 columns so
+  generated single-line files cannot inflate the result payload without bound.
 - Open file and directory operations from a VS Code-style pointer or keyboard
   context menu rather than hover-revealed row buttons. Keep create, rename,
   copy, delete confirmation, busy state, and recoverable errors at the affected
-  tree location after an operation is chosen.
-- Edit and save text with dirty-state protection.
-- Detect external changes and let the user reload or overwrite explicitly.
-- Render binary files as non-editable metadata.
+  tree location after an operation is chosen. Rename every loaded descendant
+  and preserve expanded state; delete every cached descendant immediately.
+  Ignore superseded directory reads so late responses cannot restore stale
+  paths after a successful mutation.
+- Give the Explorer tree one roving tab stop. Move through rendered rows with
+  Arrow Up/Down and Home/End; use Arrow Right to expand or enter the first child
+  and Arrow Left to collapse or return to the parent. Navigation must not open
+  files or persist filter-only expansion. Keep focus inside the inline flow and
+  return it to the originating or nearest surviving row after completion.
+- Create files with an atomic create-only backend operation. If the path already
+  exists, retain its bytes, keep the inline operation retryable, and report the
+  conflict instead of routing creation through the destructive save endpoint.
+- Edit and save text with dirty-state protection. Track the content revision
+  returned by every read and successful write; normal saves submit it as a
+  server-side precondition without a read-before-write round trip. Restored
+  legacy tabs submit their last saved content as the compatibility precondition.
+- Treat HTTP 412 as an external-change conflict, preserve the local draft, fetch
+  the latest disk content for comparison, and let the user reload or overwrite
+  explicitly. Only the explicit overwrite action may issue an unconditional
+  write.
+- Render binary files as non-editable metadata. Explorer directory entries and
+  quick-open results must use the same backend classification contract.
+- Keep common source, configuration, module, and lockfile formats on the text
+  path. Use known binary extensions as fast hints and sample unfamiliar
+  extensions instead of treating every unlisted extension as binary.
 - Validate supported configuration files and invalidate validation after edit.
 - Confirm replacement scope and use the displayed result set's searched query.
+- Render no more than 300 search matches; when an additional match proves the
+  result set is truncated, show a narrowing prompt and prohibit replacement.
 
 Acceptance: file read failure preserves the previous artifact; same-file
 selection does not reread a dirty draft; Save and Close, Don't Save, and Cancel
-protect dirty tab closure; parent rename rebases all affected tabs; Replace is
-disabled for stale results or affected unsaved content.
+protect dirty tab closure; semantic navigation always has a visible entry and
+labels dirty-buffer results as saved-document results; an unsupported native
+language leaves local editing and file outline usable without raw backend text;
+editor shortcuts never consume Conversation keystrokes; parent rename rebases
+all affected tabs and navigation locations while each open text document keeps
+its immutable model identity, live editor status, undo/redo history, selections,
+folding, and scroll; reopening the former path creates a non-colliding model;
+backward and forward navigation restores the exact caret without discarding
+drafts; cursor and line-ending status follows the active Monaco model;
+same-named tabs remain distinguishable without hover; normal edits, undo/redo
+history, selections, folding, and scroll survive live file and task switches
+without leaking between tasks; stale navigation locations are not replayed;
+closing the last owner releases its model; line-ending conversion is undoable and
+makes the tab dirty; only the latest search response may update results;
+Replace is disabled when the query, directory scope, or workspace differs from
+the successful result set, while search is running, or when affected content is
+unsaved; a result set with more than 300 matches renders only the first 300 and
+cannot be replaced.
 
 ## F7 — Browser preview
 

--- a/apps/web/docs/PRODUCT_ARCHITECTURE.md
+++ b/apps/web/docs/PRODUCT_ARCHITECTURE.md
@@ -74,13 +74,15 @@ Browser  → PreviewNavigator     + BrowserViewport
 Changes  → ChangedFileNavigator + DiffViewport
 ```
 
-Search, dialogs, mode selection, and the command palette are transient support
-surfaces. Task parameters remain inside `TaskComposer`. New-task preparation
+Search, dialogs, mode selection, and the command and file palettes are
+transient support surfaces. Task parameters remain inside `TaskComposer`. New-task preparation
 does not instantiate empty active-task or result components.
 
 At wide desktop sizes, Result Workspace is a resizable peer of Conversation.
 Around 1024 px it becomes an overlay. Full screen promotes the same workspace
-instance; it does not mount another editor or duplicate state.
+instance; it does not mount another editor or duplicate state. The obscured
+Conversation becomes inert until the task-scoped presentation returns to
+docked, including through Escape or panel close.
 
 ## Feature boundaries
 
@@ -108,8 +110,23 @@ boundary rather than coexist with a duplicate right-panel system.
 
 Owns workspace tree state, the authoritative file/diff tab model, per-file dirty
 content, Monaco model identity, search scope, file conflicts, replacement, and
-configuration validation. The service remains authoritative about disk
-content.
+configuration validation. Directory reads use newest-request-wins publication;
+confirmed rename and delete operations optimistically reconcile loaded subtree
+keys and rows before refresh. The service remains authoritative about disk
+content. Every asynchronous workspace read or mutation captures the active task
+generation and workspace root before it starts; a late response may update only
+the same task context and cannot publish into a subsequently selected task.
+Initial Monaco model identity combines a stable task scope with the normalized
+document path, so two tasks may open the same file without sharing undo history
+or view state. Because Monaco URIs are immutable, the model registry rebinds a
+renamed document's new logical path to its existing URI before tab paths change;
+an old path reopened concurrently receives a collision-free identity. One
+editor instance switches among those models. The registry owns view-state
+capture and deterministic disposal: active tabs and inactive task snapshots
+form the complete retention set, a cancelled dirty close remains in that set,
+and confirmed close or snapshot removal releases any unreferenced model.
+Explicit navigation coordinates are transient commands rather than persistent
+model state.
 
 ### `features/preview`
 
@@ -212,9 +229,15 @@ stateDiagram-v2
     Closed --> Docked: reopen last safe state
 ```
 
-An unresolved dirty artifact guards transitions that would discard its draft.
-Switching tasks stores the current task's safe workspace state and restores the
-destination task's state. It never transfers the selected artifact by position.
+An unresolved dirty artifact guards only transitions that would discard or
+overwrite its draft. Switching tasks is non-destructive: it stores the current
+task's tabs, dirty drafts, active selection, mode, explorer/search state, and Git
+review state, then restores the destination task's snapshot. It never transfers
+the selected artifact by position, even when both tasks use the same repository.
+The same snapshot model is persisted with a versioned browser-local envelope.
+Writes are debounced during interaction and flushed on `pagehide`; restoration
+normalizes transient loading/saving flags, rejects malformed entries, and falls
+back to dirty-draft-first recovery when full caches exceed storage capacity.
 
 ## Core task workflow
 
@@ -264,9 +287,18 @@ flowchart LR
 
 Search retains its searched query, line, and column. Replace is blocked when the
 input no longer matches the result set or an affected file has unsaved content.
-Binary files never enter the text save path. Preview navigation remains within
-the service-defined target boundary. Git mutations preserve review context on
-failure.
+Explorer and quick open consume the same service-owned binary classification;
+binary files never enter the text read or save path regardless of which entry
+point opened them. Preview navigation remains within the service-defined target
+boundary. Git mutations preserve review context on failure.
+
+Text file state carries a content-derived revision from the workspace service to
+the task-owned editor tab. Normal saves are conditional writes against that
+revision and do not perform a browser-side read-before-write sequence. Legacy
+persisted tabs fall back to comparing their saved content. A precondition
+mismatch leaves disk bytes untouched, returns HTTP 412, and moves the editor into
+the existing conflict state; reload refreshes both content and revision, while
+explicit overwrite is the only unconditional write path.
 
 ## Overlay and focus rules
 

--- a/apps/web/docs/PRODUCT_BLUEPRINT.md
+++ b/apps/web/docs/PRODUCT_BLUEPRINT.md
@@ -262,10 +262,13 @@ workspace, including its useful clean state.
   useful empty state.
 - Changed-file entries show status and additions/deletions without claiming
   task provenance.
-- Dirty file tabs cannot close, switch task, or reload destructively without an
-  explicit resolution.
-- A task switch restores that task's last safe workspace state and never
-  transfers another task's selected artifact.
+- Dirty file tabs cannot close, reload, replace, or overwrite destructively
+  without an explicit resolution.
+- A task switch snapshots dirty drafts with the originating task, restores that
+  task's complete workspace state on return, and never transfers another task's
+  selected artifact.
+- A normal browser refresh restores the active task and its unsaved editor
+  drafts from a versioned local snapshot without writing those drafts to disk.
 
 ## Functional modules and delivery order
 

--- a/apps/web/docs/USER_JOURNEYS.md
+++ b/apps/web/docs/USER_JOURNEYS.md
@@ -59,14 +59,18 @@ task that produced it.
    preview target, or changed-file list.
 5. Selecting another artifact updates the viewport without resetting
    Conversation, Composer, or unrelated tabs.
-6. Full screen expands the same workspace state. Closing restores full
-   Conversation width and returns focus to the opening control.
+6. The task-context header or command palette expands the same workspace
+   instance to the full content area. Escape or the same header action restores
+   the docked layout; closing restores full Conversation width.
 7. Reopening Results restores the task's last safe mode, tabs, selection, size,
    and relevant scroll position.
 
 **Recovery:** a failed artifact load retains the previous content and failed
 target with one in-context retry. A dirty artifact blocks destructive close,
-reload, and task switching until explicitly resolved.
+reload, replacement, or overwrite until explicitly resolved. Switching tasks
+snapshots the dirty draft inside its originating task and restores it on return,
+so navigation itself remains non-destructive. A normal page refresh restores
+the same browser-local dirty tab without saving it to the workspace.
 
 **Acceptance outcome:** the right workspace feels like an extension of the
 selected result, not a separate IDE or disconnected feature panel.
@@ -78,22 +82,67 @@ originating task.
 
 1. The user opens Files from an artifact entry or the mode switcher.
 2. The navigator exposes the workspace tree and search without hiding the active
-   file.
+   file. `Cmd/Ctrl+P` can instead find a file by exact name, path fragment, or
+   fuzzy subsequence without expanding directories; open tabs appear first and
+   retain their drafts.
 3. A selected text file opens in a Monaco tab; additional file and diff tabs
    preserve their own view and dirty state. Binary content renders as read-only
-   metadata.
-4. The user may edit, switch tabs, and save without losing other drafts. Dirty
-   content blocks tab close, replacement, destructive reload, and deletion only
-   when those actions would discard or overwrite that content.
-5. Search opens a match at its exact location. A failed read keeps Search and
-   the prior artifact intact. Replace uses the displayed result set's query and
-   a confirmed scope.
-6. Supported configuration can be validated. A failure can be appended to the
+   metadata. Source modules, configuration, and lockfiles stay on the text path;
+   an unfamiliar extension is content-sampled before it is treated as binary.
+   When open files share a basename, each tab shows the shortest parent suffix
+   that identifies it without requiring hover. Arrow, Home, and End keys move
+   through the tab strip; deleting or closing the focused tab continues at its
+   successor instead of dropping focus into the document body.
+   Returning to an open text tab in the same page restores its undo/redo stack,
+   cursor and selections, folding, and scroll position. The same path opened by
+   another task has an isolated model. A search or semantic jump chooses the
+   initial location once and does not overwrite that restored view on later
+   returns. Renaming the file or one of its parent directories keeps that same
+   model, editing history, status, and view under the new path. If another file
+   then appears at the former path, opening it creates an independent model
+   instead of inheriting the renamed document's state.
+4. The file toolbar provides one discoverable menu for definition, declaration,
+   references, implementations, and file outline. Keyboard and Monaco context
+   menu actions reach the same saved-document navigation. Back and Forward
+   controls return to the exact source or target caret after file, search, or
+   semantic navigation; `Ctrl+-` and `Ctrl+Shift+-` provide the same actions
+   while focus remains in the workspace.
+5. The user may edit, switch tabs, and save without losing other drafts.
+   Workspace shortcuts apply only while focus remains in the workspace, so
+   typing in Conversation cannot save, close, or switch a file accidentally.
+   `Ctrl+Tab` and `Ctrl+Shift+Tab` continue typing in the destination file or
+   diff editor when invoked from Monaco, while toolbar and tab-strip controls
+   retain focus whenever they remain mounted.
+   At compact desktop widths, `Cmd/Ctrl+B` still toggles the task list while
+   Monaco owns focus, without taking the formatting chord from Conversation.
+   The status bar follows the active cursor and selection and reports the line
+   ending of the actual Monaco model instead of assuming one for every file.
+   An editable tab can switch LF or CRLF there, undo the conversion, and save it
+   through the same dirty-file flow; context-only review cannot mutate it.
+   Returning through location history reuses any open draft rather than
+   rereading the file, and choosing a new target after going back starts a new
+   forward branch.
+   Cancelling a dirty close retains the complete editing session; confirming
+   the close releases it once no active or inactive task tab references it. A
+   browser refresh restores the draft and tabs but begins a fresh undo history.
+   Dirty content blocks tab close, replacement, destructive reload, and deletion
+   only when those actions would discard or overwrite that content.
+6. Search opens a match at its exact location and initially omits repository
+   metadata, dependency caches, and build outputs. The user can include those
+   directories explicitly, which reruns the current query and remains selected
+   when Search is reopened. A failed read keeps Search and the prior artifact
+   intact. Replace uses the displayed result set's query, directory scope, and
+   workspace only after that exact search succeeds. If more than 300 matches
+   exist, Search renders the first 300, explains that the scope must be narrowed,
+   and keeps replacement unavailable.
+7. Supported configuration can be validated. A failure can be appended to the
    same task as a reviewed correction instruction with explicit file context.
-7. The user closes Results or continues directly in Conversation.
+8. The user closes Results or continues directly in Conversation.
 
-**Recovery:** external changes offer explicit reload or overwrite. Failed save,
-rename, replace, or delete preserves the draft, selection, and retry context.
+**Recovery:** external changes offer explicit reload or overwrite. A file type
+without native language support retains Monaco-local editing and outline
+features without displaying backend protocol text. Failed save, rename,
+replace, or delete preserves the draft, selection, and retry context.
 
 **Acceptance outcome:** direct correction and agent follow-up are two connected
 ways to continue the same task.

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import { TasksPage } from '../features/tasks/pages/tasks-page';
 import { SettingsDialog } from '../features/settings/components/settings-dialog';
 import { RefreshCw, WifiOff } from 'lucide-react';
 import { Button } from '../design-system/primitives';
+import { WorkspaceQuickOpen } from '../features/workspace/components/workspace-quick-open';
 
 export function AppShell({ actions }: { actions: CodeActions }) {
   const state = useSnapshot(appState);
@@ -42,6 +43,7 @@ export function AppShell({ actions }: { actions: CodeActions }) {
         </output>
       )}
       {state.commandPaletteOpen && <CommandPalette actions={actions} />}
+      {state.fileQuickOpenOpen && <WorkspaceQuickOpen actions={actions} />}
     </main>
   );
 }

--- a/apps/web/src/components/session-experience.test.tsx
+++ b/apps/web/src/components/session-experience.test.tsx
@@ -47,6 +47,7 @@ describe('Web-native session experiences', () => {
     appState.sessionControlsLoading = {};
     appState.sessionControlsErrors = {};
     appState.contextCompacting = {};
+    appState.messagesBySession = {};
     appState.messagesLoading = {};
     appState.messageErrors = {};
     appState.modelCatalog = {
@@ -55,7 +56,6 @@ describe('Web-native session experiences', () => {
       items: [{ id: 'codex/gpt', name: 'gpt', source: 'Codex', reasoning: true, toolCall: true }],
     };
     appState.effortLevels = [{ id: 'medium', label: 'Medium' }];
-    appState.activeEffort = 'medium';
     appState.newTaskConfig = {
       workspace: '/repo',
       model: 'codex/gpt',
@@ -77,6 +77,7 @@ describe('Web-native session experiences', () => {
     appState.sessionOutputError = null;
     appState.sessionOutputErrorSessionId = null;
     appState.workspaceRoot = '/repo';
+    appState.workspacePresentation = 'docked';
     appState.editorTabs = [];
     appState.activeEditorTabId = null;
     appState.gitStatus = null;
@@ -193,6 +194,30 @@ describe('Web-native session experiences', () => {
     expect(modeTrigger).toHaveFocus();
   });
 
+  it('keeps effort unavailable until the selected task controls finish loading', async () => {
+    appState.effortLevels = [
+      { id: 'medium', label: 'Medium' },
+      { id: 'high', label: 'High' },
+    ];
+    appState.sessionControls = {};
+    appState.sessionControlsLoading = { [session.sessionId]: true };
+    render(<TaskComposer actions={{} as CodeActions} />);
+
+    expect(screen.getByRole('button', { name: 'Effort：Medium' })).toBeDisabled();
+
+    act(() => {
+      appState.sessionControls[session.sessionId] = {
+        sessionId: session.sessionId,
+        effort: 'high',
+        planningMode: 'disabled',
+        goalTracking: false,
+      };
+      appState.sessionControlsLoading[session.sessionId] = false;
+    });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Effort：High' })).toBeEnabled());
+  });
+
   it('keeps new-task parameters in the composer before a session exists', () => {
     appState.activeSessionId = null;
     appState.newTaskConfig = {
@@ -252,7 +277,7 @@ describe('Web-native session experiences', () => {
     await waitFor(() => expect(screen.getByRole('textbox', { name: '任务指令' })).toHaveTextContent('请实现以下功能'));
   });
 
-  it('opens task context panels without changing task identity', () => {
+  it('opens task context panels without changing task identity', async () => {
     appState.reviewSourceTaskId = 'older-task';
     render(<TaskHeader />);
     expect(screen.queryByRole('button', { name: '任务详情' })).not.toBeInTheDocument();
@@ -261,10 +286,97 @@ describe('Web-native session experiences', () => {
     expect(appState.activeSessionId).toBe('session-1');
     expect(appState.reviewSourceTaskId).toBe('session-1');
     expect(screen.getByText('Main task')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '关闭工作区' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '打开任务活动' })).not.toBeInTheDocument();
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: '打开任务活动' }));
+    act(() => {
+      appState.taskView = 'conversation';
+    });
+    fireEvent.click(await screen.findByRole('button', { name: '打开任务活动' }));
     expect(appState.taskView).toBe('activity');
     expect(appState.activeSessionId).toBe('session-1');
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '关闭任务活动' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '打开工作区' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('moves focus into task context and returns it to the control that opened the panel', async () => {
+    appState.filesByDirectory = { '/repo': [] };
+    appState.gitStatus = { isGitRepo: true, branch: 'main', files: [] };
+    const actions = {
+      refreshGitStatus: vi.fn(),
+      openSessionOutput: vi.fn(async () => undefined),
+    } as unknown as CodeActions;
+
+    render(<TasksPage actions={actions} />);
+    const workspaceLauncher = screen.getByRole('button', { name: '打开工作区' });
+    workspaceLauncher.focus();
+    fireEvent.click(workspaceLauncher);
+    await waitFor(() => expect(screen.getByRole('button', { name: '工作区' })).toHaveFocus());
+    fireEvent.click(await screen.findByRole('button', { name: '活动' }));
+
+    const closeFromActivity = screen.getByRole('button', { name: '关闭任务上下文面板' });
+    closeFromActivity.focus();
+    fireEvent.click(closeFromActivity);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: '打开工作区' })).toHaveFocus());
+
+    const activityLauncher = screen.getByRole('button', { name: '打开任务活动' });
+    activityLauncher.focus();
+    fireEvent.click(activityLauncher);
+    await waitFor(() => expect(screen.getByRole('button', { name: '活动' })).toHaveFocus());
+    const closeActivity = await screen.findByRole('button', { name: '关闭任务上下文面板' });
+    closeActivity.focus();
+    fireEvent.click(closeActivity);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: '打开任务活动' })).toHaveFocus());
+  });
+
+  it('returns focus to a persistent result handoff instead of the header fallback', async () => {
+    appState.filesByDirectory = { '/repo': [] };
+    appState.gitStatus = { isGitRepo: true, branch: 'main', files: [] };
+    appState.messagesBySession = {
+      'session-1': [
+        {
+          id: 'assistant-delivery',
+          sessionId: 'session-1',
+          role: 'assistant',
+          content: 'Implementation complete.',
+          createdAt: new Date().toISOString(),
+          events: [
+            {
+              type: 'agent_end',
+              verification_summary: {
+                status: 'passed',
+                report_count: 1,
+                required_check_count: 1,
+                pending_required_check_count: 0,
+                failed_check_count: 0,
+                residual_risk_count: 0,
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const actions = {
+      refreshGitStatus: vi.fn(),
+      openSessionOutput: vi.fn(async () => undefined),
+    } as unknown as CodeActions;
+
+    render(<TasksPage actions={actions} />);
+    const resultHandoff = screen.getByRole('button', { name: '审阅变更' });
+    resultHandoff.focus();
+    fireEvent.click(resultHandoff);
+    await waitFor(() => expect(screen.getByRole('button', { name: '工作区' })).toHaveFocus());
+    const close = await screen.findByRole('button', { name: '关闭任务上下文面板' });
+    close.focus();
+    fireEvent.click(close);
+
+    await waitFor(() => expect(resultHandoff).toHaveFocus());
   });
 
   it('keeps the active header synchronized with an inline task rename', async () => {
@@ -286,11 +398,16 @@ describe('Web-native session experiences', () => {
       openSessionOutput: vi.fn(async () => undefined),
     } as unknown as CodeActions;
 
-    render(<TasksPage actions={actions} />);
+    const { container } = render(<TasksPage actions={actions} />);
     fireEvent.click(screen.getByRole('button', { name: '打开工作区' }));
 
     expect(screen.getByRole('textbox', { name: '任务指令' })).toBeInTheDocument();
     expect(await screen.findByRole('navigation', { name: '任务上下文面板' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '全屏显示任务工作区' }));
+    await waitFor(() => expect(container.querySelector('.task-conversation-pane')).toHaveAttribute('inert'));
+    expect(container.querySelector('.task-conversation-pane')).toHaveAttribute('aria-hidden', 'true');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(container.querySelector('.task-conversation-pane')).not.toHaveAttribute('inert'));
     fireEvent.click(screen.getByRole('button', { name: '工作区变更' }));
     expect(screen.getByRole('complementary', { name: '变更与 Git' })).toHaveClass('compact-open');
     fireEvent.click(screen.getByRole('button', { name: '全局搜索' }));

--- a/apps/web/src/components/shell/command-palette.test.tsx
+++ b/apps/web/src/components/shell/command-palette.test.tsx
@@ -9,6 +9,11 @@ describe('CommandPalette', () => {
     cleanup();
     appState.settingsOpen = false;
     appState.commandPaletteOpen = false;
+    appState.fileQuickOpenOpen = false;
+    appState.activeSessionId = null;
+    appState.workspaceRoot = '';
+    appState.workspacePresentation = 'docked';
+    appState.taskView = 'conversation';
     window.history.replaceState(null, '', '#code/conversation');
   });
 
@@ -56,5 +61,30 @@ describe('CommandPalette', () => {
     expect(appState.settingsOpen).toBe(true);
     expect(appState.settingsTab).toBe('help');
     expect(window.location.hash).toBe('#settings/help');
+  });
+
+  it('offers file quick open only for an active task', () => {
+    appState.activeSessionId = 'task-1';
+    appState.workspaceRoot = '/repo';
+    appState.commandPaletteOpen = true;
+    render(<CommandPalette actions={{ newConversation: vi.fn() } as unknown as CodeActions} />);
+
+    fireEvent.click(screen.getByRole('option', { name: /快速打开文件/ }));
+
+    expect(appState.commandPaletteOpen).toBe(false);
+    expect(appState.fileQuickOpenOpen).toBe(true);
+  });
+
+  it('toggles the current task workspace presentation', () => {
+    appState.activeSessionId = 'task-1';
+    appState.workspaceRoot = '/repo';
+    appState.taskView = 'review';
+    appState.commandPaletteOpen = true;
+    render(<CommandPalette actions={{ newConversation: vi.fn() } as unknown as CodeActions} />);
+
+    fireEvent.click(screen.getByRole('option', { name: /全屏显示工作区/ }));
+
+    expect(appState.commandPaletteOpen).toBe(false);
+    expect(appState.workspacePresentation).toBe('fullscreen');
   });
 });

--- a/apps/web/src/components/shell/command-palette.tsx
+++ b/apps/web/src/components/shell/command-palette.tsx
@@ -1,4 +1,14 @@
-import { CircleHelp, FileDiff, History, ListChecks, Search, Settings } from 'lucide-react';
+import {
+  CircleHelp,
+  FileDiff,
+  FileSearch,
+  History,
+  ListChecks,
+  Maximize2,
+  Minimize2,
+  Search,
+  Settings,
+} from 'lucide-react';
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useSnapshot } from 'valtio';
 import type { CodeActions } from '../../features/code/use-code-controller';
@@ -14,13 +24,37 @@ export function CommandPalette({ actions }: { actions: CodeActions }) {
   const resultId = useId();
   const commands = useMemo(
     () => [
-      ...(state.activeSessionId
+      ...(state.activeSessionId && state.workspaceRoot
         ? [
             {
               label: '当前任务',
               description: '继续对话、计划和执行',
               icon: ListChecks,
               run: () => navigateTask('conversation'),
+            },
+            {
+              label: '快速打开文件',
+              description: '按文件名或路径查找工作区文件',
+              icon: FileSearch,
+              run: () => {
+                appState.fileQuickOpenOpen = true;
+              },
+            },
+          ]
+        : []),
+      ...(state.activeSessionId && state.taskView !== 'conversation'
+        ? [
+            {
+              label: state.workspacePresentation === 'fullscreen' ? '退出工作区全屏' : '全屏显示工作区',
+              description:
+                state.workspacePresentation === 'fullscreen'
+                  ? '恢复对话与任务上下文的并排布局'
+                  : '让当前任务工作区占满可用内容区域',
+              icon: state.workspacePresentation === 'fullscreen' ? Minimize2 : Maximize2,
+              run: () => {
+                appState.workspacePresentation =
+                  appState.workspacePresentation === 'fullscreen' ? 'docked' : 'fullscreen';
+              },
             },
           ]
         : []),
@@ -66,7 +100,7 @@ export function CommandPalette({ actions }: { actions: CodeActions }) {
         run: () => navigateSettings('help'),
       },
     ],
-    [actions, state.activeSessionId]
+    [actions, state.activeSessionId, state.taskView, state.workspacePresentation, state.workspaceRoot]
   );
   const visible = useMemo(
     () =>

--- a/apps/web/src/features/code/code-state.ts
+++ b/apps/web/src/features/code/code-state.ts
@@ -20,6 +20,7 @@ export interface CodeShellState {
   taskView: TaskView;
   settingsOpen: boolean;
   commandPaletteOpen: boolean;
+  fileQuickOpenOpen: boolean;
   toast: ToastState | null;
 }
 
@@ -54,6 +55,7 @@ export function createCodeShellState(): CodeShellState {
     taskView: readTaskView(),
     settingsOpen: readSettingsOpen(),
     commandPaletteOpen: false,
+    fileQuickOpenOpen: false,
     toast: null,
   };
 }

--- a/apps/web/src/features/code/use-app-bootstrap.test.ts
+++ b/apps/web/src/features/code/use-app-bootstrap.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { codeApi } from '../../lib/api';
 import { appState } from '../../state/app-state';
+import { useTaskController } from '../tasks/use-task-controller';
 import { fallbackModelCatalog, useAppBootstrap } from './use-app-bootstrap';
 
 describe('app bootstrap authority', () => {
@@ -181,4 +182,175 @@ describe('app bootstrap authority', () => {
     expect(refresh).toHaveBeenCalledTimes(1);
     hook.unmount();
   });
+
+  it('publishes delayed bootstrap messages and controls only to the session that requested them', async () => {
+    const taskA = codeSession('task-a');
+    const taskB = codeSession('task-b');
+    const messagesA = deferred<Awaited<ReturnType<typeof codeApi.messages>>>();
+    const controlsA = deferred<Awaited<ReturnType<typeof codeApi.sessionControls>>>();
+    appState.activeSessionId = taskA.sessionId;
+    appState.messagesBySession = {
+      [taskB.sessionId]: [
+        {
+          id: 'message-b',
+          sessionId: taskB.sessionId,
+          role: 'assistant',
+          content: 'keep B',
+          createdAt: new Date(0).toISOString(),
+          events: [],
+        },
+      ],
+    };
+    appState.sessionControls = {
+      [taskB.sessionId]: {
+        sessionId: taskB.sessionId,
+        effort: 'high',
+        planningMode: 'disabled',
+        goalTracking: false,
+      },
+    };
+    appState.bootPhase = 'loading';
+    vi.spyOn(codeApi, 'health').mockResolvedValue({
+      ok: true,
+      app: 'A3S Code',
+      version: '0.7.9',
+      configPath: '/repo/config.acl',
+      workspace: '/repo',
+    });
+    vi.spyOn(codeApi, 'osAccount').mockResolvedValue({
+      configured: false,
+      signedIn: false,
+      needsRefresh: false,
+      capabilitySkillActive: false,
+      builtinSkillActive: false,
+      runtimeToolActive: false,
+    });
+    vi.spyOn(codeApi, 'llmSettings').mockResolvedValue({ defaultModel: 'model-a', providers: [] });
+    vi.spyOn(codeApi, 'modelCatalog').mockResolvedValue({ items: [], warnings: [], defaultModel: 'model-a' });
+    vi.spyOn(codeApi, 'refreshModelCatalog').mockResolvedValue({ items: [], warnings: [], defaultModel: 'model-a' });
+    vi.spyOn(codeApi, 'sessions').mockResolvedValue({ items: [taskA, taskB], total: 2 });
+    vi.spyOn(codeApi, 'effortLevels').mockResolvedValue({ items: [] });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const messages = vi.spyOn(codeApi, 'messages').mockReturnValue(messagesA.promise);
+    vi.spyOn(codeApi, 'sessionControls').mockReturnValue(controlsA.promise);
+    const hook = renderHook(() => useAppBootstrap());
+    await waitFor(() => expect(messages).toHaveBeenCalledWith(taskA.sessionId));
+
+    act(() => {
+      appState.activeSessionId = taskB.sessionId;
+    });
+    await act(async () => {
+      messagesA.resolve({
+        items: [
+          {
+            id: 'message-a',
+            sessionId: taskA.sessionId,
+            role: 'assistant',
+            content: 'A response',
+            createdAt: new Date(0).toISOString(),
+            events: [],
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 100,
+      });
+      controlsA.resolve({
+        sessionId: taskA.sessionId,
+        effort: 'low',
+        planningMode: 'disabled',
+        goalTracking: false,
+      });
+    });
+    await waitFor(() => expect(appState.bootPhase).toBe('ready'));
+
+    expect(appState.activeSessionId).toBe(taskB.sessionId);
+    expect(appState.messagesBySession[taskA.sessionId]?.[0].content).toBe('A response');
+    expect(appState.messagesBySession[taskB.sessionId]?.[0].content).toBe('keep B');
+    expect(appState.sessionControls[taskA.sessionId]?.effort).toBe('low');
+    expect(appState.sessionControls[taskB.sessionId]?.effort).toBe('high');
+    hook.unmount();
+  });
+
+  it('does not let an older bootstrap controls response overwrite a successful task update', async () => {
+    const task = codeSession('task-a');
+    const bootstrapControls = deferred<Awaited<ReturnType<typeof codeApi.sessionControls>>>();
+    appState.activeSessionId = task.sessionId;
+    appState.sessions = [task];
+    appState.messagesBySession = { [task.sessionId]: [] };
+    appState.sessionControls = {};
+    appState.sessionControlsErrors = {};
+    appState.sessionControlsLoading = {};
+    appState.taskConfigSaving = null;
+    appState.bootPhase = 'loading';
+    vi.spyOn(codeApi, 'health').mockResolvedValue({
+      ok: true,
+      app: 'A3S Code',
+      version: '0.7.9',
+      configPath: '/repo/config.acl',
+      workspace: '/repo',
+    });
+    vi.spyOn(codeApi, 'osAccount').mockResolvedValue({
+      configured: false,
+      signedIn: false,
+      needsRefresh: false,
+      capabilitySkillActive: false,
+      builtinSkillActive: false,
+      runtimeToolActive: false,
+    });
+    vi.spyOn(codeApi, 'llmSettings').mockResolvedValue({ defaultModel: 'model-a', providers: [] });
+    vi.spyOn(codeApi, 'modelCatalog').mockResolvedValue({ items: [], warnings: [], defaultModel: 'model-a' });
+    vi.spyOn(codeApi, 'refreshModelCatalog').mockResolvedValue({ items: [], warnings: [], defaultModel: 'model-a' });
+    vi.spyOn(codeApi, 'sessions').mockResolvedValue({ items: [task], total: 1 });
+    vi.spyOn(codeApi, 'effortLevels').mockResolvedValue({ items: [] });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    vi.spyOn(codeApi, 'messages').mockResolvedValue({ items: [], total: 0, page: 1, limit: 100 });
+    const controls = vi.spyOn(codeApi, 'sessionControls').mockReturnValue(bootstrapControls.promise);
+    vi.spyOn(codeApi, 'updateSessionControls').mockResolvedValue({
+      sessionId: task.sessionId,
+      effort: 'high',
+      planningMode: 'disabled',
+      goalTracking: false,
+    });
+    const bootstrapHook = renderHook(() => useAppBootstrap());
+    await waitFor(() => expect(controls).toHaveBeenCalledWith(task.sessionId));
+    const taskHook = renderHook(() => useTaskController());
+
+    await act(() => taskHook.result.current.updateEffort('high'));
+    expect(appState.sessionControls[task.sessionId]?.effort).toBe('high');
+    await act(async () => {
+      bootstrapControls.resolve({
+        sessionId: task.sessionId,
+        effort: 'low',
+        planningMode: 'disabled',
+        goalTracking: false,
+      });
+    });
+    await waitFor(() => expect(appState.bootPhase).toBe('ready'));
+
+    expect(appState.sessionControls[task.sessionId]?.effort).toBe('high');
+    taskHook.unmount();
+    bootstrapHook.unmount();
+  });
 });
+
+function codeSession(sessionId: string) {
+  return {
+    sessionId,
+    workspace: '/repo',
+    cwd: '/repo',
+    model: 'codex/gpt',
+    followDefaultModel: false,
+    permissionMode: 'default',
+    state: 'idle',
+    createdAt: 1,
+  };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/web/src/features/code/use-app-bootstrap.ts
+++ b/apps/web/src/features/code/use-app-bootstrap.ts
@@ -5,14 +5,25 @@ import type { LlmSettings, ModelCatalog } from '../../types/api';
 import {
   appState,
   applyTheme,
+  captureWorkspaceContext,
   formatApiError,
+  isWorkspaceContextCurrent,
+  replaceActiveWorkspace,
   reportTaskPersistenceResult,
   showToast,
   switchActiveTask,
 } from '../../state/app-state';
+import {
+  beginSessionControlsRequest,
+  beginSessionMessagesRequest,
+  isSessionControlsRequestCurrent,
+  isSessionMessagesRequestCurrent,
+  type SessionResourceRequest,
+} from '../tasks/session-resource-order';
 import { persistNewTaskConfig } from '../tasks/task-state';
 
 interface BootstrapResult {
+  activeSessionId: string | null;
   health: Awaited<ReturnType<typeof codeApi.health>>;
   osAccount: Awaited<ReturnType<typeof codeApi.osAccount>>;
   llm: Awaited<ReturnType<typeof codeApi.llmSettings>>;
@@ -22,11 +33,14 @@ interface BootstrapResult {
   rootFiles: Awaited<ReturnType<typeof codeApi.readDir>>;
   activeMessages?: Awaited<ReturnType<typeof codeApi.messages>>;
   activeControls?: Awaited<ReturnType<typeof codeApi.sessionControls>>;
+  activeMessagesRequest?: SessionResourceRequest;
+  activeControlsRequest?: SessionResourceRequest;
   activeMessagesError?: string;
   activeControlsError?: string;
 }
 
 async function loadBootstrapResult(): Promise<BootstrapResult> {
+  const activeSessionId = appState.activeSessionId;
   const health = await codeApi.health();
   const [osAccount, llm, modelCatalogResult, sessionList, effortLevels, rootFiles] = await Promise.all([
     codeApi.osAccount(),
@@ -40,12 +54,15 @@ async function loadBootstrapResult(): Promise<BootstrapResult> {
     codeApi.readDir(health.workspace),
   ]);
   const modelCatalog = modelCatalogResult.value ?? fallbackModelCatalog(llm);
-  const activeSessionId = appState.activeSessionId;
   let activeMessages: BootstrapResult['activeMessages'];
   let activeControls: BootstrapResult['activeControls'];
+  let activeMessagesRequest: SessionResourceRequest | undefined;
+  let activeControlsRequest: SessionResourceRequest | undefined;
   let activeMessagesError: string | undefined;
   let activeControlsError: string | undefined;
   if (activeSessionId && sessionList.items.some((session) => session.sessionId === activeSessionId)) {
+    activeMessagesRequest = beginSessionMessagesRequest(activeSessionId);
+    activeControlsRequest = beginSessionControlsRequest(activeSessionId);
     const [messages, controls] = await Promise.allSettled([
       codeApi.messages(activeSessionId),
       codeApi.sessionControls(activeSessionId),
@@ -56,6 +73,7 @@ async function loadBootstrapResult(): Promise<BootstrapResult> {
     else activeControlsError = formatApiError(controls.reason);
   }
   return {
+    activeSessionId,
     health,
     osAccount,
     llm,
@@ -65,6 +83,8 @@ async function loadBootstrapResult(): Promise<BootstrapResult> {
     rootFiles,
     activeMessages,
     activeControls,
+    activeMessagesRequest,
+    activeControlsRequest,
     activeMessagesError,
     activeControlsError,
   };
@@ -98,26 +118,32 @@ function applyBootstrapResult(result: BootstrapResult) {
   }
   appState.sessions = result.sessionList.items;
   if (
-    appState.activeSessionId &&
-    !result.sessionList.items.some((session) => session.sessionId === appState.activeSessionId)
+    appState.activeSessionId === result.activeSessionId &&
+    result.activeSessionId &&
+    !result.sessionList.items.some((session) => session.sessionId === result.activeSessionId)
   )
     switchActiveTask(null);
-  if (appState.activeSessionId && result.activeMessages)
-    appState.messagesBySession[appState.activeSessionId] = result.activeMessages.items;
-  if (appState.activeSessionId) {
-    appState.messagesLoading[appState.activeSessionId] = false;
-    if (result.activeMessagesError) appState.messageErrors[appState.activeSessionId] = result.activeMessagesError;
-    else delete appState.messageErrors[appState.activeSessionId];
+  const messagesCurrent = Boolean(
+    result.activeMessagesRequest && isSessionMessagesRequestCurrent(result.activeMessagesRequest)
+  );
+  const controlsCurrent = Boolean(
+    result.activeControlsRequest && isSessionControlsRequestCurrent(result.activeControlsRequest)
+  );
+  if (result.activeSessionId && messagesCurrent && result.activeMessages) {
+    appState.messagesBySession[result.activeSessionId] = result.activeMessages.items;
   }
-  if (appState.activeSessionId && result.activeControls) {
-    appState.sessionControls[appState.activeSessionId] = result.activeControls;
-    appState.activeEffort = result.activeControls.effort;
+  if (result.activeSessionId && messagesCurrent) {
+    appState.messagesLoading[result.activeSessionId] = false;
+    if (result.activeMessagesError) appState.messageErrors[result.activeSessionId] = result.activeMessagesError;
+    else delete appState.messageErrors[result.activeSessionId];
   }
-  if (appState.activeSessionId) {
-    appState.sessionControlsLoading[appState.activeSessionId] = false;
-    if (result.activeControlsError)
-      appState.sessionControlsErrors[appState.activeSessionId] = result.activeControlsError;
-    else delete appState.sessionControlsErrors[appState.activeSessionId];
+  if (result.activeSessionId && controlsCurrent && result.activeControls) {
+    appState.sessionControls[result.activeSessionId] = result.activeControls;
+  }
+  if (result.activeSessionId && controlsCurrent) {
+    appState.sessionControlsLoading[result.activeSessionId] = false;
+    if (result.activeControlsError) appState.sessionControlsErrors[result.activeSessionId] = result.activeControlsError;
+    else delete appState.sessionControlsErrors[result.activeSessionId];
   }
   appState.effortLevels = result.effortLevels.items;
   if (!result.effortLevels.items.some((effort) => effort.id === appState.newTaskConfig.effort)) {
@@ -131,25 +157,28 @@ function applyBootstrapResult(result: BootstrapResult) {
     (session) => session.sessionId === appState.activeSessionId
   )?.workspace;
   const workspaceRoot = activeWorkspace || appState.newTaskConfig.workspace || result.health.workspace;
-  appState.workspaceRoot = workspaceRoot;
+  replaceActiveWorkspace(workspaceRoot);
   appState.filesByDirectory[result.health.workspace] = result.rootFiles;
   appState.expandedDirectories[result.health.workspace] = true;
   appState.directoryLoading[result.health.workspace] = false;
   delete appState.directoryErrors[result.health.workspace];
   if (workspaceRoot !== result.health.workspace) {
+    const context = captureWorkspaceContext();
     appState.directoryLoading[workspaceRoot] = true;
     delete appState.directoryErrors[workspaceRoot];
     void codeApi
       .readDir(workspaceRoot)
       .then((entries) => {
+        if (!isWorkspaceContextCurrent(context)) return;
         appState.filesByDirectory[workspaceRoot] = entries;
         appState.expandedDirectories[workspaceRoot] = true;
       })
       .catch((error: unknown) => {
+        if (!isWorkspaceContextCurrent(context)) return;
         appState.directoryErrors[workspaceRoot] = formatApiError(error);
       })
       .finally(() => {
-        appState.directoryLoading[workspaceRoot] = false;
+        if (isWorkspaceContextCurrent(context)) appState.directoryLoading[workspaceRoot] = false;
       });
   }
   appState.bootPhase = 'ready';

--- a/apps/web/src/features/code/use-code-controller.ts
+++ b/apps/web/src/features/code/use-code-controller.ts
@@ -2,6 +2,8 @@ import { useRunsController } from '../runs/use-runs-controller';
 import { useSettingsController } from '../settings/use-settings-controller';
 import { useTaskController } from '../tasks/use-task-controller';
 import { useWorkspaceController } from '../workspace/use-workspace-controller';
+import { useWorkspaceEditorModelLifecycle } from '../workspace/use-workspace-editor-model-lifecycle';
+import { useWorkspacePersistence } from '../workspace/use-workspace-persistence';
 import { useAppBootstrap } from './use-app-bootstrap';
 import { useShellShortcuts } from './use-shell-shortcuts';
 
@@ -11,6 +13,8 @@ export function useCodeController() {
   const settings = useSettingsController();
   const runs = useRunsController();
   const workspace = useWorkspaceController();
+  useWorkspaceEditorModelLifecycle();
+  useWorkspacePersistence();
   useShellShortcuts(tasks.newConversation);
   return { ...bootstrap, ...tasks, ...settings, ...runs, ...workspace };
 }

--- a/apps/web/src/features/code/use-shell-shortcuts.test.tsx
+++ b/apps/web/src/features/code/use-shell-shortcuts.test.tsx
@@ -9,7 +9,10 @@ describe('shell location synchronization', () => {
     appState.settingsOpen = false;
     appState.updateInstalling = false;
     appState.commandPaletteOpen = false;
+    appState.fileQuickOpenOpen = false;
     appState.sidebarOpen = true;
+    appState.activeSessionId = null;
+    appState.workspaceRoot = '';
     window.history.replaceState(null, '', '#code/conversation');
   });
 
@@ -88,5 +91,65 @@ describe('shell location synchronization', () => {
 
     expect(appState.sidebarOpen).toBe(true);
     editor.remove();
+  });
+
+  it('lets the Monaco editor toggle the task sidebar with the shell shortcut', () => {
+    appState.sidebarOpen = true;
+    renderHook(() => useShellShortcuts(() => undefined));
+    const monaco = document.createElement('div');
+    monaco.className = 'monaco-editor';
+    const input = document.createElement('div');
+    input.contentEditable = 'true';
+    input.addEventListener('keydown', (event) => event.stopPropagation());
+    monaco.append(input);
+    document.body.append(monaco);
+    const event = new KeyboardEvent('keydown', {
+      key: 'b',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    input.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(appState.sidebarOpen).toBe(false);
+    monaco.remove();
+  });
+
+  it('opens file quick open from Monaco before its key handler stops propagation', () => {
+    appState.activeSessionId = 'task-1';
+    appState.workspaceRoot = '/repo';
+    appState.commandPaletteOpen = true;
+    renderHook(() => useShellShortcuts(() => undefined));
+    const monaco = document.createElement('div');
+    monaco.className = 'monaco-editor';
+    const input = document.createElement('textarea');
+    input.addEventListener('keydown', (event) => event.stopPropagation());
+    monaco.append(input);
+    document.body.append(monaco);
+    const event = new KeyboardEvent('keydown', {
+      key: 'p',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    input.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(appState.commandPaletteOpen).toBe(false);
+    expect(appState.fileQuickOpenOpen).toBe(true);
+    monaco.remove();
+  });
+
+  it('preserves the browser print shortcut when no active workspace can open a file', () => {
+    renderHook(() => useShellShortcuts(() => undefined));
+    const event = new KeyboardEvent('keydown', { key: 'p', ctrlKey: true, cancelable: true });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(appState.fileQuickOpenOpen).toBe(false);
   });
 });

--- a/apps/web/src/features/code/use-shell-shortcuts.ts
+++ b/apps/web/src/features/code/use-shell-shortcuts.ts
@@ -22,60 +22,79 @@ export function useShellShortcuts(newTask: () => void) {
     const view = window.location.hash.match(/^#code\/(conversation|review|activity)$/)?.[1];
     if (view === 'conversation' || view === 'review' || view === 'activity') {
       appState.settingsOpen = false;
+      if (view === 'conversation') appState.workspacePresentation = 'docked';
       appState.taskView = view;
     }
   };
   useEffect(syncLocation, []);
   useEventListener('hashchange', syncLocation);
-  useEventListener('keydown', (event) => {
-    const modifier = event.metaKey || event.ctrlKey;
-    const key = event.key.toLowerCase();
-    const target = event.target;
-    const isEditing =
-      target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement ||
-      (target instanceof HTMLElement &&
-        (target.isContentEditable ||
-          target.contentEditable === 'true' ||
-          target.closest('[contenteditable="true"]') !== null));
-    if (appState.settingsOpen) {
-      const shellShortcut = modifier && ['n', 'b', 'k', ','].includes(key);
-      if (shellShortcut || (event.key === '?' && !modifier && !isEditing)) event.preventDefault();
-      if (modifier && event.key === ',') navigateSettings('general');
-      else if (event.key === '?' && !modifier && !isEditing) navigateSettings('help');
-      else if (event.key === 'Escape' && !appState.updateInstalling) closeSettings();
-      return;
-    }
-    if (modifier && key === 'n') {
-      event.preventDefault();
-      newTask();
-      navigateTask('conversation');
-      return;
-    }
-    if (modifier && key === 'b' && !isEditing) {
-      event.preventDefault();
-      appState.sidebarOpen = !appState.sidebarOpen;
-      return;
-    }
-    if (modifier && event.key === ',') {
-      event.preventDefault();
-      navigateSettings('general');
-      return;
-    }
-    if (modifier && key === 'k') {
-      event.preventDefault();
-      appState.commandPaletteOpen = !appState.commandPaletteOpen;
-      return;
-    }
-    if (event.key === 'Escape') {
-      if (appState.commandPaletteOpen) {
+  useEventListener(
+    'keydown',
+    (event) => {
+      const modifier = event.metaKey || event.ctrlKey;
+      const key = event.key.toLowerCase();
+      const target = event.target;
+      const isEditing =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement &&
+          (target.isContentEditable ||
+            target.contentEditable === 'true' ||
+            target.closest('[contenteditable="true"]') !== null));
+      const isMonacoEditor = target instanceof HTMLElement && target.closest('.monaco-editor') !== null;
+      if (modifier && key === 'p' && appState.activeSessionId && appState.workspaceRoot) {
+        event.preventDefault();
         appState.commandPaletteOpen = false;
+        appState.fileQuickOpenOpen = true;
+        return;
       }
-      return;
-    }
-    if (event.key === '?' && !event.metaKey && !event.ctrlKey && !isEditing) {
-      event.preventDefault();
-      navigateSettings('help');
-    }
-  });
+      if (event.key === 'Escape' && appState.fileQuickOpenOpen) {
+        event.preventDefault();
+        appState.fileQuickOpenOpen = false;
+        return;
+      }
+      if (appState.settingsOpen) {
+        const shellShortcut = modifier && ['n', 'b', 'k', ','].includes(key);
+        if (shellShortcut || (event.key === '?' && !modifier && !isEditing)) event.preventDefault();
+        if (modifier && event.key === ',') navigateSettings('general');
+        else if (event.key === '?' && !modifier && !isEditing) navigateSettings('help');
+        else if (event.key === 'Escape' && !appState.updateInstalling) closeSettings();
+        return;
+      }
+      if (modifier && key === 'n') {
+        event.preventDefault();
+        appState.fileQuickOpenOpen = false;
+        newTask();
+        navigateTask('conversation');
+        return;
+      }
+      if (modifier && key === 'b' && (!isEditing || isMonacoEditor)) {
+        event.preventDefault();
+        appState.sidebarOpen = !appState.sidebarOpen;
+        return;
+      }
+      if (modifier && event.key === ',') {
+        event.preventDefault();
+        navigateSettings('general');
+        return;
+      }
+      if (modifier && key === 'k') {
+        event.preventDefault();
+        appState.fileQuickOpenOpen = false;
+        appState.commandPaletteOpen = !appState.commandPaletteOpen;
+        return;
+      }
+      if (event.key === 'Escape') {
+        if (appState.commandPaletteOpen) {
+          appState.commandPaletteOpen = false;
+        }
+        return;
+      }
+      if (event.key === '?' && !event.metaKey && !event.ctrlKey && !isEditing) {
+        event.preventDefault();
+        navigateSettings('help');
+      }
+    },
+    { capture: true }
+  );
 }

--- a/apps/web/src/features/settings/components/help-settings.test.tsx
+++ b/apps/web/src/features/settings/components/help-settings.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HelpSettings } from './help-settings';
+
+describe('HelpSettings', () => {
+  afterEach(cleanup);
+
+  it('makes the editor focus shortcut searchable', () => {
+    render(<HelpSettings />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: '搜索帮助' }), {
+      target: { value: 'Ctrl B' },
+    });
+
+    expect(screen.getByText('专注编辑')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('makes file quick open discoverable by its shortcut', () => {
+    render(<HelpSettings />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: '搜索帮助' }), {
+      target: { value: 'Ctrl P' },
+    });
+
+    expect(screen.getByText('快速打开文件')).toBeInTheDocument();
+    expect(screen.getByText('P')).toBeInTheDocument();
+  });
+
+  it('makes the full-screen workspace action searchable', () => {
+    render(<HelpSettings />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: '搜索帮助' }), {
+      target: { value: '全屏工作区' },
+    });
+
+    expect(screen.getByText('全屏工作区')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/settings/components/help-settings.tsx
+++ b/apps/web/src/features/settings/components/help-settings.tsx
@@ -39,6 +39,24 @@ const entries = [
     description: '浏览、创建、复制、重命名、删除、搜索和编辑项目文件。',
     keys: [],
   },
+  {
+    group: '工作区',
+    title: '快速打开文件',
+    description: '按文件名或路径模糊查找工作区文件，并直接复用已打开的编辑标签。',
+    keys: ['⌘/Ctrl', 'P'],
+  },
+  {
+    group: '工作区',
+    title: '专注编辑',
+    description: '在工作区或编辑器内收起或展开任务列表，为代码留出更多空间。',
+    keys: ['⌘/Ctrl', 'B'],
+  },
+  {
+    group: '工作区',
+    title: '全屏工作区',
+    description: '从任务上下文标题栏展开同一编辑器；按 Escape 或再次点击即可还原。',
+    keys: [],
+  },
   { group: '工作区', title: 'Git 工作流', description: '查看差异、暂存更改并在确认后创建提交。', keys: [] },
   {
     group: '安全',

--- a/apps/web/src/features/tasks/components/execution-stream.test.tsx
+++ b/apps/web/src/features/tasks/components/execution-stream.test.tsx
@@ -643,11 +643,11 @@ describe('ExecutionStream permission decisions', () => {
     ];
 
     const { container } = render(<ExecutionStream actions={{} as TaskActions} />);
-    expect(await screen.findByRole('heading', { name: '构建结果' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '构建结果' }, { timeout: 10_000 })).toBeInTheDocument();
     expect(container.querySelector('.streaming-markdown')).toBeInTheDocument();
     await waitFor(() => expect(container.querySelector('pre code span')).toBeInTheDocument());
     expect(screen.getByRole('button', { name: '复制代码' })).toBeInTheDocument();
-  });
+  }, 20_000);
 
   it('renders completed reasoning as collapsed Markdown instead of plain preformatted text', async () => {
     appState.activeSessionId = 'session-reasoning-markdown';

--- a/apps/web/src/features/tasks/components/task-composer-effort-control.tsx
+++ b/apps/web/src/features/tasks/components/task-composer-effort-control.tsx
@@ -11,7 +11,8 @@ export function TaskComposerEffortControl({ actions }: { actions: TaskActions })
   const task = state.sessions.find((item) => item.sessionId === state.activeSessionId);
   const controls = task ? state.sessionControls[task.sessionId] : undefined;
   const controlsError = task ? state.sessionControlsErrors[task.sessionId] : undefined;
-  const value = task ? controls?.effort || state.activeEffort : state.newTaskConfig.effort;
+  const controlsLoading = task ? state.sessionControlsLoading[task.sessionId] || !controls : false;
+  const value = controls?.effort || state.newTaskConfig.effort;
   const levels = state.effortLevels;
   const selectedIndex = Math.max(
     0,
@@ -23,7 +24,7 @@ export function TaskComposerEffortControl({ actions }: { actions: TaskActions })
   const preview = levels[Math.min(previewIndex, Math.max(0, levels.length - 1))] ?? selected;
   const label = effortLabel(value, selected?.label ?? value);
   const busy = Boolean(state.streamingSessionId || state.taskConfigSaving);
-  const disabled = Boolean(!levels.length || controlsError || busy);
+  const disabled = Boolean(!levels.length || controlsError || controlsLoading || busy);
 
   useEffect(() => {
     setPreviewIndex(selectedIndex);
@@ -36,7 +37,7 @@ export function TaskComposerEffortControl({ actions }: { actions: TaskActions })
     committedValue.current = level.id;
     if (task) {
       void actions.updateEffort(level.id).finally(() => {
-        const current = appState.sessionControls[task.sessionId]?.effort || appState.activeEffort;
+        const current = appState.sessionControls[task.sessionId]?.effort || appState.newTaskConfig.effort;
         committedValue.current = current;
         setPreviewIndex(
           Math.max(

--- a/apps/web/src/features/tasks/components/task-context-panel.test.tsx
+++ b/apps/web/src/features/tasks/components/task-context-panel.test.tsx
@@ -1,0 +1,68 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CodeActions } from '../../code/use-code-controller';
+import { appState } from '../../../state/app-state';
+import { TaskContextPanel } from './task-context-panel';
+
+describe('TaskContextPanel presentation', () => {
+  beforeEach(() => {
+    appState.activeSessionId = null;
+    appState.taskView = 'activity';
+    appState.workspacePresentation = 'docked';
+    window.history.replaceState(null, '', '#code/activity');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    appState.taskView = 'conversation';
+    appState.workspacePresentation = 'docked';
+    window.history.replaceState(null, '', '#code/conversation');
+  });
+
+  it('preserves a more specific focus target established inside the opened panel', () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+    render(<TaskContextPanel view='activity' actions={{} as CodeActions} />);
+
+    const returnToConversation = screen.getByRole('button', { name: '返回对话' });
+    returnToConversation.focus();
+    act(() => frames.shift()?.(0));
+
+    expect(returnToConversation).toHaveFocus();
+  });
+
+  it('expands the existing task context and exits full screen with Escape', async () => {
+    render(<TaskContextPanel view='activity' actions={{} as CodeActions} />);
+
+    const panel = screen.getByRole('complementary', { name: '任务活动面板' });
+    const enter = screen.getByRole('button', { name: '全屏显示任务活动面板' });
+    fireEvent.click(enter);
+
+    expect(appState.workspacePresentation).toBe('fullscreen');
+    await waitFor(() => expect(panel).toHaveClass('fullscreen'));
+    const exit = await screen.findByRole('button', { name: '退出任务活动面板全屏' });
+    expect(exit).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(appState.workspacePresentation).toBe('docked');
+    await waitFor(() => expect(panel).not.toHaveClass('fullscreen'));
+    await waitFor(() => expect(screen.getByRole('button', { name: '全屏显示任务活动面板' })).toHaveFocus());
+  });
+
+  it('returns to a docked presentation when the context panel is closed', () => {
+    appState.workspacePresentation = 'fullscreen';
+    render(<TaskContextPanel view='activity' actions={{} as CodeActions} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '关闭任务上下文面板' }));
+
+    expect(appState.taskView).toBe('conversation');
+    expect(appState.workspacePresentation).toBe('docked');
+    expect(window.location.hash).toBe('#code/conversation');
+  });
+});

--- a/apps/web/src/features/tasks/components/task-context-panel.tsx
+++ b/apps/web/src/features/tasks/components/task-context-panel.tsx
@@ -1,9 +1,10 @@
-import { Files, GitBranch, History, PanelRightClose } from 'lucide-react';
-import { useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from 'react';
+import { Files, GitBranch, History, Maximize2, Minimize2, PanelRightClose } from 'lucide-react';
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from 'react';
+import { useSnapshot } from 'valtio';
 import type { CodeActions } from '../../code/use-code-controller';
 import type { TaskView } from '../../code/code-state';
 import { Button, IconButton } from '../../../design-system/primitives';
-import { navigateTask } from '../../../state/app-state';
+import { appState, navigateTask } from '../../../state/app-state';
 import { WorkspacePage } from '../../code/pages/workspace-page';
 import { RunsPage } from '../../runs/pages/runs-page';
 
@@ -26,8 +27,36 @@ function readPanelWidth() {
 }
 
 export function TaskContextPanel({ view, actions }: { view: Exclude<TaskView, 'conversation'>; actions: CodeActions }) {
+  const state = useSnapshot(appState);
   const [width, setWidth] = useState(readPanelWidth);
   const [changesOpen, setChangesOpen] = useState(false);
+  const panelRef = useRef<HTMLElement>(null);
+  const workspaceModeButtonRef = useRef<HTMLButtonElement>(null);
+  const activityModeButtonRef = useRef<HTMLButtonElement>(null);
+  const presentationButtonRef = useRef<HTMLButtonElement>(null);
+  const fullscreen = state.workspacePresentation === 'fullscreen';
+  const panelName = view === 'review' ? '任务工作区' : '任务活动面板';
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel || panel.contains(document.activeElement)) return;
+      const target = view === 'review' ? workspaceModeButtonRef.current : activityModeButtonRef.current;
+      target?.focus({ preventScroll: true });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [view]);
+  useEffect(() => {
+    if (!fullscreen) return;
+    const exitFullscreen = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.key !== 'Escape') return;
+      if (event.target instanceof Element && event.target.closest('[role="dialog"]')) return;
+      event.preventDefault();
+      appState.workspacePresentation = 'docked';
+      requestAnimationFrame(() => presentationButtonRef.current?.focus());
+    };
+    window.addEventListener('keydown', exitFullscreen);
+    return () => window.removeEventListener('keydown', exitFullscreen);
+  }, [fullscreen]);
   const updateWidth = (next: number, persist = false) => {
     const normalized = clampPanelWidth(next);
     setWidth(normalized);
@@ -44,8 +73,9 @@ export function TaskContextPanel({ view, actions }: { view: Exclude<TaskView, 'c
   };
   return (
     <aside
-      className='task-context-panel'
-      aria-label={view === 'review' ? '任务工作区' : '任务活动面板'}
+      ref={panelRef}
+      className={`task-context-panel ${fullscreen ? 'fullscreen' : ''}`}
+      aria-label={panelName}
       style={{ '--task-context-width': `${width}px` } as CSSProperties}
     >
       <hr
@@ -79,6 +109,7 @@ export function TaskContextPanel({ view, actions }: { view: Exclude<TaskView, 'c
       <header className='task-context-header'>
         <nav aria-label='任务上下文面板'>
           <button
+            ref={workspaceModeButtonRef}
             type='button'
             className={view === 'review' ? 'active' : ''}
             aria-current={view === 'review' ? 'page' : undefined}
@@ -88,6 +119,7 @@ export function TaskContextPanel({ view, actions }: { view: Exclude<TaskView, 'c
             工作区
           </button>
           <button
+            ref={activityModeButtonRef}
             type='button'
             className={view === 'activity' ? 'active' : ''}
             aria-current={view === 'activity' ? 'page' : undefined}
@@ -112,6 +144,17 @@ export function TaskContextPanel({ view, actions }: { view: Exclude<TaskView, 'c
               工作区变更
             </Button>
           )}
+          <IconButton
+            ref={presentationButtonRef}
+            label={fullscreen ? `退出${panelName}全屏` : `全屏显示${panelName}`}
+            tooltip={fullscreen ? `退出${panelName}全屏 (Esc)` : `全屏显示${panelName}`}
+            selected={fullscreen}
+            onClick={() => {
+              appState.workspacePresentation = fullscreen ? 'docked' : 'fullscreen';
+            }}
+          >
+            {fullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+          </IconButton>
           <IconButton label='关闭任务上下文面板' onClick={() => navigateTask('conversation')}>
             <PanelRightClose size={16} />
           </IconButton>

--- a/apps/web/src/features/tasks/components/task-header.tsx
+++ b/apps/web/src/features/tasks/components/task-header.tsx
@@ -2,6 +2,7 @@ import { Files, History, PanelLeftOpen } from 'lucide-react';
 import { useSnapshot } from 'valtio';
 import { IconButton, StatusBadge } from '../../../design-system/primitives';
 import { appState, navigateTask, sessionTitle } from '../../../state/app-state';
+import { taskContextLauncherIds } from '../task-context-focus';
 
 export function TaskHeader() {
   const state = useSnapshot(appState);
@@ -32,28 +33,28 @@ export function TaskHeader() {
       </div>
       <div className='task-header-actions'>
         {task && state.streamingSessionId === task.sessionId && <StatusBadge tone='info'>运行中</StatusBadge>}
-        <IconButton
-          label={state.taskView === 'review' ? '关闭工作区' : '打开工作区'}
-          selected={state.taskView === 'review'}
-          onClick={() => {
-            if (state.taskView === 'review') {
-              navigateTask('conversation');
-              return;
-            }
-            appState.reviewIntent = 'review';
-            appState.reviewSourceTaskId = state.activeSessionId;
-            navigateTask('review');
-          }}
-        >
-          <Files size={17} />
-        </IconButton>
-        <IconButton
-          label={state.taskView === 'activity' ? '关闭任务活动' : '打开任务活动'}
-          selected={state.taskView === 'activity'}
-          onClick={() => navigateTask(state.taskView === 'activity' ? 'conversation' : 'activity')}
-        >
-          <History size={17} />
-        </IconButton>
+        {state.taskView === 'conversation' && (
+          <>
+            <IconButton
+              id={taskContextLauncherIds.review}
+              label='打开工作区'
+              onClick={() => {
+                appState.reviewIntent = 'review';
+                appState.reviewSourceTaskId = state.activeSessionId;
+                navigateTask('review');
+              }}
+            >
+              <Files size={17} />
+            </IconButton>
+            <IconButton
+              id={taskContextLauncherIds.activity}
+              label='打开任务活动'
+              onClick={() => navigateTask('activity')}
+            >
+              <History size={17} />
+            </IconButton>
+          </>
+        )}
       </div>
     </header>
   );

--- a/apps/web/src/features/tasks/pages/tasks-page.tsx
+++ b/apps/web/src/features/tasks/pages/tasks-page.tsx
@@ -19,10 +19,17 @@ export function TasksPage({ actions }: { actions: CodeActions }) {
     );
   }
 
+  const contextFullscreen = state.taskView !== 'conversation' && state.workspacePresentation === 'fullscreen';
   return (
     <section className='code-page task-product active-task-product'>
-      <div className={`active-task-layout ${state.taskView !== 'conversation' ? 'with-context' : ''}`}>
-        <section className='task-conversation-pane'>
+      <div
+        className={`active-task-layout ${state.taskView !== 'conversation' ? 'with-context' : ''} ${contextFullscreen ? 'context-fullscreen' : ''}`}
+      >
+        <section
+          className='task-conversation-pane'
+          aria-hidden={contextFullscreen || undefined}
+          inert={contextFullscreen || undefined}
+        >
           <TaskHeader />
           <TaskRuntimeFloatingPanel />
           <main className='task-workspace'>

--- a/apps/web/src/features/tasks/session-resource-order.ts
+++ b/apps/web/src/features/tasks/session-resource-order.ts
@@ -1,0 +1,41 @@
+export interface SessionResourceRequest {
+  sessionId: string;
+  version: number;
+}
+
+const messageRequestVersions = new Map<string, number>();
+const controlsRequestVersions = new Map<string, number>();
+
+function beginRequest(versions: Map<string, number>, sessionId: string): SessionResourceRequest {
+  const version = (versions.get(sessionId) ?? 0) + 1;
+  versions.set(sessionId, version);
+  return { sessionId, version };
+}
+
+function isCurrent(versions: Map<string, number>, request: SessionResourceRequest): boolean {
+  return versions.get(request.sessionId) === request.version;
+}
+
+export function beginSessionMessagesRequest(sessionId: string): SessionResourceRequest {
+  return beginRequest(messageRequestVersions, sessionId);
+}
+
+export function invalidateSessionMessagesRequests(sessionId: string): void {
+  beginSessionMessagesRequest(sessionId);
+}
+
+export function isSessionMessagesRequestCurrent(request: SessionResourceRequest): boolean {
+  return isCurrent(messageRequestVersions, request);
+}
+
+export function beginSessionControlsRequest(sessionId: string): SessionResourceRequest {
+  return beginRequest(controlsRequestVersions, sessionId);
+}
+
+export function invalidateSessionControlsRequests(sessionId: string): SessionResourceRequest {
+  return beginSessionControlsRequest(sessionId);
+}
+
+export function isSessionControlsRequestCurrent(request: SessionResourceRequest): boolean {
+  return isCurrent(controlsRequestVersions, request);
+}

--- a/apps/web/src/features/tasks/task-context-focus.ts
+++ b/apps/web/src/features/tasks/task-context-focus.ts
@@ -1,0 +1,36 @@
+import type { TaskView } from '../code/code-state';
+
+type TaskContextView = Exclude<TaskView, 'conversation'>;
+
+export const taskContextLauncherIds: Record<TaskContextView, string> = {
+  review: 'task-context-workspace-launcher',
+  activity: 'task-context-activity-launcher',
+};
+
+interface TaskContextFocusTarget {
+  element: HTMLElement | null;
+  elementId: string;
+  fallbackId: string;
+}
+
+let focusTarget: TaskContextFocusTarget | null = null;
+
+export function rememberTaskContextFocus(view: TaskContextView): void {
+  const element = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  focusTarget = {
+    element: element === document.body ? null : element,
+    elementId: element?.id ?? '',
+    fallbackId: taskContextLauncherIds[view],
+  };
+}
+
+export function restoreTaskContextFocus(fallbackView: TaskContextView): void {
+  const target = focusTarget;
+  focusTarget = null;
+  window.requestAnimationFrame(() => {
+    const connectedTarget = target?.element?.isConnected ? target.element : null;
+    const replacementTarget = target?.elementId ? document.getElementById(target.elementId) : null;
+    const fallbackTarget = document.getElementById(target?.fallbackId ?? taskContextLauncherIds[fallbackView]);
+    (connectedTarget ?? replacementTarget ?? fallbackTarget)?.focus({ preventScroll: true });
+  });
+}

--- a/apps/web/src/features/tasks/task-state.ts
+++ b/apps/web/src/features/tasks/task-state.ts
@@ -22,7 +22,6 @@ export interface TaskState {
   toolDecisionState: Record<string, 'approving' | 'denying' | 'approved' | 'denied'>;
   toolDecisionErrors: Record<string, string>;
   effortLevels: EffortLevel[];
-  activeEffort: string;
   newTaskConfig: NewTaskConfig;
   taskConfigSaving: 'model' | 'effort' | 'permission' | 'goal' | null;
   contextCompacting: Record<string, boolean>;
@@ -207,7 +206,6 @@ export function createTaskState(): TaskState {
     toolDecisionState: {},
     toolDecisionErrors: {},
     effortLevels: [],
-    activeEffort: 'medium',
     newTaskConfig: readNewTaskConfig(),
     taskConfigSaving: null,
     contextCompacting: {},

--- a/apps/web/src/features/tasks/use-task-controller.test.ts
+++ b/apps/web/src/features/tasks/use-task-controller.test.ts
@@ -2,12 +2,21 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { codeApi } from '../../lib/api';
 import { appState, reportTaskPersistenceResult, setTheme } from '../../state/app-state';
-import { createTaskState, persistQueuedPrompts, persistTaskDrafts } from './task-state';
+import { fileEditorTabId, type WorkspaceFileEditorTab } from '../workspace/workspace-state';
+import { createTaskState, newTaskDraftKey, persistQueuedPrompts, persistTaskDrafts } from './task-state';
 import { applyAssistantStreamEvent, composeTaskPrompt, useTaskController } from './use-task-controller';
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  appState.workspaceSnapshotsByTask = {};
+  appState.workspaceGeneration = 0;
+  appState.editorTabs = [];
+  appState.activeEditorTabId = null;
+  appState.workspaceSearchResults = [];
+  appState.workspaceSearchQuery = '';
+  appState.gitStatus = null;
+  appState.taskView = 'conversation';
   localStorage.removeItem('a3s-code-web.active-task');
   localStorage.removeItem('a3s-code-web.task-drafts');
   localStorage.removeItem('a3s-code-web.queued-prompts');
@@ -84,6 +93,187 @@ describe('task-scoped draft recovery', () => {
     hook.unmount();
   });
 
+  it('ignores a late controls response from the previously selected task', async () => {
+    const taskA = codeSession('task-a', '/repo');
+    const taskB = codeSession('task-b', '/repo');
+    const controlsA = deferred<Awaited<ReturnType<typeof codeApi.sessionControls>>>();
+    const controlsB = deferred<Awaited<ReturnType<typeof codeApi.sessionControls>>>();
+    appState.sessions = [taskA, taskB];
+    appState.activeSessionId = taskA.sessionId;
+    appState.messagesBySession = { 'task-a': [], 'task-b': [] };
+    appState.filesByDirectory = { '/repo': [] };
+    vi.spyOn(codeApi, 'sessionControls').mockImplementation((sessionId) =>
+      sessionId === taskA.sessionId ? controlsA.promise : controlsB.promise
+    );
+    const hook = renderHook(() => useTaskController());
+    let pendingA!: Promise<void>;
+    let pendingB!: Promise<void>;
+
+    act(() => {
+      pendingA = hook.result.current.selectSession(taskA.sessionId);
+    });
+    act(() => {
+      pendingB = hook.result.current.selectSession(taskB.sessionId);
+    });
+    await act(async () => {
+      controlsB.resolve({
+        sessionId: taskB.sessionId,
+        effort: 'high',
+        planningMode: 'disabled',
+        goalTracking: false,
+      });
+      await pendingB;
+    });
+
+    expect(appState.activeSessionId).toBe(taskB.sessionId);
+
+    await act(async () => {
+      controlsA.resolve({
+        sessionId: taskA.sessionId,
+        effort: 'low',
+        planningMode: 'disabled',
+        goalTracking: false,
+      });
+      await pendingA;
+    });
+
+    expect(appState.sessionControls[taskA.sessionId]?.effort).toBe('low');
+    expect(appState.sessionControls[taskB.sessionId]?.effort).toBe('high');
+    expect(appState.activeSessionId).toBe(taskB.sessionId);
+    hook.unmount();
+  });
+
+  it('keeps the newest message load when the same task is selected twice', async () => {
+    const task = codeSession('task-a', '/repo');
+    const firstMessages = deferred<Awaited<ReturnType<typeof codeApi.messages>>>();
+    const secondMessages = deferred<Awaited<ReturnType<typeof codeApi.messages>>>();
+    appState.sessions = [task];
+    appState.activeSessionId = task.sessionId;
+    appState.messagesBySession = {};
+    appState.filesByDirectory = { '/repo': [] };
+    vi.spyOn(codeApi, 'messages')
+      .mockReturnValueOnce(firstMessages.promise)
+      .mockReturnValueOnce(secondMessages.promise);
+    vi.spyOn(codeApi, 'sessionControls').mockResolvedValue({
+      sessionId: task.sessionId,
+      effort: 'medium',
+      planningMode: 'disabled',
+      goalTracking: false,
+    });
+    const hook = renderHook(() => useTaskController());
+    let firstSelection!: Promise<void>;
+    let secondSelection!: Promise<void>;
+
+    act(() => {
+      firstSelection = hook.result.current.selectSession(task.sessionId);
+      secondSelection = hook.result.current.selectSession(task.sessionId);
+    });
+    await act(async () => {
+      secondMessages.resolve({ items: [chatMessage(task.sessionId, 'newest')], total: 1, page: 1, limit: 100 });
+      await secondSelection;
+    });
+    await act(async () => {
+      firstMessages.resolve({ items: [chatMessage(task.sessionId, 'stale')], total: 1, page: 1, limit: 100 });
+      await firstSelection;
+    });
+
+    expect(appState.messagesBySession[task.sessionId]?.map((message) => message.content)).toEqual(['newest']);
+    expect(appState.messagesLoading[task.sessionId]).toBe(false);
+    hook.unmount();
+  });
+
+  it('does not let an older controls load overwrite a successful effort update', async () => {
+    const task = codeSession('task-a', '/repo');
+    const staleControls = deferred<Awaited<ReturnType<typeof codeApi.sessionControls>>>();
+    appState.sessions = [task];
+    appState.activeSessionId = task.sessionId;
+    appState.messagesBySession = { [task.sessionId]: [] };
+    appState.filesByDirectory = { '/repo': [] };
+    appState.taskConfigSaving = null;
+    vi.spyOn(codeApi, 'sessionControls').mockReturnValue(staleControls.promise);
+    vi.spyOn(codeApi, 'updateSessionControls').mockResolvedValue({
+      sessionId: task.sessionId,
+      effort: 'high',
+      planningMode: 'disabled',
+      goalTracking: false,
+    });
+    const hook = renderHook(() => useTaskController());
+    let pendingSelection!: Promise<void>;
+
+    act(() => {
+      pendingSelection = hook.result.current.selectSession(task.sessionId);
+    });
+    await act(() => hook.result.current.updateEffort('high'));
+    expect(appState.sessionControls[task.sessionId]?.effort).toBe('high');
+
+    await act(async () => {
+      staleControls.resolve({
+        sessionId: task.sessionId,
+        effort: 'low',
+        planningMode: 'disabled',
+        goalTracking: false,
+      });
+      await pendingSelection;
+    });
+
+    expect(appState.sessionControls[task.sessionId]?.effort).toBe('high');
+    expect(appState.sessionControlsLoading[task.sessionId]).toBe(false);
+    hook.unmount();
+  });
+
+  it('restores editor tabs, dirty drafts, selection, and view per task even when tasks share a workspace', async () => {
+    const taskA = codeSession('task-a', '/repo');
+    const taskB = codeSession('task-b', '/repo');
+    const tabA = fileTab('/repo/a.ts', 'saved A', 'draft A');
+    appState.sessions = [taskA, taskB];
+    appState.activeSessionId = taskA.sessionId;
+    appState.workspaceRoot = taskA.workspace;
+    appState.taskView = 'review';
+    appState.editorTabs = [tabA];
+    appState.activeEditorTabId = tabA.id;
+    appState.messagesBySession = { 'task-a': [], 'task-b': [] };
+    appState.draftsByTask = {};
+    vi.spyOn(codeApi, 'sessionControls').mockImplementation(async (sessionId) => ({
+      sessionId,
+      effort: 'medium',
+      planningMode: 'disabled',
+      goalTracking: false,
+    }));
+    const hook = renderHook(() => useTaskController());
+
+    await act(() => hook.result.current.selectSession('task-b'));
+
+    expect(appState.activeSessionId).toBe('task-b');
+    expect(appState.workspaceRoot).toBe('/repo');
+    expect(appState.editorTabs).toEqual([]);
+    expect(appState.activeEditorTabId).toBeNull();
+    expect(appState.taskView).toBe('conversation');
+
+    const tabB = fileTab('/repo/b.ts', 'saved B');
+    appState.editorTabs = [tabB];
+    appState.activeEditorTabId = tabB.id;
+    appState.taskView = 'activity';
+
+    await act(() => hook.result.current.selectSession('task-a'));
+
+    expect(appState.editorTabs).toHaveLength(1);
+    expect(appState.editorTabs[0]).toMatchObject({
+      id: tabA.id,
+      content: 'saved A',
+      draft: 'draft A',
+    });
+    expect(appState.activeEditorTabId).toBe(tabA.id);
+    expect(appState.taskView).toBe('review');
+
+    await act(() => hook.result.current.selectSession('task-b'));
+
+    expect(appState.editorTabs).toHaveLength(1);
+    expect(appState.editorTabs[0]).toMatchObject({ id: tabB.id, content: 'saved B' });
+    expect(appState.activeEditorTabId).toBe(tabB.id);
+    expect(appState.taskView).toBe('activity');
+    hook.unmount();
+  });
+
   it('restores the active draft and follow-up queue after refresh', () => {
     localStorage.setItem('a3s-code-web.active-task', 'task-a');
     localStorage.setItem(
@@ -142,10 +332,67 @@ describe('task-scoped draft recovery', () => {
   });
 });
 
+function codeSession(sessionId: string, workspace: string) {
+  return {
+    sessionId,
+    workspace,
+    cwd: workspace,
+    model: 'codex/gpt',
+    followDefaultModel: false,
+    permissionMode: 'default',
+    state: 'idle',
+    createdAt: 1,
+  };
+}
+
+function fileTab(path: string, content: string, draft = content): WorkspaceFileEditorTab {
+  return {
+    id: fileEditorTabId(path),
+    kind: 'file',
+    path,
+    content,
+    draft,
+    revision: null,
+    isBinary: false,
+    location: null,
+    loading: false,
+    loadError: null,
+    saving: false,
+    configValidation: null,
+  };
+}
+
+function chatMessage(sessionId: string, content: string) {
+  return {
+    id: `${sessionId}-${content}`,
+    sessionId,
+    role: 'assistant' as const,
+    content,
+    createdAt: new Date(0).toISOString(),
+    pending: false,
+    events: [],
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('task configuration', () => {
   it('switches the new-task workspace and removes context owned by the previous workspace', async () => {
     appState.activeSessionId = null;
     appState.workspaceRoot = '/repo';
+    appState.editorTabs = [fileTab('/repo/old.ts', 'saved', 'draft')];
+    appState.activeEditorTabId = fileEditorTabId('/repo/old.ts');
+    appState.workspaceSearchQuery = 'old query';
+    appState.gitStatus = { isGitRepo: true, branch: 'main', files: [] };
     appState.composerContextFiles = ['src/app.ts'];
     appState.composerSkills = ['review'];
     appState.newTaskConfig = {
@@ -163,6 +410,10 @@ describe('task configuration', () => {
     expect(readDir).toHaveBeenCalledWith('/clients/acme');
     expect(appState.newTaskConfig.workspace).toBe('/clients/acme');
     expect(appState.workspaceRoot).toBe('/clients/acme');
+    expect(appState.editorTabs).toEqual([]);
+    expect(appState.activeEditorTabId).toBeNull();
+    expect(appState.workspaceSearchQuery).toBe('');
+    expect(appState.gitStatus).toBeNull();
     expect(appState.composerContextFiles).toEqual([]);
     expect(appState.composerSkills).toEqual([]);
     expect(JSON.parse(localStorage.getItem('a3s-code-web.new-task-config') ?? '{}')).toMatchObject({
@@ -297,6 +548,70 @@ describe('task configuration', () => {
     });
     expect(appState.sessionControls['task-new']?.effort).toBe('high');
     expect(appState.newTaskConfig.goal).toBe('');
+    hook.unmount();
+  });
+
+  it('promotes prepared editor and composer state without leaking it into the next new task', async () => {
+    appState.activeSessionId = null;
+    appState.workspaceRoot = '/repo';
+    appState.sessions = [];
+    appState.messagesBySession = {};
+    appState.newTaskConfig = {
+      workspace: '/repo',
+      model: 'codex/gpt',
+      effort: 'medium',
+      permissionMode: 'default',
+      goal: '',
+    };
+    const tab = fileTab('/repo/src/prepared.ts', 'saved', 'prepared draft');
+    appState.editorTabs = [tab];
+    appState.activeEditorTabId = tab.id;
+    appState.taskView = 'review';
+    appState.composerValue = 'Review the prepared draft';
+    appState.composerContextFiles = ['src/prepared.ts'];
+    appState.composerSkills = ['review'];
+    appState.draftsByTask = {
+      [newTaskDraftKey]: {
+        content: 'Review the prepared draft',
+        contextFiles: ['src/prepared.ts'],
+        skillNames: ['review'],
+      },
+    };
+    const session = codeSession('task-created', '/repo');
+    vi.spyOn(codeApi, 'createSession').mockResolvedValue({ success: true, session });
+    vi.spyOn(codeApi, 'updateSessionControls').mockResolvedValue({
+      sessionId: session.sessionId,
+      effort: 'medium',
+      planningMode: 'disabled',
+      goalTracking: false,
+    });
+    const hook = renderHook(() => useTaskController());
+
+    await act(() => hook.result.current.createSession('Prepared task'));
+
+    expect(appState.activeSessionId).toBe(session.sessionId);
+    expect(appState.workspaceRoot).toBe('/repo');
+    expect(appState.editorTabs).toHaveLength(1);
+    expect(appState.editorTabs[0]).toMatchObject({
+      id: tab.id,
+      content: 'saved',
+      draft: 'prepared draft',
+    });
+    expect(appState.activeEditorTabId).toBe(tab.id);
+    expect(appState.taskView).toBe('review');
+    expect(appState.draftsByTask[newTaskDraftKey]).toBeUndefined();
+    expect(appState.draftsByTask[session.sessionId]).toEqual({
+      content: 'Review the prepared draft',
+      contextFiles: ['src/prepared.ts'],
+      skillNames: ['review'],
+    });
+    expect(JSON.parse(localStorage.getItem('a3s-code-web.task-drafts') ?? '{}')).toEqual({
+      [session.sessionId]: {
+        content: 'Review the prepared draft',
+        contextFiles: ['src/prepared.ts'],
+        skillNames: ['review'],
+      },
+    });
     hook.unmount();
   });
 

--- a/apps/web/src/features/tasks/use-task-controller.ts
+++ b/apps/web/src/features/tasks/use-task-controller.ts
@@ -4,17 +4,30 @@ import { subscribeKey } from 'valtio/utils';
 import { codeApi, streamSessionMessage } from '../../lib/api';
 import {
   appState,
+  captureWorkspaceContext,
   formatApiError,
+  isWorkspaceContextCurrent,
   persistSessionTitle,
+  promoteActiveTask,
   reportTaskPersistenceResult,
+  removeWorkspaceTaskSnapshot,
   removePersistedSessionTitle,
+  replaceActiveWorkspace,
   showModelChangeNotice,
   showToast,
+  switchActiveTask,
 } from '../../state/app-state';
-import type { AgentEvent, ChatMessage, CodeSession } from '../../types/api';
+import type { AgentEvent, ChatMessage, CodeSession, SessionControls } from '../../types/api';
 import { parseGoalCommand, type GoalCommand } from './goal-command';
 import {
-  persistActiveTask,
+  beginSessionControlsRequest,
+  beginSessionMessagesRequest,
+  invalidateSessionControlsRequests,
+  invalidateSessionMessagesRequests,
+  isSessionControlsRequestCurrent,
+  isSessionMessagesRequestCurrent,
+} from './session-resource-order';
+import {
   persistGoalTimings,
   persistNewTaskConfig,
   persistPausedQueues,
@@ -102,21 +115,40 @@ function clearSessionToolDecisions(sessionId: string): void {
 }
 
 async function cacheWorkspaceDirectory(workspace: string): Promise<void> {
+  const context = captureWorkspaceContext();
   appState.directoryLoading[workspace] = true;
   delete appState.directoryErrors[workspace];
   try {
-    appState.filesByDirectory[workspace] = await codeApi.readDir(workspace);
+    const entries = await codeApi.readDir(workspace);
+    if (!isWorkspaceContextCurrent(context)) return;
+    appState.filesByDirectory[workspace] = entries;
     appState.expandedDirectories[workspace] = true;
   } catch (error) {
+    if (!isWorkspaceContextCurrent(context)) return;
     appState.directoryErrors[workspace] = formatApiError(error);
     throw error;
   } finally {
-    appState.directoryLoading[workspace] = false;
+    if (isWorkspaceContextCurrent(context)) appState.directoryLoading[workspace] = false;
   }
 }
 
 export function useTaskController() {
   const abortRef = useRef<AbortController | null>(null);
+  const invalidateMessageRequests = (sessionId: string) => {
+    invalidateSessionMessagesRequests(sessionId);
+    appState.messagesLoading[sessionId] = false;
+  };
+  const invalidateControlsRequests = (sessionId: string) => {
+    const request = invalidateSessionControlsRequests(sessionId);
+    appState.sessionControlsLoading[sessionId] = false;
+    return request;
+  };
+  const publishControlsMutation = (sessionId: string, controls: SessionControls) => {
+    invalidateSessionControlsRequests(sessionId);
+    appState.sessionControls[sessionId] = controls;
+    appState.sessionControlsLoading[sessionId] = false;
+    delete appState.sessionControlsErrors[sessionId];
+  };
   const persistCurrentDraft = useMemoizedFn(() => {
     const key = taskDraftKey(appState.activeSessionId);
     appState.draftsByTask[key] = {
@@ -125,12 +157,6 @@ export function useTaskController() {
       skillNames: [...appState.composerSkills],
     };
     reportTaskPersistenceResult(persistTaskDrafts(appState.draftsByTask));
-  });
-  const restoreDraft = useMemoizedFn((sessionId: string | null) => {
-    const draft = appState.draftsByTask[taskDraftKey(sessionId)];
-    appState.composerValue = draft?.content ?? '';
-    appState.composerContextFiles = [...(draft?.contextFiles ?? [])];
-    appState.composerSkills = [...(draft?.skillNames ?? [])];
   });
   useEffect(() => {
     const persist = () => persistCurrentDraft();
@@ -144,45 +170,50 @@ export function useTaskController() {
     };
   }, [persistCurrentDraft]);
   const loadMessages = useMemoizedFn(async (sessionId: string) => {
+    const request = beginSessionMessagesRequest(sessionId);
     appState.messagesLoading[sessionId] = true;
     delete appState.messageErrors[sessionId];
     try {
-      appState.messagesBySession[sessionId] = (await codeApi.messages(sessionId)).items;
+      const messages = await codeApi.messages(sessionId);
+      if (!isSessionMessagesRequestCurrent(request)) return;
+      appState.messagesBySession[sessionId] = messages.items;
     } catch (error) {
+      if (!isSessionMessagesRequestCurrent(request)) return;
       const message = formatApiError(error);
       appState.messageErrors[sessionId] = message;
       showToast(message, 'error');
     } finally {
-      appState.messagesLoading[sessionId] = false;
+      if (isSessionMessagesRequestCurrent(request)) {
+        appState.messagesLoading[sessionId] = false;
+      }
     }
   });
   const loadControls = useMemoizedFn(async (sessionId: string) => {
+    const request = beginSessionControlsRequest(sessionId);
     appState.sessionControlsLoading[sessionId] = true;
     delete appState.sessionControlsErrors[sessionId];
     try {
       const controls = await codeApi.sessionControls(sessionId);
+      if (!isSessionControlsRequestCurrent(request)) return;
       appState.sessionControls[sessionId] = controls;
-      appState.activeEffort = controls.effort;
     } catch (error) {
+      if (!isSessionControlsRequestCurrent(request)) return;
       appState.sessionControlsErrors[sessionId] = formatApiError(error);
       throw error;
     } finally {
-      appState.sessionControlsLoading[sessionId] = false;
+      if (isSessionControlsRequestCurrent(request)) {
+        appState.sessionControlsLoading[sessionId] = false;
+      }
     }
   });
   const selectSession = useMemoizedFn(async (sessionId: string) => {
-    persistCurrentDraft();
     const session = appState.sessions.find((item) => item.sessionId === sessionId);
-    appState.activeSessionId = sessionId;
-    appState.taskView = 'conversation';
+    switchActiveTask(sessionId, session?.workspace);
     if (session?.workspace) {
-      appState.workspaceRoot = session.workspace;
       if (!appState.filesByDirectory[session.workspace]) {
         void cacheWorkspaceDirectory(session.workspace).catch(() => undefined);
       }
     }
-    reportTaskPersistenceResult(persistActiveTask(sessionId));
-    restoreDraft(sessionId);
     if (!appState.messagesBySession[sessionId]) await loadMessages(sessionId);
     try {
       await loadControls(sessionId);
@@ -209,21 +240,17 @@ export function useTaskController() {
     });
     const session = response.session;
     appState.sessions.unshift(session);
-    appState.activeSessionId = session.sessionId;
-    appState.taskView = 'conversation';
-    appState.workspaceRoot = session.workspace;
-    reportTaskPersistenceResult(persistActiveTask(session.sessionId));
+    promoteActiveTask(session.sessionId, session.workspace);
     appState.messagesBySession[session.sessionId] = [];
     reportTaskPersistenceResult(persistSessionTitle(session.sessionId, title));
+    const controlsMutationRequest = invalidateControlsRequests(session.sessionId);
     appState.sessionControlsLoading[session.sessionId] = true;
     try {
       const controls = await codeApi.updateSessionControls(session.sessionId, {
         effort: config.effort,
         goal: requestedGoal || null,
       });
-      appState.sessionControls[session.sessionId] = controls;
-      appState.activeEffort = controls.effort;
-      delete appState.sessionControlsErrors[session.sessionId];
+      publishControlsMutation(session.sessionId, controls);
       if (controls.goal) {
         appState.goalTimings[session.sessionId] =
           preparedGoalTiming?.goal === controls.goal
@@ -235,10 +262,11 @@ export function useTaskController() {
       appState.newTaskConfig.goal = '';
       reportTaskPersistenceResult(persistNewTaskConfig(appState.newTaskConfig));
     } catch (error) {
-      appState.sessionControlsErrors[session.sessionId] = formatApiError(error);
+      if (isSessionControlsRequestCurrent(controlsMutationRequest)) {
+        appState.sessionControlsErrors[session.sessionId] = formatApiError(error);
+        appState.sessionControlsLoading[session.sessionId] = false;
+      }
       throw error;
-    } finally {
-      appState.sessionControlsLoading[session.sessionId] = false;
     }
     return session;
   });
@@ -246,13 +274,17 @@ export function useTaskController() {
     if (appState.activeSessionId) throw new Error('只能在创建新任务时切换工作区。');
     const normalized = workspace.trim();
     if (!normalized) throw new Error('请选择一个有效的工作区。');
-    await cacheWorkspaceDirectory(normalized);
+    const context = captureWorkspaceContext();
+    const entries = await codeApi.readDir(normalized);
+    if (!isWorkspaceContextCurrent(context) || appState.activeSessionId) return;
     if (appState.newTaskConfig.workspace !== normalized) {
       appState.composerContextFiles = [];
       appState.composerSkills = [];
     }
     appState.newTaskConfig.workspace = normalized;
-    appState.workspaceRoot = normalized;
+    replaceActiveWorkspace(normalized);
+    appState.filesByDirectory[normalized] = entries;
+    appState.expandedDirectories[normalized] = true;
     reportTaskPersistenceResult(persistNewTaskConfig(appState.newTaskConfig));
   });
   const pickNewTaskWorkspace = useMemoizedFn(async (): Promise<string | null> => {
@@ -263,13 +295,9 @@ export function useTaskController() {
     return selected.path;
   });
   const newConversation = useMemoizedFn(() => {
-    persistCurrentDraft();
-    appState.activeSessionId = null;
-    appState.taskView = 'conversation';
-    reportTaskPersistenceResult(persistActiveTask(null));
-    restoreDraft(null);
+    const workspace = appState.newTaskConfig.workspace || appState.health?.workspace || appState.workspaceRoot;
+    switchActiveTask(null, workspace);
     appState.streamEvents = [];
-    appState.workspaceRoot = appState.newTaskConfig.workspace || appState.health?.workspace || appState.workspaceRoot;
   });
   const refreshSessions = useMemoizedFn(async () => {
     appState.sessions = (await codeApi.sessions()).items;
@@ -318,6 +346,7 @@ export function useTaskController() {
         else if ((appState.messagesBySession[sessionId]?.length ?? 0) === 0)
           reportTaskPersistenceResult(persistSessionTitle(sessionId, promptTitle(content)));
         const targetSessionId = sessionId;
+        invalidateMessageRequests(targetSessionId);
         const user = temporaryMessage(targetSessionId, 'user', transportContent);
         const assistant = temporaryMessage(targetSessionId, 'assistant', '');
         appState.messagesBySession[targetSessionId] ??= [];
@@ -444,9 +473,10 @@ export function useTaskController() {
       return;
     }
     appState.taskConfigSaving = 'goal';
+    invalidateControlsRequests(sessionId);
     try {
       const controls = await codeApi.updateSessionControls(sessionId, { goal });
-      appState.sessionControls[sessionId] = controls;
+      publishControlsMutation(sessionId, controls);
       if (controls.goal) appState.goalTimings[sessionId] = { goal: controls.goal, startedAt: Date.now() };
       else delete appState.goalTimings[sessionId];
       reportTaskPersistenceResult(persistGoalTimings(appState.goalTimings));
@@ -526,6 +556,8 @@ export function useTaskController() {
       await codeApi.deleteSession(sessionId);
       const index = sessionIndex(sessionId);
       if (index >= 0) appState.sessions.splice(index, 1);
+      invalidateMessageRequests(sessionId);
+      invalidateControlsRequests(sessionId);
       delete appState.messagesBySession[sessionId];
       delete appState.messagesLoading[sessionId];
       delete appState.messageErrors[sessionId];
@@ -544,11 +576,10 @@ export function useTaskController() {
       const titlePersisted = removePersistedSessionTitle(sessionId);
       if (appState.reviewSourceTaskId === sessionId) appState.reviewSourceTaskId = null;
       if (appState.activeSessionId === sessionId) {
-        appState.activeSessionId = null;
-        appState.taskView = 'conversation';
-        reportTaskPersistenceResult(persistActiveTask(null));
-        restoreDraft(null);
+        const workspace = appState.newTaskConfig.workspace || appState.health?.workspace || appState.workspaceRoot;
+        switchActiveTask(null, workspace);
       }
+      removeWorkspaceTaskSnapshot(sessionId);
       reportTaskPersistenceResult(titlePersisted);
     } catch (error) {
       showToast(formatApiError(error), 'error');
@@ -592,10 +623,10 @@ export function useTaskController() {
     const sessionId = appState.activeSessionId;
     if (!sessionId || appState.taskConfigSaving) return;
     appState.taskConfigSaving = 'effort';
+    invalidateControlsRequests(sessionId);
     try {
       const controls = await codeApi.updateSessionControls(sessionId, { effort });
-      appState.sessionControls[sessionId] = controls;
-      appState.activeEffort = controls.effort;
+      publishControlsMutation(sessionId, controls);
     } catch (error) {
       showToast(formatApiError(error), 'error');
     } finally {

--- a/apps/web/src/features/workspace/components/code-intelligence-error.ts
+++ b/apps/web/src/features/workspace/components/code-intelligence-error.ts
@@ -1,0 +1,34 @@
+import { ApiError } from '../../../lib/api';
+
+const unsupportedErrorCode = 'CODE_INTELLIGENCE_UNSUPPORTED';
+
+export function isUnsupportedCodeIntelligenceError(error: unknown): boolean {
+  return unsupportedErrorDetails(error) !== null;
+}
+
+export function isUnsupportedCodeIntelligenceLanguageError(error: unknown): boolean {
+  const details = unsupportedErrorDetails(error);
+  if (!details) return false;
+  if (details.operation === 'language') return true;
+
+  const message = details.message;
+  if (typeof message !== 'string') return false;
+  const normalizedMessage = message.startsWith(`${unsupportedErrorCode}: `)
+    ? message.slice(unsupportedErrorCode.length + 2)
+    : message;
+  return normalizedMessage.startsWith("Code Intelligence operation 'language' is unsupported:");
+}
+
+function unsupportedErrorDetails(error: unknown): Record<string, unknown> | null {
+  if (!(error instanceof ApiError) || error.status !== 501 || !isRecord(error.details)) return null;
+
+  const statusCode = error.details.statusCode;
+  if (statusCode === unsupportedErrorCode) return error.details;
+
+  const message = error.details.message;
+  return typeof message === 'string' && message.startsWith(`${unsupportedErrorCode}:`) ? error.details : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}

--- a/apps/web/src/features/workspace/components/code-navigation-menu.tsx
+++ b/apps/web/src/features/workspace/components/code-navigation-menu.tsx
@@ -1,0 +1,90 @@
+import { ArrowRight, ChevronDown, FileCode2, GitBranch, ListTree, Search } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { Button } from '../../../design-system/primitives';
+import type { CodeNavigationKind } from '../../../types/api';
+import { WorkspaceContextMenu, type WorkspaceContextMenuItem } from './workspace-context-menu';
+
+export type CodeEditorNavigationAction = CodeNavigationKind | 'outline';
+
+export function CodeNavigationMenu({
+  disabled,
+  onSelect,
+}: {
+  disabled: boolean;
+  onSelect: (action: CodeEditorNavigationAction) => void;
+}) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
+  const items: readonly WorkspaceContextMenuItem[] = [
+    {
+      id: 'definition',
+      label: '转到定义',
+      shortcut: 'F12',
+      icon: <ArrowRight size={14} />,
+      onSelect: () => onSelect('definition'),
+    },
+    {
+      id: 'declaration',
+      label: '转到声明',
+      icon: <FileCode2 size={14} />,
+      onSelect: () => onSelect('declaration'),
+    },
+    {
+      id: 'references',
+      label: '查找引用',
+      shortcut: 'Shift F12',
+      icon: <Search size={14} />,
+      onSelect: () => onSelect('references'),
+    },
+    {
+      id: 'implementations',
+      label: '转到实现',
+      shortcut: 'Cmd/Ctrl F12',
+      icon: <GitBranch size={14} />,
+      onSelect: () => onSelect('implementations'),
+    },
+    {
+      id: 'outline',
+      label: '文件符号大纲',
+      shortcut: 'Cmd/Ctrl Shift O',
+      icon: <ListTree size={14} />,
+      separatorBefore: true,
+      onSelect: () => onSelect('outline'),
+    },
+  ];
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        className='code-navigation-trigger'
+        tone='quiet'
+        disabled={disabled}
+        aria-haspopup='menu'
+        aria-expanded={anchor !== null}
+        title={disabled ? '编辑器加载完成后可用' : '定义、引用、实现和文件大纲'}
+        onClick={() => {
+          if (anchor) {
+            setAnchor(null);
+            return;
+          }
+          const bounds = triggerRef.current?.getBoundingClientRect();
+          setAnchor({ x: bounds?.left ?? 0, y: (bounds?.bottom ?? 0) + 4 });
+        }}
+      >
+        <FileCode2 size={13} />
+        <span>代码导航</span>
+        <ChevronDown size={11} />
+      </Button>
+      {anchor && (
+        <WorkspaceContextMenu
+          label='代码导航'
+          x={anchor.x}
+          y={anchor.y}
+          items={items}
+          onClose={() => setAnchor(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/workspace/components/line-ending-status-control.tsx
+++ b/apps/web/src/features/workspace/components/line-ending-status-control.tsx
@@ -1,0 +1,67 @@
+import { Check } from 'lucide-react';
+import { useRef, useState } from 'react';
+import type { MonacoLineEnding } from './monaco-editor-status';
+import { WorkspaceContextMenu, type WorkspaceContextMenuItem } from './workspace-context-menu';
+
+export function LineEndingStatusControl({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: MonacoLineEnding;
+  disabled: boolean;
+  onChange: (value: MonacoLineEnding) => void;
+}) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
+  const item = (lineEnding: MonacoLineEnding, platform: string): WorkspaceContextMenuItem => ({
+    id: lineEnding.toLowerCase(),
+    label: lineEnding,
+    ariaLabel: `${lineEnding}，${platform}`,
+    shortcut: platform,
+    checked: value === lineEnding,
+    icon: (
+      <Check
+        className={`line-ending-menu-check ${value === lineEnding ? 'selected' : ''}`}
+        size={13}
+        aria-hidden='true'
+      />
+    ),
+    onSelect: () => onChange(lineEnding),
+  });
+  const items = [item('LF', 'Unix / macOS'), item('CRLF', 'Windows')];
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type='button'
+        className='workspace-editor-status-action'
+        aria-label={`换行符 ${value}`}
+        aria-haspopup='menu'
+        aria-expanded={anchor !== null}
+        disabled={disabled}
+        title={disabled ? '只读模式下不能更改换行符' : '选择换行符序列'}
+        onClick={() => {
+          if (anchor) {
+            setAnchor(null);
+            return;
+          }
+          const bounds = triggerRef.current?.getBoundingClientRect();
+          setAnchor({ x: bounds?.left ?? 0, y: (bounds?.bottom ?? 0) + 4 });
+        }}
+      >
+        {value}
+      </button>
+      {anchor && (
+        <WorkspaceContextMenu
+          label='选择换行符序列'
+          x={anchor.x}
+          y={anchor.y}
+          items={items}
+          onClose={() => setAnchor(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/workspace/components/monaco-code-editor-fallback.test.tsx
+++ b/apps/web/src/features/workspace/components/monaco-code-editor-fallback.test.tsx
@@ -1,0 +1,235 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import * as monaco from 'monaco-editor';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, codeApi } from '../../../lib/api';
+import type { CodeIntelligenceStatus } from '../../../types/api';
+import { MonacoCodeEditor } from './monaco-code-editor';
+import { workspaceEditorModelPath } from './monaco-editor-model-store';
+
+const testMonaco = monaco as unknown as {
+  __actions: Array<{ id: string; run: () => void | Promise<void> }>;
+  __documentSymbolProviders: Array<{
+    languageSelector: string;
+    provider: {
+      provideDocumentSymbols: (model: unknown, token: unknown) => Promise<unknown>;
+    };
+  }>;
+  __model: unknown;
+  editor: { setModelMarkers: ReturnType<typeof vi.fn> };
+};
+
+const readyStatus: CodeIntelligenceStatus = {
+  state: 'ready',
+  capabilities: {
+    documentSymbols: true,
+    workspaceSymbols: true,
+    definition: true,
+    declaration: true,
+    references: true,
+    implementations: true,
+    diagnostics: true,
+  },
+  languages: [],
+  message: null,
+};
+
+describe('Monaco unsupported-language fallback', () => {
+  beforeEach(() => {
+    testMonaco.__actions.splice(0);
+    testMonaco.__documentSymbolProviders.splice(0);
+    testMonaco.editor.setModelMarkers.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps unsupported saved-document diagnostics out of the status bar', async () => {
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
+    vi.spyOn(codeApi, 'codeDiagnostics').mockRejectedValue(currentUnsupportedError());
+    const onStatusChange = vi.fn();
+
+    renderEditor({ onStatusChange });
+
+    await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith('本地编辑功能可用'));
+    expect(testMonaco.editor.setModelMarkers).toHaveBeenLastCalledWith(testMonaco.__model, 'a3s-code-intelligence', []);
+    expect(statusHistory(onStatusChange)).not.toContain('CODE_INTELLIGENCE_UNSUPPORTED');
+    expect(statusHistory(onStatusChange)).not.toContain('no language profile');
+  });
+
+  it('returns no native symbols quietly so Monaco JSON outline providers remain usable', async () => {
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
+    vi.spyOn(codeApi, 'codeDiagnostics').mockResolvedValue(emptyDiagnostics());
+    const outline = vi.spyOn(codeApi, 'codeOutline').mockRejectedValue(normalizedUnsupportedError());
+    const onStatusChange = vi.fn();
+
+    renderEditor({ onStatusChange });
+    await waitFor(() => expect(testMonaco.__documentSymbolProviders).toHaveLength(1));
+    await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith('代码导航就绪 · 0 个问题'));
+    onStatusChange.mockClear();
+
+    const registration = testMonaco.__documentSymbolProviders[0];
+    const symbols = await registration.provider.provideDocumentSymbols(testMonaco.__model, cancellationToken());
+
+    expect(registration.languageSelector).toBe('json');
+    expect(outline).toHaveBeenCalledWith('package.json', expect.any(Object));
+    expect(symbols).toEqual([]);
+    expect(onStatusChange).not.toHaveBeenCalled();
+  });
+
+  it('reuses a language-level unsupported result across native document operations', async () => {
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
+    const diagnostics = vi.spyOn(codeApi, 'codeDiagnostics').mockRejectedValue(currentUnsupportedError());
+    const outline = vi.spyOn(codeApi, 'codeOutline').mockRejectedValue(new Error('outline should not be queried'));
+    const navigation = vi
+      .spyOn(codeApi, 'codeNavigation')
+      .mockRejectedValue(new Error('navigation should not be queried'));
+    const onStatusChange = vi.fn();
+
+    const view = renderEditor({ onStatusChange });
+    await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith('本地编辑功能可用'));
+
+    view.rerender(editorElement({ savedDocument: false, onStatusChange }));
+    await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith('本地编辑功能可用'));
+
+    const symbols = await testMonaco.__documentSymbolProviders[0].provider.provideDocumentSymbols(
+      testMonaco.__model,
+      cancellationToken()
+    );
+    const action = testMonaco.__actions.find((candidate) => candidate.id === 'a3s.code-navigation.definition');
+    await act(async () => action?.run());
+
+    expect(diagnostics).toHaveBeenCalledTimes(1);
+    expect(outline).not.toHaveBeenCalled();
+    expect(navigation).not.toHaveBeenCalled();
+    expect(symbols).toEqual([]);
+    expect(onStatusChange).toHaveBeenLastCalledWith('此文件类型不支持定义导航');
+  });
+
+  it('keeps genuine diagnostics failures visible without leaking transport details', async () => {
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
+    vi.spyOn(codeApi, 'codeDiagnostics').mockRejectedValue(
+      new ApiError('connect ECONNREFUSED 127.0.0.1:3021', 503, { message: 'upstream unavailable' })
+    );
+    const onStatusChange = vi.fn();
+
+    renderEditor({ onStatusChange });
+
+    await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith('代码诊断暂时不可用'));
+    expect(statusHistory(onStatusChange)).not.toContain('ECONNREFUSED');
+    expect(statusHistory(onStatusChange)).not.toContain('upstream unavailable');
+  });
+
+  it('reports unsupported cursor navigation as a file-type limitation', async () => {
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
+    vi.spyOn(codeApi, 'codeDiagnostics').mockResolvedValue(emptyDiagnostics());
+    vi.spyOn(codeApi, 'codeNavigation').mockRejectedValue(currentUnsupportedError());
+    const onStatusChange = vi.fn();
+
+    renderEditor({ onStatusChange });
+    await waitFor(() => expect(testMonaco.__actions).not.toHaveLength(0));
+    await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith('代码导航就绪 · 0 个问题'));
+
+    const action = testMonaco.__actions.find((candidate) => candidate.id === 'a3s.code-navigation.definition');
+    await act(async () => action?.run());
+
+    expect(onStatusChange).toHaveBeenLastCalledWith('此文件类型不支持定义导航');
+    expect(statusHistory(onStatusChange)).not.toContain('CODE_INTELLIGENCE_UNSUPPORTED');
+  });
+
+  it('keeps genuine outline failures visible without replacing them with backend text', async () => {
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
+    vi.spyOn(codeApi, 'codeDiagnostics').mockResolvedValue(emptyDiagnostics());
+    vi.spyOn(codeApi, 'codeOutline').mockRejectedValue(
+      new ApiError('socket closed while reading symbols', 502, { message: 'gateway disconnected' })
+    );
+    const onStatusChange = vi.fn();
+
+    renderEditor({ onStatusChange });
+    await waitFor(() => expect(testMonaco.__documentSymbolProviders).toHaveLength(1));
+    await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith('代码导航就绪 · 0 个问题'));
+    onStatusChange.mockClear();
+
+    await testMonaco.__documentSymbolProviders[0].provider.provideDocumentSymbols(
+      testMonaco.__model,
+      cancellationToken()
+    );
+
+    expect(onStatusChange).toHaveBeenLastCalledWith('文件符号暂时不可用');
+    expect(statusHistory(onStatusChange)).not.toContain('socket closed');
+    expect(statusHistory(onStatusChange)).not.toContain('gateway disconnected');
+  });
+});
+
+function renderEditor(
+  overrides: Partial<React.ComponentProps<typeof MonacoCodeEditor>> = {}
+): ReturnType<typeof render> {
+  return render(editorElement(overrides));
+}
+
+function editorElement(overrides: Partial<React.ComponentProps<typeof MonacoCodeEditor>> = {}): React.ReactElement {
+  return (
+    <MonacoCodeEditor
+      path='/repo/package.json'
+      modelPath={workspaceEditorModelPath('new-task', '/repo/package.json')}
+      value='{"scripts": {"test": "vitest"}}'
+      location={null}
+      readOnly={false}
+      dark={false}
+      workspaceRoot='/repo'
+      sessionId={null}
+      savedDocument
+      onChange={vi.fn()}
+      onSave={vi.fn()}
+      onClose={vi.fn()}
+      onNavigate={vi.fn(async () => true)}
+      onStatusChange={vi.fn()}
+      onEditorStatusChange={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
+function emptyDiagnostics() {
+  return {
+    items: [],
+    truncated: false,
+    workspaceRevision: 2,
+    document: { revision: 1, contentHash: 'hash', stale: false },
+  };
+}
+
+function currentUnsupportedError(): ApiError {
+  return new ApiError(
+    "CODE_INTELLIGENCE_UNSUPPORTED: Code Intelligence operation 'language' is unsupported: no language profile supports saved document package.json",
+    501,
+    {
+      statusCode: 501,
+      message:
+        "CODE_INTELLIGENCE_UNSUPPORTED: Code Intelligence operation 'language' is unsupported: no language profile supports saved document package.json",
+      error: 'Not Implemented',
+    }
+  );
+}
+
+function normalizedUnsupportedError(): ApiError {
+  return new ApiError('The selected file type has no native language profile', 501, {
+    statusCode: 'CODE_INTELLIGENCE_UNSUPPORTED',
+    message: 'The selected file type has no native language profile',
+  });
+}
+
+function cancellationToken(): {
+  isCancellationRequested: boolean;
+  onCancellationRequested: () => { dispose: () => void };
+} {
+  return {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose: vi.fn() }),
+  };
+}
+
+function statusHistory(callback: ReturnType<typeof vi.fn>): string {
+  return callback.mock.calls.map(([label]) => String(label)).join('\n');
+}

--- a/apps/web/src/features/workspace/components/monaco-code-editor.test.tsx
+++ b/apps/web/src/features/workspace/components/monaco-code-editor.test.tsx
@@ -1,12 +1,15 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as monaco from 'monaco-editor';
+import { createRef, type Ref } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { codeApi } from '../../../lib/api';
 import type { CodeIntelligenceStatus } from '../../../types/api';
-import { MonacoCodeEditor } from './monaco-code-editor';
+import { workspaceEditorModelPath } from './monaco-editor-model-store';
+import { MonacoCodeEditor, type MonacoCodeEditorHandle } from './monaco-code-editor';
 
 const testMonaco = monaco as unknown as {
   __actions: Array<{ id: string; run: () => void | Promise<void> }>;
+  __editorActionRuns: string[];
   __documentSymbolProviders: Array<{
     languageSelector: string;
     provider: {
@@ -14,7 +17,15 @@ const testMonaco = monaco as unknown as {
       provideDocumentSymbols: (model: unknown, token: unknown) => Promise<unknown>;
     };
   }>;
+  __cursorSelectionListeners: Array<() => void>;
+  __modelContentListeners: Array<() => void>;
+  __editorMountCount: number;
+  __savedViewStates: unknown[];
+  __restoredViewStates: unknown[];
+  __pushEolCalls: number[];
   __position: { lineNumber: number; column: number };
+  __selections: Array<{ selectedText: string; isEmpty: () => boolean }>;
+  __eol: '\n' | '\r\n';
   __model: unknown;
   editor: { setModelMarkers: ReturnType<typeof vi.fn> };
 };
@@ -58,14 +69,150 @@ const unavailableStatus: CodeIntelligenceStatus = {
 describe('Monaco code-intelligence bridge', () => {
   beforeEach(() => {
     testMonaco.__actions.splice(0);
+    testMonaco.__editorActionRuns.splice(0);
     testMonaco.__documentSymbolProviders.splice(0);
+    testMonaco.__cursorSelectionListeners.splice(0);
+    testMonaco.__modelContentListeners.splice(0);
+    testMonaco.__pushEolCalls.splice(0);
     testMonaco.__position = { lineNumber: 1, column: 1 };
+    testMonaco.__selections = [{ selectedText: '', isEmpty: () => true }];
+    testMonaco.__eol = '\n';
     testMonaco.editor.setModelMarkers.mockClear();
   });
 
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it('reports live cursor, selection, and line-ending state from the Monaco model', async () => {
+    const onEditorStatusChange = vi.fn();
+    renderEditor({ value: 'first\r\nsecond', onEditorStatusChange });
+
+    await waitFor(() =>
+      expect(onEditorStatusChange).toHaveBeenLastCalledWith({
+        lineNumber: 1,
+        column: 1,
+        selectedCharacters: 0,
+        selectionCount: 1,
+        lineEnding: 'CRLF',
+      })
+    );
+
+    act(() => {
+      testMonaco.__position = { lineNumber: 2, column: 4 };
+      testMonaco.__selections = [{ selectedText: 'A😀', isEmpty: () => false }];
+      for (const listener of testMonaco.__cursorSelectionListeners) listener();
+    });
+    expect(onEditorStatusChange).toHaveBeenLastCalledWith({
+      lineNumber: 2,
+      column: 4,
+      selectedCharacters: 3,
+      selectionCount: 1,
+      lineEnding: 'CRLF',
+    });
+
+    act(() => {
+      testMonaco.__eol = '\n';
+      for (const listener of testMonaco.__modelContentListeners) listener();
+    });
+    expect(onEditorStatusChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lineEnding: 'LF', lineNumber: 2, column: 4 })
+    );
+  });
+
+  it('changes line endings through Monaco history and restores editor focus', async () => {
+    const ref = createRef<MonacoCodeEditorHandle>();
+    const onChange = vi.fn();
+    const onEditorStatusChange = vi.fn();
+    renderEditor({ value: 'first\nsecond', onChange, onEditorStatusChange }, ref);
+    await waitFor(() => expect(ref.current).not.toBeNull());
+
+    act(() => ref.current?.setLineEnding('LF'));
+    expect(testMonaco.__pushEolCalls).toEqual([]);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => ref.current?.setLineEnding('CRLF'));
+
+    expect(testMonaco.__pushEolCalls).toEqual([1]);
+    expect(onChange).toHaveBeenCalledWith('first\r\nsecond');
+    expect(onEditorStatusChange).toHaveBeenLastCalledWith(expect.objectContaining({ lineEnding: 'CRLF' }));
+    expect(screen.getByRole('textbox', { name: '编辑 app.ts' })).toHaveFocus();
+  });
+
+  it('reports a successful imperative focus handoff once Monaco is mounted', async () => {
+    const ref = createRef<MonacoCodeEditorHandle>();
+    renderEditor({}, ref);
+    await waitFor(() => expect(ref.current).not.toBeNull());
+
+    let focused = false;
+    act(() => {
+      focused = ref.current?.focus() ?? false;
+    });
+
+    expect(focused).toBe(true);
+    expect(screen.getByRole('textbox', { name: '编辑 app.ts' })).toHaveFocus();
+  });
+
+  it('reports an explicit navigation target as consumed after applying it', async () => {
+    const onLocationApplied = vi.fn();
+
+    renderEditor({ location: { line: 7, column: 3 }, onLocationApplied });
+
+    await waitFor(() => expect(onLocationApplied).toHaveBeenCalledTimes(1));
+    expect(testMonaco.__position).toEqual({ lineNumber: 7, column: 3 });
+  });
+
+  it('keeps one editor instance and restores model-owned view state across document switches', async () => {
+    const modelA = workspaceEditorModelPath('task-a', '/repo/src/app.ts');
+    const modelB = workspaceEditorModelPath('task-a', '/repo/src/lib.rs');
+    const initialMountCount = testMonaco.__editorMountCount;
+    const view = renderEditor({ modelPath: modelA });
+    await screen.findByRole('textbox', { name: '编辑 app.ts' });
+    act(() => {
+      testMonaco.__position = { lineNumber: 8, column: 4 };
+    });
+
+    view.rerender(editorElement({ path: '/repo/src/lib.rs', modelPath: modelB, value: 'fn value() {}' }));
+    await waitFor(() => expect(testMonaco.__savedViewStates).toContainEqual(expect.objectContaining({ path: modelA })));
+    await waitFor(() => expect(testMonaco.__documentSymbolProviders[0]?.languageSelector).toBe('rust'));
+    act(() => {
+      testMonaco.__position = { lineNumber: 3, column: 2 };
+    });
+
+    view.rerender(editorElement({ modelPath: modelA }));
+
+    await waitFor(() =>
+      expect(testMonaco.__restoredViewStates).toContainEqual(expect.objectContaining({ path: modelA }))
+    );
+    expect(testMonaco.__position).toEqual({ lineNumber: 8, column: 4 });
+    expect(testMonaco.__editorMountCount).toBe(initialMountCount + 1);
+    expect(testMonaco.__documentSymbolProviders).toHaveLength(1);
+    expect(testMonaco.__documentSymbolProviders[0]?.languageSelector).toBe('typescript');
+  });
+
+  it('refreshes document symbols when a renamed retained model changes language', async () => {
+    const modelPath = workspaceEditorModelPath('task-a', '/repo/src/app.ts');
+    const initialMountCount = testMonaco.__editorMountCount;
+    const view = renderEditor({ modelPath });
+    await waitFor(() => expect(testMonaco.__documentSymbolProviders[0]?.languageSelector).toBe('typescript'));
+
+    view.rerender(editorElement({ path: '/repo/src/app.rs', modelPath, value: 'fn main() {}' }));
+
+    await waitFor(() => expect(testMonaco.__documentSymbolProviders[0]?.languageSelector).toBe('rust'));
+    expect(testMonaco.__editorMountCount).toBe(initialMountCount + 1);
+  });
+
+  it('does not let an imperative caller change a read-only model line ending', async () => {
+    const ref = createRef<MonacoCodeEditorHandle>();
+    const onChange = vi.fn();
+    renderEditor({ readOnly: true, onChange }, ref);
+    await waitFor(() => expect(ref.current).not.toBeNull());
+
+    act(() => ref.current?.setLineEnding('CRLF'));
+
+    expect(testMonaco.__pushEolCalls).toEqual([]);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('loads saved-document diagnostics into the existing Monaco model', async () => {
@@ -482,6 +629,31 @@ describe('Monaco code-intelligence bridge', () => {
     expect(onStatusChange).toHaveBeenLastCalledWith('代码导航就绪 · 0 个问题 · 基于已保存版本');
   });
 
+  it('opens the Monaco file outline through the editor command handle', async () => {
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
+    vi.spyOn(codeApi, 'codeDiagnostics').mockResolvedValue({
+      items: [],
+      truncated: false,
+      workspaceRevision: 2,
+      document: { revision: 2, contentHash: 'hash', stale: false },
+    });
+    const ref = createRef<MonacoCodeEditorHandle>();
+
+    renderEditor({}, ref);
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    act(() => ref.current?.showOutline());
+
+    expect(testMonaco.__editorActionRuns).toEqual(['editor.action.quickOutline']);
+  });
+
+  it('does not register an outline provider with an undefined language selector', async () => {
+    renderEditor({ path: '/repo/src/notes.custom' });
+
+    await waitFor(() => expect(screen.getByRole('textbox', { name: '编辑 notes.custom' })).toBeInTheDocument());
+    expect(testMonaco.__documentSymbolProviders).toHaveLength(1);
+    expect(testMonaco.__documentSymbolProviders[0].languageSelector).toBe('plaintext');
+  });
+
   it('does not query a file outside the served workspace', async () => {
     const status = vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue(readyStatus);
     const diagnostics = vi.spyOn(codeApi, 'codeDiagnostics');
@@ -511,11 +683,21 @@ describe('Monaco code-intelligence bridge', () => {
 });
 
 function renderEditor(
-  overrides: Partial<React.ComponentProps<typeof MonacoCodeEditor>> = {}
+  overrides: Partial<React.ComponentProps<typeof MonacoCodeEditor>> = {},
+  ref?: Ref<MonacoCodeEditorHandle>
 ): ReturnType<typeof render> {
-  return render(
+  return render(editorElement(overrides, ref));
+}
+
+function editorElement(
+  overrides: Partial<React.ComponentProps<typeof MonacoCodeEditor>> = {},
+  ref?: Ref<MonacoCodeEditorHandle>
+): React.ReactElement {
+  return (
     <MonacoCodeEditor
+      ref={ref}
       path='/repo/src/app.ts'
+      modelPath={workspaceEditorModelPath('new-task', '/repo/src/app.ts')}
       value='const value = 1;'
       location={null}
       readOnly={false}
@@ -528,6 +710,8 @@ function renderEditor(
       onClose={vi.fn()}
       onNavigate={vi.fn(async () => true)}
       onStatusChange={vi.fn()}
+      onEditorStatusChange={vi.fn()}
+      onLocationApplied={vi.fn()}
       {...overrides}
     />
   );

--- a/apps/web/src/features/workspace/components/monaco-code-editor.tsx
+++ b/apps/web/src/features/workspace/components/monaco-code-editor.tsx
@@ -1,6 +1,6 @@
 import Editor, { type Monaco, type OnMount } from '@monaco-editor/react';
 import type { CancellationToken, editor, IDisposable, languages } from 'monaco-editor';
-import { useEffect, useRef, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react';
 import { codeApi } from '../../../lib/api';
 import type {
   CodeDiagnosticSeverity,
@@ -17,55 +17,132 @@ import {
   workspaceSelection,
 } from '../code-intelligence';
 import type { WorkspaceFileSelection } from '../workspace-state';
+import {
+  isUnsupportedCodeIntelligenceError,
+  isUnsupportedCodeIntelligenceLanguageError,
+} from './code-intelligence-error';
 import { type NavigationCandidate, type NavigationPickerState, NavigationResultPicker } from './code-navigation-picker';
+import { type MonacoEditorStatus, type MonacoLineEnding, observeMonacoEditorStatus } from './monaco-editor-status';
+import { attachWorkspaceEditorModel, saveWorkspaceEditorModel } from './monaco-editor-model-store';
 import { configureMonaco, languageForPath, monacoTheme } from './monaco-environment';
 
 const markerOwner = 'a3s-code-intelligence';
 
-export function MonacoCodeEditor({
-  path,
-  value,
-  location,
-  readOnly,
-  dark,
-  workspaceRoot,
-  sessionId,
-  savedDocument,
-  onChange,
-  onSave,
-  onClose,
-  onNavigate,
-  onStatusChange,
-}: {
-  path: string;
-  value: string;
-  location: { line: number; column: number } | null;
-  readOnly: boolean;
-  dark: boolean;
-  workspaceRoot: string;
-  sessionId: string | null;
-  savedDocument: boolean;
-  onChange: (value: string) => void;
-  onSave: () => void;
-  onClose: () => void;
-  onNavigate: (selection: WorkspaceFileSelection) => Promise<boolean>;
-  onStatusChange: (label: string) => void;
-}) {
+export interface MonacoCodeEditorHandle {
+  focus: () => boolean;
+  navigate: (kind: CodeNavigationKind) => void;
+  setLineEnding: (lineEnding: MonacoLineEnding) => void;
+  showOutline: () => void;
+}
+
+export const MonacoCodeEditor = forwardRef<
+  MonacoCodeEditorHandle,
+  {
+    path: string;
+    modelPath: string;
+    value: string;
+    location: { line: number; column: number } | null;
+    readOnly: boolean;
+    dark: boolean;
+    workspaceRoot: string;
+    sessionId: string | null;
+    savedDocument: boolean;
+    onChange: (value: string) => void;
+    onSave: () => void;
+    onClose: () => void;
+    onNavigate: (selection: WorkspaceFileSelection) => Promise<boolean>;
+    onStatusChange: (label: string) => void;
+    onEditorStatusChange: (status: MonacoEditorStatus | null) => void;
+    onLocationApplied?: () => void;
+    onReadyChange?: (ready: boolean) => void;
+  }
+>(function MonacoCodeEditor(
+  {
+    path,
+    modelPath,
+    value,
+    location,
+    readOnly,
+    dark,
+    workspaceRoot,
+    sessionId,
+    savedDocument,
+    onChange,
+    onSave,
+    onClose,
+    onNavigate,
+    onStatusChange,
+    onEditorStatusChange,
+    onLocationApplied,
+    onReadyChange,
+  },
+  ref
+) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
-  const actionDisposablesRef = useRef<IDisposable[]>([]);
+  const editorDisposablesRef = useRef<IDisposable[]>([]);
+  const documentSymbolDisposableRef = useRef<IDisposable | null>(null);
+  const activeModelPathRef = useRef(modelPath);
+  const modelPathRef = useRef(modelPath);
   const statusRef = useRef<CodeIntelligenceStatus | null>(null);
+  const unsupportedDocumentsRef = useRef(new Set<string>());
   const diagnosticCountRef = useRef<number | undefined>(undefined);
   const diagnosticStaleRef = useRef(false);
   const navigationAbortRef = useRef<AbortController | null>(null);
   const propsRef = useRef({ path, workspaceRoot, sessionId, savedDocument, onNavigate, onStatusChange });
+  const editorStatusChangeRef = useRef(onEditorStatusChange);
+  const locationAppliedRef = useRef(onLocationApplied);
+  const readyChangeRef = useRef(onReadyChange);
   const [mounted, setMounted] = useState(false);
   const [navigationPicker, setNavigationPicker] = useState<NavigationPickerState | null>(null);
+  const editorLanguage = languageForPath(path);
   const saveRef = useRef(onSave);
   const closeRef = useRef(onClose);
   saveRef.current = onSave;
   closeRef.current = onClose;
+  readyChangeRef.current = onReadyChange;
+  editorStatusChangeRef.current = onEditorStatusChange;
+  locationAppliedRef.current = onLocationApplied;
   propsRef.current = { path, workspaceRoot, sessionId, savedDocument, onNavigate, onStatusChange };
+  modelPathRef.current = modelPath;
+
+  const saveCurrentEditorModel = (): void => {
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (!editor || !model || model.isDisposed()) return;
+    saveWorkspaceEditorModel(activeModelPathRef.current, model, editor.saveViewState());
+  };
+
+  const refreshDocumentSymbolProvider = (): void => {
+    documentSymbolDisposableRef.current?.dispose();
+    documentSymbolDisposableRef.current = null;
+    const editor = editorRef.current;
+    const monaco = monacoRef.current;
+    const languageSelector = editor?.getModel()?.getLanguageId();
+    if (!editor || !monaco || !languageSelector) return;
+    documentSymbolDisposableRef.current = monaco.languages.registerDocumentSymbolProvider(languageSelector, {
+      displayName: 'Code Intelligence',
+      provideDocumentSymbols: runDocumentSymbols,
+    });
+  };
+
+  const activateCurrentEditorModel = (): void => {
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (!editor || !model) return;
+    const nextModelPath = modelPathRef.current;
+    const viewState = attachWorkspaceEditorModel(nextModelPath, model);
+    activeModelPathRef.current = nextModelPath;
+    if (viewState) editor.restoreViewState(viewState);
+    refreshDocumentSymbolProvider();
+    readyChangeRef.current?.(true);
+  };
+
+  useLayoutEffect(() => {
+    if (!mounted || activeModelPathRef.current === modelPath) return;
+    readyChangeRef.current?.(false);
+    saveCurrentEditorModel();
+  }, [modelPath, mounted]);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -80,11 +157,18 @@ export function MonacoCodeEditor({
       return;
     }
 
-    const controller = new AbortController();
-    let active = true;
+    const documentKey = codeIntelligenceDocumentKey(path, workspaceRoot, sessionId);
     statusRef.current = null;
     diagnosticCountRef.current = undefined;
     diagnosticStaleRef.current = false;
+    if (unsupportedDocumentsRef.current.has(documentKey)) {
+      monaco.editor.setModelMarkers(model, markerOwner, []);
+      onStatusChange('本地编辑功能可用');
+      return;
+    }
+
+    const controller = new AbortController();
+    let active = true;
     onStatusChange('代码导航连接中');
 
     void (async () => {
@@ -120,8 +204,11 @@ export function MonacoCodeEditor({
         onStatusChange(statusLabel(negotiatedStatus, savedDocument, diagnostics.length, diagnosticStaleRef.current));
       } catch (error) {
         if (!active || controller.signal.aborted) return;
+        if (isUnsupportedCodeIntelligenceLanguageError(error)) {
+          unsupportedDocumentsRef.current.add(documentKey);
+        }
         monaco.editor.setModelMarkers(model, markerOwner, []);
-        onStatusChange(error instanceof Error ? `代码诊断不可用：${error.message}` : '代码诊断不可用');
+        onStatusChange(isUnsupportedCodeIntelligenceError(error) ? '本地编辑功能可用' : '代码诊断暂时不可用');
       }
     })();
 
@@ -138,13 +225,18 @@ export function MonacoCodeEditor({
     editor.setPosition(position);
     editor.revealPositionInCenterIfOutsideViewport(position);
     editor.focus();
+    locationAppliedRef.current?.();
   }, [location]);
 
   useEffect(
     () => () => {
+      saveCurrentEditorModel();
+      readyChangeRef.current?.(false);
       navigationAbortRef.current?.abort();
-      for (const disposable of actionDisposablesRef.current) disposable.dispose();
-      actionDisposablesRef.current = [];
+      documentSymbolDisposableRef.current?.dispose();
+      documentSymbolDisposableRef.current = null;
+      for (const disposable of editorDisposablesRef.current) disposable.dispose();
+      editorDisposablesRef.current = [];
       const model = editorRef.current?.getModel();
       if (model && monacoRef.current) monacoRef.current.editor.setModelMarkers(model, markerOwner, []);
     },
@@ -155,26 +247,23 @@ export function MonacoCodeEditor({
     setNavigationPicker(null);
   }, [path, sessionId, workspaceRoot]);
 
+  useEffect(() => {
+    if (mounted) refreshDocumentSymbolProvider();
+  }, [editorLanguage, mounted]);
+
   const mount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
     monacoRef.current = monaco;
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => saveRef.current());
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyW, () => closeRef.current());
-    for (const disposable of actionDisposablesRef.current) disposable.dispose();
-    actionDisposablesRef.current = [
+    for (const disposable of editorDisposablesRef.current) disposable.dispose();
+    editorDisposablesRef.current = [
+      observeMonacoEditorStatus(editor, (status) => editorStatusChangeRef.current(status)),
       ...navigationActions(editor, monaco, runNavigation),
-      monaco.languages.registerDocumentSymbolProvider(languageForPath(path), {
-        displayName: 'Code Intelligence',
-        provideDocumentSymbols: runDocumentSymbols,
-      }),
+      editor.onDidChangeModel(activateCurrentEditorModel),
     ];
+    activateCurrentEditorModel();
     setMounted(true);
-    if (location) {
-      const position = { lineNumber: location.line, column: location.column };
-      editor.setPosition(position);
-      editor.revealPositionInCenterIfOutsideViewport(position);
-      editor.focus();
-    }
   };
 
   const runNavigation = async (kind: CodeNavigationKind): Promise<void> => {
@@ -185,10 +274,17 @@ export function MonacoCodeEditor({
     if (!editor || !relativePath || !position) return;
 
     navigationAbortRef.current?.abort();
-    const controller = new AbortController();
-    navigationAbortRef.current = controller;
+    navigationAbortRef.current = null;
     setNavigationPicker(null);
     const label = navigationLabel(kind);
+    const documentKey = codeIntelligenceDocumentKey(current.path, current.workspaceRoot, current.sessionId);
+    if (unsupportedDocumentsRef.current.has(documentKey)) {
+      current.onStatusChange(`此文件类型不支持${label}导航`);
+      return;
+    }
+
+    const controller = new AbortController();
+    navigationAbortRef.current = controller;
     current.onStatusChange(`正在查找${label}`);
     try {
       const status =
@@ -227,7 +323,12 @@ export function MonacoCodeEditor({
       current.onStatusChange(`找到 ${candidates.length} 处${label}，请选择目标${resultSuffix}`);
     } catch (error) {
       if (controller.signal.aborted) return;
-      current.onStatusChange(error instanceof Error ? `${label}导航失败：${error.message}` : `${label}导航失败`);
+      if (isUnsupportedCodeIntelligenceLanguageError(error)) {
+        unsupportedDocumentsRef.current.add(documentKey);
+      }
+      current.onStatusChange(
+        isUnsupportedCodeIntelligenceError(error) ? `此文件类型不支持${label}导航` : `${label}导航暂时不可用`
+      );
     } finally {
       if (navigationAbortRef.current === controller) navigationAbortRef.current = null;
     }
@@ -250,6 +351,39 @@ export function MonacoCodeEditor({
     editorRef.current?.focus();
   };
 
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      const editor = editorRef.current;
+      if (!editor) return false;
+      editor.focus();
+      return true;
+    },
+    navigate: (kind) => {
+      editorRef.current?.focus();
+      void runNavigation(kind);
+    },
+    setLineEnding: (lineEnding) => {
+      const editor = editorRef.current;
+      const model = editor?.getModel();
+      const monaco = monacoRef.current;
+      if (readOnly || !editor || !model || !monaco) return;
+      const sequence =
+        lineEnding === 'CRLF' ? monaco.editor.EndOfLineSequence.CRLF : monaco.editor.EndOfLineSequence.LF;
+      if (model.getEndOfLineSequence() !== sequence) model.pushEOL(sequence);
+      editor.focus();
+    },
+    showOutline: () => {
+      const editor = editorRef.current;
+      const action = editor?.getAction('editor.action.quickOutline');
+      if (!editor || !action) {
+        propsRef.current.onStatusChange('文件符号大纲不可用');
+        return;
+      }
+      editor.focus();
+      void action.run();
+    },
+  }));
+
   const runDocumentSymbols = async (
     model: editor.ITextModel,
     token: CancellationToken
@@ -259,6 +393,9 @@ export function MonacoCodeEditor({
     const current = propsRef.current;
     const relativePath = workspaceCodePath(current.path, current.workspaceRoot);
     if (!editor || !monaco || model !== editor.getModel() || !relativePath) return [];
+
+    const documentKey = codeIntelligenceDocumentKey(current.path, current.workspaceRoot, current.sessionId);
+    if (unsupportedDocumentsRef.current.has(documentKey)) return [];
 
     const controller = new AbortController();
     const cancellation = token.onCancellationRequested(() => controller.abort());
@@ -289,10 +426,11 @@ export function MonacoCodeEditor({
       );
       return result.items.map((symbol) => monacoDocumentSymbol(monaco, symbol));
     } catch (error) {
-      if (!controller.signal.aborted) {
-        current.onStatusChange(
-          error instanceof Error ? `Code Intelligence 大纲不可用：${error.message}` : 'Code Intelligence 大纲不可用'
-        );
+      if (isUnsupportedCodeIntelligenceLanguageError(error)) {
+        unsupportedDocumentsRef.current.add(documentKey);
+      }
+      if (!controller.signal.aborted && !isUnsupportedCodeIntelligenceError(error)) {
+        current.onStatusChange('文件符号暂时不可用');
       }
       return [];
     } finally {
@@ -303,13 +441,15 @@ export function MonacoCodeEditor({
   return (
     <section className='monaco-editor-surface' aria-label={`编辑 ${basename(path)}`}>
       <Editor
-        path={path}
-        language={languageForPath(path)}
+        path={modelPath}
+        language={editorLanguage}
         value={value}
         theme={monacoTheme(dark)}
         beforeMount={configureMonaco as (monaco: Monaco) => void}
         onMount={mount}
         onChange={(nextValue) => onChange(nextValue ?? '')}
+        saveViewState={false}
+        keepCurrentModel
         loading={<span className='monaco-loading'>正在加载编辑器…</span>}
         options={{
           ariaLabel: `编辑 ${basename(path)}`,
@@ -346,7 +486,7 @@ export function MonacoCodeEditor({
       )}
     </section>
   );
-}
+});
 
 function navigationActions(
   editor: editor.IStandaloneCodeEditor,
@@ -498,4 +638,8 @@ function runtimeUnavailableSuffix(status: CodeIntelligenceStatus): string {
 
 function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() || path;
+}
+
+function codeIntelligenceDocumentKey(path: string, workspaceRoot: string, sessionId: string | null): string {
+  return JSON.stringify([workspaceRoot, sessionId, path]);
 }

--- a/apps/web/src/features/workspace/components/monaco-diff-editor.tsx
+++ b/apps/web/src/features/workspace/components/monaco-diff-editor.tsx
@@ -6,15 +6,21 @@ export function MonacoDiffEditor({
   original,
   modified,
   dark,
+  focusOnMount = false,
+  onFocusOnMount,
 }: {
   path: string;
   original: string;
   modified: string;
   dark: boolean;
+  focusOnMount?: boolean;
+  onFocusOnMount?: () => void;
 }) {
   const language = languageForPath(path);
   const mount: DiffOnMount = (editor) => {
+    if (!focusOnMount) return;
     editor.getModifiedEditor().focus();
+    onFocusOnMount?.();
   };
   return (
     <section className='monaco-editor-surface monaco-diff-surface' aria-label={`比较 ${basename(path)}`}>

--- a/apps/web/src/features/workspace/components/monaco-editor-model-store.test.ts
+++ b/apps/web/src/features/workspace/components/monaco-editor-model-store.test.ts
@@ -1,0 +1,107 @@
+import type { editor } from 'monaco-editor';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  attachWorkspaceEditorModel,
+  clearWorkspaceEditorModels,
+  disposeWorkspaceEditorModelsExcept,
+  rebaseWorkspaceEditorModelPath,
+  saveWorkspaceEditorModel,
+  workspaceEditorModelPath,
+} from './monaco-editor-model-store';
+
+describe('workspace Monaco model store', () => {
+  afterEach(() => clearWorkspaceEditorModels());
+
+  it('isolates the same file by task scope while preserving its virtual directory and extension', () => {
+    const taskA = workspaceEditorModelPath('task-a', '/repo/src/app.ts');
+    const taskB = workspaceEditorModelPath('task-b', '/repo/src/app.ts');
+
+    expect(taskA).toBe('a3s-code://workspace/task-a/repo/src/app.ts');
+    expect(taskB).toBe('a3s-code://workspace/task-b/repo/src/app.ts');
+    expect(taskA).not.toBe(taskB);
+    expect(workspaceEditorModelPath('task-a', 'C:\\repo\\src\\app.ts')).toBe(
+      'a3s-code://workspace/task-a/C%3A/repo/src/app.ts'
+    );
+  });
+
+  it('restores a retained view state and disposes only models no longer owned by an open tab', () => {
+    const modelA = fakeModel();
+    const modelB = fakeModel();
+    const stateA = viewState('a');
+    const stateB = viewState('b');
+    const pathA = workspaceEditorModelPath('task-a', '/repo/a.ts');
+    const pathB = workspaceEditorModelPath('task-a', '/repo/b.ts');
+    saveWorkspaceEditorModel(pathA, modelA.value, stateA);
+    saveWorkspaceEditorModel(pathB, modelB.value, stateB);
+
+    expect(attachWorkspaceEditorModel(pathA, modelA.value)).toBe(stateA);
+
+    disposeWorkspaceEditorModelsExcept(new Set([pathA]));
+
+    expect(modelA.dispose).not.toHaveBeenCalled();
+    expect(modelB.dispose).toHaveBeenCalledTimes(1);
+
+    clearWorkspaceEditorModels();
+    expect(modelA.dispose).toHaveBeenCalledTimes(1);
+    expect(modelB.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces a stale model instance without losing the saved view state', () => {
+    const stale = fakeModel();
+    const replacement = fakeModel();
+    const state = viewState('saved');
+    const path = workspaceEditorModelPath('task-a', '/repo/app.ts');
+    saveWorkspaceEditorModel(path, stale.value, state);
+
+    expect(attachWorkspaceEditorModel(path, replacement.value)).toBe(state);
+    expect(stale.dispose).toHaveBeenCalledTimes(1);
+
+    clearWorkspaceEditorModels();
+    expect(replacement.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves model identity across rename without colliding with a reopened old path', () => {
+    const scope = 'task-a';
+    const previousPath = '/repo/src/app.ts';
+    const nextPath = '/repo/lib/app.ts';
+    const modelPath = workspaceEditorModelPath(scope, previousPath);
+    const model = fakeModel();
+    saveWorkspaceEditorModel(modelPath, model.value, viewState('renamed'));
+
+    rebaseWorkspaceEditorModelPath(scope, previousPath, nextPath);
+
+    expect(workspaceEditorModelPath(scope, nextPath)).toBe(modelPath);
+    disposeWorkspaceEditorModelsExcept(new Set([workspaceEditorModelPath(scope, nextPath)]));
+    expect(model.dispose).not.toHaveBeenCalled();
+
+    const reopenedOldPath = workspaceEditorModelPath(scope, previousPath);
+    expect(reopenedOldPath).not.toBe(modelPath);
+    expect(reopenedOldPath).toBe(`${modelPath}?instance=2`);
+
+    disposeWorkspaceEditorModelsExcept(new Set([reopenedOldPath]));
+    expect(model.dispose).toHaveBeenCalledTimes(1);
+    expect(workspaceEditorModelPath(scope, previousPath)).toBe(reopenedOldPath);
+
+    disposeWorkspaceEditorModelsExcept(new Set());
+    expect(workspaceEditorModelPath(scope, previousPath)).toBe(modelPath);
+  });
+});
+
+function fakeModel(): { value: editor.ITextModel; dispose: ReturnType<typeof vi.fn> } {
+  const dispose = vi.fn();
+  let disposed = false;
+  dispose.mockImplementation(() => {
+    disposed = true;
+  });
+  return {
+    value: {
+      dispose,
+      isDisposed: () => disposed,
+    } as unknown as editor.ITextModel,
+    dispose,
+  };
+}
+
+function viewState(id: string): editor.ICodeEditorViewState {
+  return { cursorState: [], viewState: { id } } as unknown as editor.ICodeEditorViewState;
+}

--- a/apps/web/src/features/workspace/components/monaco-editor-model-store.ts
+++ b/apps/web/src/features/workspace/components/monaco-editor-model-store.ts
@@ -1,0 +1,95 @@
+import type { editor } from 'monaco-editor';
+
+interface WorkspaceEditorModelEntry {
+  model: editor.ITextModel;
+  viewState: editor.ICodeEditorViewState | null;
+}
+
+const workspaceEditorModels = new Map<string, WorkspaceEditorModelEntry>();
+const workspaceEditorModelPaths = new Map<string, string>();
+
+// Monaco model URIs are immutable. This idempotent registry keeps one logical
+// document on the same URI after a file-system rename and allocates a fresh URI
+// if the old path is opened again while the renamed document is still alive.
+export function workspaceEditorModelPath(scope: string, path: string): string {
+  const logicalPath = defaultWorkspaceEditorModelPath(scope, path);
+  const existing = workspaceEditorModelPaths.get(logicalPath);
+  if (existing) return existing;
+
+  const assignedPaths = new Set(workspaceEditorModelPaths.values());
+  let modelPath = logicalPath;
+  let instance = 2;
+  while (assignedPaths.has(modelPath) || workspaceEditorModels.has(modelPath)) {
+    modelPath = `${logicalPath}?instance=${instance}`;
+    instance += 1;
+  }
+  workspaceEditorModelPaths.set(logicalPath, modelPath);
+  return modelPath;
+}
+
+export function rebaseWorkspaceEditorModelPath(scope: string, previousPath: string, nextPath: string): void {
+  const previousLogicalPath = defaultWorkspaceEditorModelPath(scope, previousPath);
+  const nextLogicalPath = defaultWorkspaceEditorModelPath(scope, nextPath);
+  if (previousLogicalPath === nextLogicalPath) return;
+  const modelPath = workspaceEditorModelPaths.get(previousLogicalPath) ?? workspaceEditorModelPath(scope, previousPath);
+  workspaceEditorModelPaths.delete(previousLogicalPath);
+  workspaceEditorModelPaths.set(nextLogicalPath, modelPath);
+}
+
+function defaultWorkspaceEditorModelPath(scope: string, path: string): string {
+  const normalizedScope = encodeURIComponent(scope.trim() || 'workspace');
+  const normalizedPath = path
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join('/');
+  return `a3s-code://workspace/${normalizedScope}/${normalizedPath || 'untitled'}`;
+}
+
+export function attachWorkspaceEditorModel(
+  modelPath: string,
+  model: editor.ITextModel
+): editor.ICodeEditorViewState | null {
+  const retained = workspaceEditorModels.get(modelPath);
+  if (!retained) {
+    workspaceEditorModels.set(modelPath, { model, viewState: null });
+    return null;
+  }
+  if (retained.model !== model) {
+    disposeModel(retained.model);
+    retained.model = model;
+  }
+  return retained.viewState;
+}
+
+export function saveWorkspaceEditorModel(
+  modelPath: string,
+  model: editor.ITextModel,
+  viewState: editor.ICodeEditorViewState | null
+): void {
+  const retained = workspaceEditorModels.get(modelPath);
+  if (retained && retained.model !== model) disposeModel(retained.model);
+  workspaceEditorModels.set(modelPath, { model, viewState });
+}
+
+export function disposeWorkspaceEditorModelsExcept(retainedModelPaths: ReadonlySet<string>): void {
+  for (const [modelPath, retained] of workspaceEditorModels) {
+    if (retainedModelPaths.has(modelPath)) continue;
+    disposeModel(retained.model);
+    workspaceEditorModels.delete(modelPath);
+  }
+  for (const [logicalPath, modelPath] of workspaceEditorModelPaths) {
+    if (!retainedModelPaths.has(modelPath)) workspaceEditorModelPaths.delete(logicalPath);
+  }
+}
+
+export function clearWorkspaceEditorModels(): void {
+  disposeWorkspaceEditorModelsExcept(new Set());
+  workspaceEditorModelPaths.clear();
+}
+
+function disposeModel(model: editor.ITextModel): void {
+  if (!model.isDisposed()) model.dispose();
+}

--- a/apps/web/src/features/workspace/components/monaco-editor-status.test.ts
+++ b/apps/web/src/features/workspace/components/monaco-editor-status.test.ts
@@ -1,0 +1,74 @@
+import type { editor, IDisposable } from 'monaco-editor';
+import { describe, expect, it, vi } from 'vitest';
+import { observeMonacoEditorStatus } from './monaco-editor-status';
+
+describe('Monaco editor status', () => {
+  it('reports cursor, model-native selection lengths, multiple cursors, and the line ending', () => {
+    let position = { lineNumber: 1, column: 1 };
+    let selections = [selection('')];
+    let eol = '\n';
+    const cursorListeners: Array<() => void> = [];
+    const contentListeners: Array<() => void> = [];
+    const modelListeners: Array<() => void> = [];
+    const dispose = vi.fn();
+    const source = {
+      getModel: () => ({
+        getEOL: () => eol,
+        getValueLengthInRange: (range: { selectedText: string }) => range.selectedText.length,
+      }),
+      getPosition: () => position,
+      getSelections: () => selections,
+      onDidChangeCursorSelection: (listener: () => void) => registration(cursorListeners, listener, dispose),
+      onDidChangeModelContent: (listener: () => void) => registration(contentListeners, listener, dispose),
+      onDidChangeModel: (listener: () => void) => registration(modelListeners, listener, dispose),
+    } as unknown as editor.IStandaloneCodeEditor;
+    const onChange = vi.fn();
+
+    const subscription = observeMonacoEditorStatus(source, onChange);
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      lineNumber: 1,
+      column: 1,
+      selectedCharacters: 0,
+      selectionCount: 1,
+      lineEnding: 'LF',
+    });
+
+    position = { lineNumber: 3, column: 7 };
+    selections = [selection('A😀'), selection('two')];
+    cursorListeners[0]();
+    expect(onChange).toHaveBeenLastCalledWith({
+      lineNumber: 3,
+      column: 7,
+      selectedCharacters: 6,
+      selectionCount: 2,
+      lineEnding: 'LF',
+    });
+
+    eol = '\r\n';
+    contentListeners[0]();
+    expect(onChange).toHaveBeenLastCalledWith({
+      lineNumber: 3,
+      column: 7,
+      selectedCharacters: 6,
+      selectionCount: 2,
+      lineEnding: 'CRLF',
+    });
+
+    const callCount = onChange.mock.calls.length;
+    modelListeners[0]();
+    expect(onChange).toHaveBeenCalledTimes(callCount);
+
+    subscription.dispose();
+    expect(dispose).toHaveBeenCalledTimes(3);
+  });
+});
+
+function selection(selectedText: string): { selectedText: string; isEmpty: () => boolean } {
+  return { selectedText, isEmpty: () => selectedText.length === 0 };
+}
+
+function registration(listeners: Array<() => void>, listener: () => void, dispose: () => void): IDisposable {
+  listeners.push(listener);
+  return { dispose };
+}

--- a/apps/web/src/features/workspace/components/monaco-editor-status.ts
+++ b/apps/web/src/features/workspace/components/monaco-editor-status.ts
@@ -1,0 +1,59 @@
+import type { editor, IDisposable } from 'monaco-editor';
+
+export type MonacoLineEnding = 'LF' | 'CRLF';
+
+export interface MonacoEditorStatus {
+  lineNumber: number;
+  column: number;
+  selectedCharacters: number;
+  selectionCount: number;
+  lineEnding: MonacoLineEnding;
+}
+
+export function observeMonacoEditorStatus(
+  source: editor.IStandaloneCodeEditor,
+  onChange: (status: MonacoEditorStatus | null) => void
+): IDisposable {
+  let previous: string | null = null;
+  let disposed = false;
+  const publish = () => {
+    const status = readMonacoEditorStatus(source);
+    const next = status ? JSON.stringify(status) : '';
+    if (next === previous) return;
+    previous = next;
+    onChange(status);
+  };
+  const subscriptions = [
+    source.onDidChangeCursorSelection(publish),
+    source.onDidChangeModelContent(publish),
+    source.onDidChangeModel(publish),
+  ];
+  publish();
+
+  return {
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      for (const subscription of subscriptions) subscription.dispose();
+    },
+  };
+}
+
+function readMonacoEditorStatus(source: editor.IStandaloneCodeEditor): MonacoEditorStatus | null {
+  const model = source.getModel();
+  const position = source.getPosition();
+  if (!model || !position) return null;
+  const selections = source.getSelections();
+  const selectedCharacters = (selections ?? []).reduce(
+    (total, selection) => total + model.getValueLengthInRange(selection),
+    0
+  );
+
+  return {
+    lineNumber: position.lineNumber,
+    column: position.column,
+    selectedCharacters,
+    selectionCount: selections?.length || 1,
+    lineEnding: model.getEOL() === '\r\n' ? 'CRLF' : 'LF',
+  };
+}

--- a/apps/web/src/features/workspace/components/monaco-environment.test.ts
+++ b/apps/web/src/features/workspace/components/monaco-environment.test.ts
@@ -1,0 +1,57 @@
+import * as monaco from 'monaco-editor';
+import { describe, expect, it } from 'vitest';
+import { configureMonaco, languageForPath } from './monaco-environment';
+
+describe('Monaco environment', () => {
+  it('keeps native document symbols as the single outline source', () => {
+    configureMonaco(monaco);
+
+    expect(monaco.typescript.typescriptDefaults.setModeConfiguration).toHaveBeenCalledWith({
+      documentSymbols: false,
+      definitions: true,
+      references: true,
+    });
+    expect(monaco.typescript.javascriptDefaults.setModeConfiguration).toHaveBeenCalledWith({
+      documentSymbols: false,
+      definitions: true,
+      references: true,
+    });
+  });
+
+  it.each([
+    ['config.acl', 'a3s-acl'],
+    ['main.hcl', 'a3s-acl'],
+    ['script.sh', 'shell'],
+    ['script.bash', 'shell'],
+    ['native.c', 'c'],
+    ['native.h', 'c'],
+    ['native.cc', 'cpp'],
+    ['native.cpp', 'cpp'],
+    ['next.config.mjs', 'javascript'],
+    ['tool.cjs', 'javascript'],
+    ['component.jsx', 'javascript'],
+    ['module.mts', 'typescript'],
+    ['module.cts', 'typescript'],
+    ['component.tsx', 'typescript'],
+    ['styles.css', 'css'],
+    ['main.go', 'go'],
+    ['index.html', 'html'],
+    ['package.json', 'json'],
+    ['README.md', 'markdown'],
+    ['guide.mdx', 'markdown'],
+    ['worker.py', 'python'],
+    ['lib.rs', 'rust'],
+    ['query.sql', 'sql'],
+    ['settings.toml', 'ini'],
+    ['layout.xml', 'xml'],
+    ['workflow.yaml', 'yaml'],
+    ['workflow.yml', 'yaml'],
+  ])('maps %s to %s', (path, language) => {
+    expect(languageForPath(`/repo/${path}`)).toBe(language);
+  });
+
+  it('leaves unsupported and extensionless files in plain text mode', () => {
+    expect(languageForPath('/repo/image.png')).toBeUndefined();
+    expect(languageForPath('/repo/Makefile')).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/workspace/components/monaco-environment.ts
+++ b/apps/web/src/features/workspace/components/monaco-environment.ts
@@ -1,5 +1,6 @@
 import { loader } from '@monaco-editor/react';
-import * as monaco from 'monaco-editor';
+import type * as MonacoNamespace from 'monaco-editor';
+import { monaco } from './monaco-runtime';
 
 type MonacoGlobal = typeof globalThis & {
   MonacoEnvironment?: {
@@ -43,9 +44,13 @@ loader.config({ monaco });
 
 let configured = false;
 
-export function configureMonaco(instance: typeof monaco): void {
+export function configureMonaco(instance: typeof MonacoNamespace): void {
   if (configured) return;
   configured = true;
+
+  for (const defaults of [instance.typescript.typescriptDefaults, instance.typescript.javascriptDefaults]) {
+    defaults.setModeConfiguration({ ...defaults.modeConfiguration, documentSymbols: false });
+  }
 
   instance.editor.defineTheme('a3s-light', {
     base: 'vs',
@@ -122,8 +127,10 @@ export function languageForPath(path: string): string | undefined {
     bash: 'shell',
     c: 'c',
     cc: 'cpp',
+    cjs: 'javascript',
     cpp: 'cpp',
     css: 'css',
+    cts: 'typescript',
     go: 'go',
     h: 'c',
     hcl: 'a3s-acl',
@@ -133,6 +140,8 @@ export function languageForPath(path: string): string | undefined {
     jsx: 'javascript',
     md: 'markdown',
     mdx: 'markdown',
+    mjs: 'javascript',
+    mts: 'typescript',
     py: 'python',
     rs: 'rust',
     sh: 'shell',

--- a/apps/web/src/features/workspace/components/monaco-runtime.test.ts
+++ b/apps/web/src/features/workspace/components/monaco-runtime.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const expectedBasicLanguages = [
+  'cpp',
+  'css',
+  'go',
+  'html',
+  'ini',
+  'javascript',
+  'markdown',
+  'python',
+  'rust',
+  'shell',
+  'sql',
+  'typescript',
+  'xml',
+  'yaml',
+].sort();
+
+const expectedLanguageServices = ['css', 'html', 'json', 'typescript'].sort();
+
+describe('Monaco runtime import graph', () => {
+  it('starts from the editor API without importing the broad package entry', () => {
+    const source = runtimeSource();
+
+    expect(source).toContain('monaco-editor/esm/vs/editor/editor.api.js');
+    expect(source).toContain('monaco-editor/esm/vs/editor/edcore.main.js');
+    expect(source).not.toMatch(/^import\s+(?!type\b).*from\s+['"]monaco-editor['"];?$/m);
+    expect(source).not.toContain('monaco-editor/esm/vs/editor/editor.main.js');
+    expect(source).not.toContain('monaco-lsp-client');
+  });
+
+  it('loads only the language services and tokenizers supported by the editor', () => {
+    const source = runtimeSource();
+    const basicLanguages = [...source.matchAll(/monaco-editor\/esm\/vs\/basic-languages\/([^/'"]+)\//g)]
+      .map((match) => match[1])
+      .sort();
+    const languageServices = [...source.matchAll(/monaco-editor\/esm\/vs\/language\/([^/'"]+)\//g)]
+      .map((match) => match[1])
+      .sort();
+
+    expect(basicLanguages).toEqual(expectedBasicLanguages);
+    expect(languageServices).toEqual(expectedLanguageServices);
+  });
+});
+
+function runtimeSource(): string {
+  return readFileSync(resolve(process.cwd(), 'src/features/workspace/components/monaco-runtime.ts'), 'utf8');
+}

--- a/apps/web/src/features/workspace/components/monaco-runtime.ts
+++ b/apps/web/src/features/workspace/components/monaco-runtime.ts
@@ -1,0 +1,35 @@
+import type * as MonacoNamespace from 'monaco-editor';
+import * as editorApi from 'monaco-editor/esm/vs/editor/editor.api.js';
+import * as css from 'monaco-editor/esm/vs/language/css/monaco.contribution.js';
+import * as html from 'monaco-editor/esm/vs/language/html/monaco.contribution.js';
+import * as json from 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
+import * as typescript from 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
+import 'monaco-editor/esm/vs/editor/edcore.main.js';
+import 'monaco-editor/esm/vs/basic-languages/cpp/cpp.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/css/css.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/go/go.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/html/html.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/ini/ini.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/python/python.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/rust/rust.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/shell/shell.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/xml/xml.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
+
+// Keep the complete standalone editor and diff surface, but expose only the
+// language services used by the product. Monaco's package root also exports
+// every bundled tokenizer and an unused LSP client.
+const languages = Object.assign(editorApi.languages, { css, html, json, typescript });
+
+export const monaco = {
+  ...editorApi,
+  css,
+  html,
+  json,
+  languages,
+  typescript,
+} as typeof MonacoNamespace;

--- a/apps/web/src/features/workspace/components/use-workspace-explorer-tree.ts
+++ b/apps/web/src/features/workspace/components/use-workspace-explorer-tree.ts
@@ -1,0 +1,155 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type { WorkspaceEntry } from '../../../types/api';
+
+export interface ExplorerTreeItem {
+  entry: Readonly<WorkspaceEntry>;
+  parentPath: string;
+  displayExpanded: boolean;
+  index: number;
+}
+
+export interface ExplorerTreeProjection {
+  items: ExplorerTreeItem[];
+  itemByPath: Map<string, ExplorerTreeItem>;
+  visiblePaths: Set<string>;
+  displayExpandedPaths: Set<string>;
+  normalizedQuery: string;
+}
+
+export function useWorkspaceExplorerTree({
+  root,
+  filesByDirectory,
+  expandedDirectories,
+  query,
+  activePath,
+  toggleDirectory,
+}: {
+  root: string;
+  filesByDirectory: Readonly<Record<string, readonly Readonly<WorkspaceEntry>[]>>;
+  expandedDirectories: Readonly<Record<string, boolean>>;
+  query: string;
+  activePath: string | null;
+  toggleDirectory: (path: string) => Promise<void>;
+}) {
+  const [focusedPath, setFocusedPath] = useState<string | null>(null);
+  const itemRefs = useRef(new Map<string, HTMLButtonElement>());
+  const tree = useMemo(
+    () => projectExplorerTree(root, filesByDirectory, expandedDirectories, query),
+    [root, filesByDirectory, expandedDirectories, query]
+  );
+  const rovingPath =
+    (focusedPath && tree.itemByPath.has(focusedPath) ? focusedPath : null) ??
+    (activePath && tree.itemByPath.has(activePath) ? activePath : null) ??
+    tree.items[0]?.entry.path ??
+    null;
+  const registerItem = useCallback((path: string, element: HTMLButtonElement | null) => {
+    if (element) itemRefs.current.set(path, element);
+    else itemRefs.current.delete(path);
+  }, []);
+  const focusItem = useCallback((path: string) => {
+    setFocusedPath(path);
+    const target = itemRefs.current.get(path);
+    if (!target) return;
+    target.focus({ preventScroll: true });
+    target.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+  }, []);
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || !(event.target instanceof Element)) return;
+      const row = event.target.closest<HTMLButtonElement>('button[data-explorer-path]');
+      if (!row || !event.currentTarget.contains(row)) return;
+      const path = row.dataset.explorerPath;
+      const item = path ? tree.itemByPath.get(path) : undefined;
+      if (!path || !item) return;
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Home' || event.key === 'End') {
+        event.preventDefault();
+        const targetIndex =
+          event.key === 'Home'
+            ? 0
+            : event.key === 'End'
+              ? tree.items.length - 1
+              : event.key === 'ArrowDown'
+                ? Math.min(item.index + 1, tree.items.length - 1)
+                : Math.max(item.index - 1, 0);
+        const target = tree.items[targetIndex];
+        if (target) focusItem(target.entry.path);
+        return;
+      }
+
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        if (!item.entry.isDirectory) return;
+        if (!item.displayExpanded) {
+          void toggleDirectory(path);
+          return;
+        }
+        const firstChild = tree.items[item.index + 1];
+        if (firstChild?.parentPath === path) focusItem(firstChild.entry.path);
+        return;
+      }
+
+      if (event.key !== 'ArrowLeft') return;
+      event.preventDefault();
+      if (item.entry.isDirectory && item.displayExpanded && !tree.normalizedQuery) {
+        void toggleDirectory(path);
+        return;
+      }
+      if (tree.itemByPath.has(item.parentPath)) focusItem(item.parentPath);
+    },
+    [focusItem, toggleDirectory, tree]
+  );
+
+  return { tree, rovingPath, setFocusedPath, registerItem, focusItem, handleKeyDown };
+}
+
+function projectExplorerTree(
+  root: string,
+  filesByDirectory: Readonly<Record<string, readonly Readonly<WorkspaceEntry>[]>>,
+  expandedDirectories: Readonly<Record<string, boolean>>,
+  query: string
+): ExplorerTreeProjection {
+  const normalizedQuery = query.trim().toLowerCase();
+  const items: ExplorerTreeItem[] = [];
+  const itemByPath = new Map<string, ExplorerTreeItem>();
+  const visiblePaths = new Set<string>();
+  const displayExpandedPaths = new Set<string>();
+  const matchCache = new Map<string, boolean>();
+  const matchingStack = new Set<string>();
+
+  const hasLoadedMatch = (directory: string): boolean => {
+    const cached = matchCache.get(directory);
+    if (cached !== undefined) return cached;
+    if (matchingStack.has(directory)) return false;
+    matchingStack.add(directory);
+    const matches = (filesByDirectory[directory] ?? []).some(
+      (entry) => entry.name.toLowerCase().includes(normalizedQuery) || (entry.isDirectory && hasLoadedMatch(entry.path))
+    );
+    matchingStack.delete(directory);
+    matchCache.set(directory, matches);
+    return matches;
+  };
+
+  const projectedDirectories = new Set<string>();
+  const visit = (directory: string) => {
+    if (projectedDirectories.has(directory)) return;
+    projectedDirectories.add(directory);
+    for (const entry of filesByDirectory[directory] ?? []) {
+      const matchingDescendant = Boolean(normalizedQuery && entry.isDirectory && hasLoadedMatch(entry.path));
+      const visible = !normalizedQuery || entry.name.toLowerCase().includes(normalizedQuery) || matchingDescendant;
+      if (!visible || itemByPath.has(entry.path)) continue;
+      const displayExpanded = Boolean(expandedDirectories[entry.path]) || matchingDescendant;
+      const item = { entry, parentPath: directory, displayExpanded, index: items.length };
+      items.push(item);
+      itemByPath.set(entry.path, item);
+      visiblePaths.add(entry.path);
+      if (!entry.isDirectory || !displayExpanded) continue;
+      displayExpandedPaths.add(entry.path);
+      visit(entry.path);
+    }
+  };
+
+  visit(root);
+  return { items, itemByPath, visiblePaths, displayExpandedPaths, normalizedQuery };
+}

--- a/apps/web/src/features/workspace/components/workspace-context-menu.tsx
+++ b/apps/web/src/features/workspace/components/workspace-context-menu.tsx
@@ -1,15 +1,49 @@
 import type { ReactNode } from 'react';
-import { createPortal } from 'react-dom';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 export interface WorkspaceContextMenuItem {
   id: string;
   label: string;
+  ariaLabel?: string;
   icon: ReactNode;
   onSelect(): void;
+  shortcut?: string;
+  checked?: boolean;
   danger?: boolean;
   disabled?: boolean;
   separatorBefore?: boolean;
+}
+
+function WorkspaceContextMenuButton({ item, onSelect }: { item: WorkspaceContextMenuItem; onSelect(): void }) {
+  const content = (
+    <>
+      {item.icon}
+      <span>{item.label}</span>
+      {item.shortcut && <kbd>{item.shortcut}</kbd>}
+    </>
+  );
+  const props = {
+    type: 'button' as const,
+    'aria-label': item.ariaLabel,
+    className: item.danger ? 'danger' : undefined,
+    disabled: item.disabled,
+    onClick: onSelect,
+  };
+
+  if (item.checked !== undefined) {
+    return (
+      <button {...props} role='menuitemradio' aria-checked={item.checked}>
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <button {...props} role='menuitem'>
+      {content}
+    </button>
+  );
 }
 
 export function WorkspaceContextMenu({
@@ -95,19 +129,13 @@ export function WorkspaceContextMenu({
       {items.map((item) => (
         <div className='workspace-context-menu-item' key={item.id}>
           {item.separatorBefore && <hr />}
-          <button
-            type='button'
-            role='menuitem'
-            className={item.danger ? 'danger' : undefined}
-            disabled={item.disabled}
-            onClick={() => {
+          <WorkspaceContextMenuButton
+            item={item}
+            onSelect={() => {
               onClose();
               item.onSelect();
             }}
-          >
-            {item.icon}
-            <span>{item.label}</span>
-          </button>
+          />
         </div>
       ))}
     </div>,

--- a/apps/web/src/features/workspace/components/workspace-editor-keyboard.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-editor-keyboard.test.tsx
@@ -1,0 +1,287 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { codeApi } from '../../../lib/api';
+import { appState } from '../../../state/app-state';
+import type { WorkspaceActions } from '../workspace-actions';
+import {
+  diffEditorTabId,
+  fileEditorTabId,
+  type WorkspaceDiffEditorTab,
+  type WorkspaceFileEditorTab,
+} from '../workspace-state';
+import { WorkspaceEditor } from './workspace-editor';
+
+describe('Workspace editor keyboard scope', () => {
+  beforeEach(() => {
+    appState.workspaceRoot = '/repo';
+    appState.reviewIntent = 'review';
+    appState.reviewSourceTaskId = null;
+    appState.editorTabs = [fileTab('/repo/first.ts'), fileTab('/repo/second.ts')];
+    appState.activeEditorTabId = fileEditorTabId('/repo/first.ts');
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue({
+      state: 'ready',
+      capabilities: {
+        documentSymbols: true,
+        workspaceSymbols: true,
+        definition: true,
+        declaration: true,
+        references: true,
+        implementations: true,
+        diagnostics: true,
+      },
+      languages: [],
+      message: null,
+    });
+    vi.spyOn(codeApi, 'codeDiagnostics').mockResolvedValue({
+      items: [],
+      truncated: false,
+      workspaceRevision: 1,
+      document: { revision: 1, contentHash: 'hash', stale: false },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    vi.restoreAllMocks();
+  });
+
+  it('does not consume editor shortcuts while focus is outside the workspace editor', () => {
+    const actions = keyboardActions();
+    render(
+      <>
+        <textarea aria-label='任务指令' />
+        <WorkspaceEditor actions={actions.value} />
+      </>
+    );
+    const taskInput = screen.getByRole('textbox', { name: '任务指令' });
+    taskInput.focus();
+
+    expect(fireEvent.keyDown(taskInput, { key: 's', ctrlKey: true })).toBe(true);
+    expect(fireEvent.keyDown(taskInput, { key: 'w', ctrlKey: true })).toBe(true);
+    expect(fireEvent.keyDown(taskInput, { key: 'Tab', ctrlKey: true })).toBe(true);
+    expect(fireEvent.keyDown(taskInput, { key: '-', code: 'Minus', ctrlKey: true })).toBe(true);
+    expect(fireEvent.keyDown(taskInput, { key: '_', code: 'Minus', ctrlKey: true, shiftKey: true })).toBe(true);
+
+    expect(actions.save).not.toHaveBeenCalled();
+    expect(actions.close).not.toHaveBeenCalled();
+    expect(actions.activate).not.toHaveBeenCalled();
+    expect(actions.back).not.toHaveBeenCalled();
+    expect(actions.forward).not.toHaveBeenCalled();
+  });
+
+  it('retains save, close, tab switching, and location history shortcuts inside the workspace editor', async () => {
+    const actions = keyboardActions();
+    render(<WorkspaceEditor actions={actions.value} />);
+    const editor = await screen.findByRole('textbox', { name: '编辑 first.ts' });
+    editor.focus();
+
+    expect(fireEvent.keyDown(editor, { key: 's', ctrlKey: true })).toBe(false);
+    expect(fireEvent.keyDown(editor, { key: 'w', ctrlKey: true })).toBe(false);
+    expect(fireEvent.keyDown(editor, { key: 'Tab', ctrlKey: true })).toBe(false);
+    expect(fireEvent.keyDown(editor, { key: '-', code: 'Minus', ctrlKey: true })).toBe(false);
+    expect(fireEvent.keyDown(editor, { key: '_', code: 'Minus', ctrlKey: true, shiftKey: true })).toBe(false);
+
+    expect(actions.save).toHaveBeenCalledWith(fileEditorTabId('/repo/first.ts'));
+    expect(actions.close).toHaveBeenCalledWith(fileEditorTabId('/repo/first.ts'));
+    expect(actions.activate).toHaveBeenCalledWith(fileEditorTabId('/repo/second.ts'));
+    expect(actions.back).toHaveBeenCalledTimes(1);
+    expect(actions.forward).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: '返回上一个编辑位置' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: '前往下一个编辑位置' })).toBeEnabled();
+  });
+
+  it('keeps Monaco focus in the next editor after Ctrl+Tab starts in the document', async () => {
+    const actions = keyboardActions({ activateTab: true });
+    render(<WorkspaceEditor actions={actions.value} />);
+    const firstEditor = await screen.findByRole('textbox', { name: '编辑 first.ts' });
+    firstEditor.focus();
+
+    fireEvent.keyDown(firstEditor, { key: 'Tab', ctrlKey: true });
+
+    const secondEditor = await screen.findByRole('textbox', { name: '编辑 second.ts' });
+    await waitFor(() => expect(secondEditor).toHaveFocus());
+    expect(appState.activeEditorTabId).toBe(fileEditorTabId('/repo/second.ts'));
+  });
+
+  it('keeps Monaco focus when Ctrl+Shift+Tab wraps to the final editor', async () => {
+    appState.editorTabs = [fileTab('/repo/first.ts'), fileTab('/repo/second.ts'), fileTab('/repo/third.ts')];
+    const actions = keyboardActions({ activateTab: true });
+    render(<WorkspaceEditor actions={actions.value} />);
+    const firstEditor = await screen.findByRole('textbox', { name: '编辑 first.ts' });
+    firstEditor.focus();
+
+    fireEvent.keyDown(firstEditor, { key: 'Tab', ctrlKey: true, shiftKey: true });
+
+    const thirdEditor = await screen.findByRole('textbox', { name: '编辑 third.ts' });
+    await waitFor(() => expect(thirdEditor).toHaveFocus());
+    expect(appState.activeEditorTabId).toBe(fileEditorTabId('/repo/third.ts'));
+  });
+
+  it('moves focus into the modified diff editor when Ctrl+Tab starts in Monaco', async () => {
+    appState.editorTabs = [fileTab('/repo/first.ts'), diffTab('/repo/second.ts')];
+    const actions = keyboardActions({ activateTab: true });
+    render(<WorkspaceEditor actions={actions.value} />);
+    const firstEditor = await screen.findByRole('textbox', { name: '编辑 first.ts' });
+    firstEditor.focus();
+
+    fireEvent.keyDown(firstEditor, { key: 'Tab', ctrlKey: true });
+
+    const diffEditor = await screen.findByTestId('monaco-diff-editor');
+    await waitFor(() => expect(diffEditor).toHaveFocus());
+    expect(appState.activeEditorTabId).toBe(diffEditorTabId('/repo/second.ts', false));
+  });
+
+  it('does not move focus into Monaco when Ctrl+Tab starts from a connected workspace control', async () => {
+    const actions = keyboardActions({ activateTab: true });
+    render(<WorkspaceEditor actions={actions.value} />);
+    const backButton = screen.getByRole('button', { name: '返回上一个编辑位置' });
+    backButton.focus();
+
+    fireEvent.keyDown(backButton, { key: 'Tab', ctrlKey: true });
+
+    await screen.findByRole('textbox', { name: '编辑 second.ts' });
+    expect(appState.activeEditorTabId).toBe(fileEditorTabId('/repo/second.ts'));
+    expect(backButton).toHaveFocus();
+  });
+
+  it('does not let a newly mounted diff editor steal focus from a workspace control', async () => {
+    appState.editorTabs = [fileTab('/repo/first.ts'), diffTab('/repo/second.ts')];
+    const actions = keyboardActions({ activateTab: true });
+    render(<WorkspaceEditor actions={actions.value} />);
+    const backButton = screen.getByRole('button', { name: '返回上一个编辑位置' });
+    backButton.focus();
+
+    fireEvent.keyDown(backButton, { key: 'Tab', ctrlKey: true });
+
+    const diffEditor = await screen.findByTestId('monaco-diff-editor');
+    expect(appState.activeEditorTabId).toBe(diffEditorTabId('/repo/second.ts', false));
+    expect(diffEditor).not.toHaveFocus();
+    expect(screen.getByRole('tab', { name: 'second.ts（工作树）' })).toHaveFocus();
+  });
+
+  it('keeps editing focus in the successor document when a keyboard close removes the active editor', async () => {
+    const actions = keyboardActions({ removeClosedTab: true });
+    render(<WorkspaceEditor actions={actions.value} />);
+    const editor = await screen.findByRole('textbox', { name: '编辑 first.ts' });
+    editor.focus();
+
+    fireEvent.keyDown(editor, { key: 'w', ctrlKey: true });
+
+    await waitFor(() => expect(screen.getByRole('textbox', { name: '编辑 second.ts' })).toHaveFocus());
+    expect(appState.activeEditorTabId).toBe(fileEditorTabId('/repo/second.ts'));
+  });
+
+  it('moves focus to Quick Open when keyboard close removes the final tab', async () => {
+    appState.editorTabs = [fileTab('/repo/first.ts')];
+    appState.activeEditorTabId = fileEditorTabId('/repo/first.ts');
+    const actions = keyboardActions({ removeClosedTab: true });
+    render(<WorkspaceEditor actions={actions.value} />);
+    const editor = await screen.findByRole('textbox', { name: '编辑 first.ts' });
+    editor.focus();
+
+    fireEvent.keyDown(editor, { key: 'w', ctrlKey: true });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /快速打开/ })).toHaveFocus());
+    expect(appState.activeEditorTabId).toBeNull();
+  });
+
+  it('does not steal focus from a connected control when a tab closes elsewhere', async () => {
+    const actions = keyboardActions({ removeClosedTab: true });
+    render(
+      <>
+        <button type='button'>Explorer action</button>
+        <WorkspaceEditor actions={actions.value} />
+      </>
+    );
+    const explorerAction = screen.getByRole('button', { name: 'Explorer action' });
+    explorerAction.focus();
+
+    act(() => actions.value.closeEditorTab(fileEditorTabId('/repo/first.ts')));
+
+    await waitFor(() => expect(appState.activeEditorTabId).toBe(fileEditorTabId('/repo/second.ts')));
+    expect(explorerAction).toHaveFocus();
+  });
+});
+
+function fileTab(path: string): WorkspaceFileEditorTab {
+  return {
+    id: fileEditorTabId(path),
+    kind: 'file',
+    path,
+    content: 'export const value = 1;\n',
+    draft: 'export const value = 1;\n',
+    revision: null,
+    isBinary: false,
+    location: null,
+    loading: false,
+    loadError: null,
+    saving: false,
+    configValidation: null,
+  };
+}
+
+function diffTab(path: string): WorkspaceDiffEditorTab {
+  return {
+    id: diffEditorTabId(path, false),
+    kind: 'diff',
+    path,
+    staged: false,
+    original: 'export const value = 1;\n',
+    modified: 'export const value = 2;\n',
+    unified: '@@ -1 +1 @@\n',
+    isBinary: false,
+    loading: false,
+    loadError: null,
+  };
+}
+
+function keyboardActions({
+  removeClosedTab = false,
+  activateTab = false,
+}: {
+  removeClosedTab?: boolean;
+  activateTab?: boolean;
+} = {}): {
+  value: WorkspaceActions;
+  save: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  activate: ReturnType<typeof vi.fn>;
+  back: ReturnType<typeof vi.fn>;
+  forward: ReturnType<typeof vi.fn>;
+} {
+  const save = vi.fn(async () => true);
+  const close = vi.fn((tabId: string) => {
+    if (!removeClosedTab) return;
+    const previousTabs = [...appState.editorTabs];
+    const index = previousTabs.findIndex((tab) => tab.id === tabId);
+    const nextActive = previousTabs[index + 1] ?? previousTabs[index - 1] ?? null;
+    appState.editorTabs = previousTabs.filter((tab) => tab.id !== tabId);
+    appState.activeEditorTabId = nextActive?.id ?? null;
+  });
+  const activate = vi.fn((tabId: string) => {
+    if (activateTab) appState.activeEditorTabId = tabId;
+  });
+  const back = vi.fn(async () => true);
+  const forward = vi.fn(async () => true);
+  return {
+    value: {
+      canNavigateEditorBack: true,
+      canNavigateEditorForward: true,
+      navigateEditorBack: back,
+      navigateEditorForward: forward,
+      updateEditorPosition: vi.fn(),
+      saveEditorTab: save,
+      closeEditorTab: close,
+      activateEditorTab: activate,
+      selectFile: vi.fn(async () => true),
+      updateEditorDraft: vi.fn(),
+    } as unknown as WorkspaceActions,
+    save,
+    close,
+    activate,
+    back,
+    forward,
+  };
+}

--- a/apps/web/src/features/workspace/components/workspace-editor-status.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-editor-status.test.tsx
@@ -1,0 +1,159 @@
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import * as monaco from 'monaco-editor';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { codeApi } from '../../../lib/api';
+import { appState } from '../../../state/app-state';
+import type { WorkspaceActions } from '../workspace-actions';
+import { fileEditorTabId, type WorkspaceFileEditorTab } from '../workspace-state';
+import { rebaseWorkspaceEditorModelPath } from './monaco-editor-model-store';
+import { WorkspaceEditor } from './workspace-editor';
+
+const testMonaco = monaco as unknown as {
+  __cursorSelectionListeners: Array<() => void>;
+  __position: { lineNumber: number; column: number };
+  __selections: Array<{ selectedText: string; isEmpty: () => boolean }>;
+};
+
+describe('Workspace editor status bar', () => {
+  beforeEach(() => {
+    appState.workspaceRoot = '/repo';
+    appState.reviewIntent = 'review';
+    testMonaco.__cursorSelectionListeners.splice(0);
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue({
+      state: 'ready',
+      capabilities: {
+        documentSymbols: true,
+        workspaceSymbols: true,
+        definition: true,
+        declaration: true,
+        references: true,
+        implementations: true,
+        diagnostics: true,
+      },
+      languages: [],
+      message: null,
+    });
+    vi.spyOn(codeApi, 'codeDiagnostics').mockResolvedValue({
+      items: [],
+      truncated: false,
+      workspaceRevision: 1,
+      document: { revision: 1, contentHash: 'hash', stale: false },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    vi.restoreAllMocks();
+  });
+
+  it('shows the live cursor, selection, and actual model line ending', async () => {
+    openFile('/repo/app.ts', 'first\r\nsecond');
+    render(<WorkspaceEditor actions={editorActions()} />);
+
+    expect(await screen.findByText('行 1，列 1')).toBeInTheDocument();
+    expect(screen.getByText('CRLF')).toBeInTheDocument();
+    expect(screen.queryByText('LF')).not.toBeInTheDocument();
+
+    act(() => {
+      testMonaco.__position = { lineNumber: 2, column: 4 };
+      testMonaco.__selections = [
+        { selectedText: 'A😀', isEmpty: () => false },
+        { selectedText: 'two', isEmpty: () => false },
+      ];
+      for (const listener of testMonaco.__cursorSelectionListeners) listener();
+    });
+
+    await waitFor(() => expect(screen.getByText('行 2，列 4')).toBeInTheDocument());
+    expect(screen.getByText('已选择 6 个字符（2 处）')).toBeInTheDocument();
+  });
+
+  it('does not claim text encoding or line endings for a binary file', () => {
+    openFile('/repo/image.png', '', true);
+    render(<WorkspaceEditor actions={editorActions()} />);
+
+    expect(screen.getByText('二进制文件仅供识别')).toBeInTheDocument();
+    expect(screen.queryByText('UTF-8')).not.toBeInTheDocument();
+    expect(screen.queryByText('LF')).not.toBeInTheDocument();
+    expect(screen.queryByText('CRLF')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^行 \d/)).not.toBeInTheDocument();
+  });
+
+  it('changes the model line ending from the status menu and marks the tab dirty', async () => {
+    openFile('/repo/app.ts', 'first\nsecond');
+    render(<WorkspaceEditor actions={editorActions()} />);
+
+    const trigger = await screen.findByRole('button', { name: '换行符 LF' });
+    fireEvent.click(trigger);
+    const menu = screen.getByRole('menu', { name: '选择换行符序列' });
+    expect(within(menu).getByRole('menuitemradio', { name: /^LF，/ })).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(within(menu).getByRole('menuitemradio', { name: /^CRLF，/ }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: '换行符 CRLF' })).toBeInTheDocument());
+    expect(screen.getAllByText('未保存')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: '保存文件' })).toBeEnabled();
+    expect(screen.getByRole('textbox', { name: '编辑 app.ts' })).toHaveFocus();
+  });
+
+  it('keeps line-ending conversion unavailable in read-only context review', async () => {
+    appState.reviewIntent = 'select-context';
+    openFile('/repo/app.ts', 'first\nsecond');
+    render(<WorkspaceEditor actions={editorActions()} />);
+
+    expect(await screen.findByRole('button', { name: '换行符 LF' })).toBeDisabled();
+    expect(screen.queryByRole('menu', { name: '选择换行符序列' })).not.toBeInTheDocument();
+  });
+
+  it('keeps model status and code navigation ready after an open file is renamed', async () => {
+    appState.editorModelScope = 'rename-status-scope';
+    openFile('/repo/app.ts', 'export const value = 1;\n');
+    render(<WorkspaceEditor actions={editorActions()} />);
+
+    expect(await screen.findByText('行 1，列 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '代码导航' })).toBeEnabled();
+
+    act(() => {
+      const tab = appState.editorTabs[0] as WorkspaceFileEditorTab;
+      rebaseWorkspaceEditorModelPath(appState.editorModelScope, tab.path, '/repo/app.rs');
+      tab.path = '/repo/app.rs';
+      tab.id = fileEditorTabId(tab.path);
+      appState.activeEditorTabId = tab.id;
+    });
+
+    expect(await screen.findByRole('textbox', { name: '编辑 app.rs' })).toBeInTheDocument();
+    expect(screen.getByText('行 1，列 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '代码导航' })).toBeEnabled();
+  });
+});
+
+function openFile(path: string, content: string, isBinary = false): void {
+  const tab: WorkspaceFileEditorTab = {
+    id: fileEditorTabId(path),
+    kind: 'file',
+    path,
+    content,
+    draft: content,
+    revision: null,
+    isBinary,
+    location: null,
+    loading: false,
+    loadError: null,
+    saving: false,
+    configValidation: null,
+  };
+  appState.editorTabs = [tab];
+  appState.activeEditorTabId = tab.id;
+}
+
+function editorActions(): WorkspaceActions {
+  return {
+    updateEditorDraft: vi.fn((tabId: string, value: string) => {
+      const tab = appState.editorTabs.find((candidate) => candidate.id === tabId);
+      if (tab?.kind === 'file') tab.draft = value;
+    }),
+    selectFile: vi.fn(async () => true),
+    saveEditorTab: vi.fn(async () => true),
+    closeEditorTab: vi.fn(),
+  } as unknown as WorkspaceActions;
+}

--- a/apps/web/src/features/workspace/components/workspace-editor-tab-label.test.ts
+++ b/apps/web/src/features/workspace/components/workspace-editor-tab-label.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { workspaceEditorTabLabels } from './workspace-editor-tab-label';
+
+describe('workspace editor tab labels', () => {
+  it('keeps unique filenames compact', () => {
+    const labels = workspaceEditorTabLabels(
+      [
+        { id: 'app', kind: 'file', path: '/repo/src/app.ts' },
+        { id: 'readme', kind: 'file', path: '/repo/README.md' },
+      ],
+      '/repo'
+    );
+
+    expect(labels.get('app')).toMatchObject({ name: 'app.ts', detail: null, ariaLabel: 'app.ts' });
+    expect(labels.get('readme')).toMatchObject({ name: 'README.md', detail: null, ariaLabel: 'README.md' });
+  });
+
+  it('uses the shortest unique parent suffix for duplicate filenames', () => {
+    const labels = workspaceEditorTabLabels(
+      [
+        { id: 'acl', kind: 'file', path: '/repo/crates/acl/src/lib.rs' },
+        { id: 'code', kind: 'file', path: '/repo/crates/code/src/lib.rs' },
+        { id: 'root', kind: 'file', path: '/repo/lib.rs' },
+      ],
+      '/repo'
+    );
+
+    expect(labels.get('acl')).toMatchObject({ name: 'lib.rs', detail: 'acl/src', ariaLabel: 'lib.rs，acl/src' });
+    expect(labels.get('code')).toMatchObject({ name: 'lib.rs', detail: 'code/src', ariaLabel: 'lib.rs，code/src' });
+    expect(labels.get('root')).toMatchObject({ name: 'lib.rs', detail: '.', ariaLabel: 'lib.rs，.' });
+  });
+
+  it('distinguishes working and staged diffs without expanding their file labels', () => {
+    const labels = workspaceEditorTabLabels(
+      [
+        { id: 'file', kind: 'file', path: '/repo/src/app.ts' },
+        { id: 'working', kind: 'diff', path: 'src/app.ts', staged: false },
+        { id: 'staged', kind: 'diff', path: 'src/app.ts', staged: true },
+      ],
+      '/repo'
+    );
+
+    expect(labels.get('file')).toMatchObject({ name: 'app.ts', detail: null });
+    expect(labels.get('working')).toMatchObject({ name: 'app.ts（工作树）', detail: null });
+    expect(labels.get('staged')).toMatchObject({ name: 'app.ts（已暂存）', detail: null });
+  });
+
+  it('normalizes Windows paths before comparing parent suffixes', () => {
+    const labels = workspaceEditorTabLabels(
+      [
+        { id: 'client', kind: 'file', path: 'C:\\repo\\client\\src\\index.ts' },
+        { id: 'server', kind: 'file', path: 'C:\\repo\\server\\src\\index.ts' },
+      ],
+      'C:\\repo'
+    );
+
+    expect(labels.get('client')?.detail).toBe('client/src');
+    expect(labels.get('server')?.detail).toBe('server/src');
+  });
+});

--- a/apps/web/src/features/workspace/components/workspace-editor-tab-label.ts
+++ b/apps/web/src/features/workspace/components/workspace-editor-tab-label.ts
@@ -1,0 +1,83 @@
+import type { WorkspaceDiffEditorTab, WorkspaceFileEditorTab } from '../workspace-state';
+import { workspaceRelativePath } from '../workspace-state';
+
+type WorkspaceEditorTabLabelSource =
+  | Readonly<Pick<WorkspaceFileEditorTab, 'id' | 'kind' | 'path'>>
+  | Readonly<Pick<WorkspaceDiffEditorTab, 'id' | 'kind' | 'path' | 'staged'>>;
+
+export interface WorkspaceEditorTabLabel {
+  name: string;
+  detail: string | null;
+  ariaLabel: string;
+  title: string;
+}
+
+interface TabLabelCandidate {
+  tab: WorkspaceEditorTabLabelSource;
+  name: string;
+  relativePath: string;
+  parentSegments: string[];
+}
+
+export function workspaceEditorTabLabels(
+  tabs: readonly WorkspaceEditorTabLabelSource[],
+  workspaceRoot: string
+): ReadonlyMap<string, WorkspaceEditorTabLabel> {
+  const candidates = tabs.map((tab): TabLabelCandidate => {
+    const relativePath = workspaceRelativePath(tab.path, workspaceRoot).replace(/\\/g, '/');
+    const name = editorTabName(tab);
+    return {
+      tab,
+      name,
+      relativePath,
+      parentSegments: relativePath.split('/').filter(Boolean).slice(0, -1),
+    };
+  });
+  const collisions = new Map<string, TabLabelCandidate[]>();
+  for (const candidate of candidates) {
+    const peers = collisions.get(candidate.name);
+    if (peers) peers.push(candidate);
+    else collisions.set(candidate.name, [candidate]);
+  }
+
+  return new Map(
+    candidates.map((candidate) => {
+      const peers = collisions.get(candidate.name) ?? [candidate];
+      const detail = peers.length > 1 ? shortestUniqueParent(candidate, peers) : null;
+      const diffDetail = candidate.tab.kind === 'diff' ? (candidate.tab.staged ? '已暂存差异' : '工作树差异') : null;
+      const title = diffDetail ? `${candidate.relativePath} · ${diffDetail}` : candidate.relativePath;
+      return [
+        candidate.tab.id,
+        {
+          name: candidate.name,
+          detail,
+          ariaLabel: detail ? `${candidate.name}，${detail}` : candidate.name,
+          title,
+        },
+      ];
+    })
+  );
+}
+
+function editorTabName(tab: WorkspaceEditorTabLabelSource): string {
+  const name = basename(tab.path);
+  if (tab.kind === 'file') return name;
+  return `${name}${tab.staged ? '（已暂存）' : '（工作树）'}`;
+}
+
+function shortestUniqueParent(candidate: TabLabelCandidate, peers: readonly TabLabelCandidate[]): string {
+  for (let depth = 1; depth <= candidate.parentSegments.length; depth += 1) {
+    const detail = parentSuffix(candidate, depth);
+    if (peers.every((peer) => peer === candidate || parentSuffix(peer, depth) !== detail)) return detail;
+  }
+  return parentSuffix(candidate, candidate.parentSegments.length);
+}
+
+function parentSuffix(candidate: TabLabelCandidate, depth: number): string {
+  if (!candidate.parentSegments.length) return '.';
+  return candidate.parentSegments.slice(-Math.max(1, depth)).join('/');
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path;
+}

--- a/apps/web/src/features/workspace/components/workspace-editor-tabs.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-editor-tabs.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appState } from '../../../state/app-state';
+import type { WorkspaceActions } from '../workspace-actions';
+import { fileEditorTabId, type WorkspaceFileEditorTab } from '../workspace-state';
+import { WorkspaceEditorTabs } from './workspace-editor-tabs';
+
+describe('Workspace editor tabs', () => {
+  beforeEach(() => {
+    appState.workspaceRoot = '/repo';
+    appState.editorTabs = [
+      fileTab('/repo/crates/acl/src/lib.rs'),
+      fileTab('/repo/crates/code/src/lib.rs'),
+      fileTab('/repo/README.md'),
+    ];
+    appState.activeEditorTabId = fileEditorTabId('/repo/crates/acl/src/lib.rs');
+  });
+
+  afterEach(() => {
+    cleanup();
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+  });
+
+  it('renders duplicate filenames with visible and accessible unique parent suffixes', () => {
+    const activateEditorTab = vi.fn();
+    const closeEditorTab = vi.fn();
+    const actions = { activateEditorTab, closeEditorTab } as unknown as WorkspaceActions;
+    render(<WorkspaceEditorTabs actions={actions} />);
+
+    const acl = screen.getByRole('tab', { name: 'lib.rs，acl/src' });
+    const code = screen.getByRole('tab', { name: 'lib.rs，code/src' });
+    const readme = screen.getByRole('tab', { name: 'README.md' });
+
+    expect(acl).toHaveAttribute('title', 'crates/acl/src/lib.rs');
+    expect(within(acl).getByText('acl/src')).toBeInTheDocument();
+    expect(within(code).getByText('code/src')).toBeInTheDocument();
+    expect(readme.querySelector('.workspace-tab-detail')).toBeNull();
+
+    fireEvent.click(code);
+    expect(activateEditorTab).toHaveBeenCalledWith(fileEditorTabId('/repo/crates/code/src/lib.rs'));
+
+    fireEvent.click(screen.getByRole('button', { name: '关闭 lib.rs，acl/src' }));
+    expect(closeEditorTab).toHaveBeenCalledWith(fileEditorTabId('/repo/crates/acl/src/lib.rs'));
+  });
+
+  it('keeps each tab and its close action as sibling controls', () => {
+    const actions = {
+      activateEditorTab: vi.fn(),
+      closeEditorTab: vi.fn(),
+    } as unknown as WorkspaceActions;
+    render(<WorkspaceEditorTabs actions={actions} />);
+
+    const tab = screen.getByRole('tab', { name: 'lib.rs，acl/src' });
+    const close = screen.getByRole('button', { name: '关闭 lib.rs，acl/src' });
+
+    expect(tab.tagName).toBe('BUTTON');
+    expect(tab).not.toContainElement(close);
+    expect(close.closest('[role="tab"]')).toBeNull();
+  });
+
+  it('supports automatic arrow, Home, End, and Delete navigation', async () => {
+    const activateEditorTab = vi.fn((tabId: string) => {
+      appState.activeEditorTabId = tabId;
+    });
+    const closeEditorTab = vi.fn();
+    const actions = { activateEditorTab, closeEditorTab } as unknown as WorkspaceActions;
+    render(<WorkspaceEditorTabs actions={actions} />);
+
+    const acl = screen.getByRole('tab', { name: 'lib.rs，acl/src' });
+    acl.focus();
+    fireEvent.keyDown(acl, { key: 'End' });
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'README.md' })).toHaveFocus());
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'README.md' }), { key: 'Home' });
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'lib.rs，acl/src' })).toHaveFocus());
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'lib.rs，acl/src' }), { key: 'ArrowLeft' });
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'README.md' })).toHaveFocus());
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'README.md' }), { key: 'Delete' });
+    expect(closeEditorTab).toHaveBeenCalledWith(fileEditorTabId('/repo/README.md'));
+  });
+
+  it('focuses a boundary target even when that tab is already selected', async () => {
+    appState.activeEditorTabId = fileEditorTabId('/repo/README.md');
+    const activateEditorTab = vi.fn((tabId: string) => {
+      appState.activeEditorTabId = tabId;
+    });
+    const actions = { activateEditorTab, closeEditorTab: vi.fn() } as unknown as WorkspaceActions;
+    render(<WorkspaceEditorTabs actions={actions} />);
+
+    const inactive = screen.getByRole('tab', { name: 'lib.rs，acl/src' });
+    inactive.focus();
+    fireEvent.keyDown(inactive, { key: 'End' });
+
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'README.md' })).toHaveFocus());
+    expect(activateEditorTab).toHaveBeenCalledWith(fileEditorTabId('/repo/README.md'));
+  });
+});
+
+function fileTab(path: string): WorkspaceFileEditorTab {
+  return {
+    id: fileEditorTabId(path),
+    kind: 'file',
+    path,
+    content: '',
+    draft: '',
+    revision: null,
+    isBinary: false,
+    location: null,
+    loading: false,
+    loadError: null,
+    saving: false,
+    configValidation: null,
+  };
+}

--- a/apps/web/src/features/workspace/components/workspace-editor-tabs.tsx
+++ b/apps/web/src/features/workspace/components/workspace-editor-tabs.tsx
@@ -1,74 +1,105 @@
 import { FileDiff, LoaderCircle, X } from 'lucide-react';
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { useSnapshot } from 'valtio';
 import { appState } from '../../../state/app-state';
 import type { WorkspaceActions } from '../workspace-actions';
-import { isFileEditorTabDirty, workspaceRelativePath } from '../workspace-state';
+import { isFileEditorTabDirty } from '../workspace-state';
+import { workspaceEditorTabLabels } from './workspace-editor-tab-label';
 import { WorkspaceFileIcon } from './workspace-file-icon';
 
 export function WorkspaceEditorTabs({ actions }: { actions: WorkspaceActions }) {
   const state = useSnapshot(appState);
   const activeRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
+  const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+  const requestedFocusIdRef = useRef<string | null>(null);
+  useLayoutEffect(() => {
     activeRef.current?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    const requestedFocusId = requestedFocusIdRef.current;
+    if (!requestedFocusId || requestedFocusId !== state.activeEditorTabId) return;
+    const target = tabRefs.current.get(requestedFocusId);
+    if (!target) return;
+    requestedFocusIdRef.current = null;
+    target.focus({ preventScroll: true });
   }, [state.activeEditorTabId]);
   if (!state.editorTabs.length) return null;
+  const labels = workspaceEditorTabLabels(state.editorTabs, state.workspaceRoot);
+
+  const activateFromKeyboard = (tabId: string) => {
+    requestedFocusIdRef.current = tabId;
+    actions.activateEditorTab(tabId);
+    const target = tabRefs.current.get(tabId);
+    if (!target) return;
+    requestedFocusIdRef.current = null;
+    target.focus({ preventScroll: true });
+  };
 
   return (
-    <div className='workspace-editor-tabs' role='tablist' aria-label='已打开的编辑器'>
+    <div className='workspace-editor-tabs' role='tablist' aria-label='已打开的编辑器' aria-orientation='horizontal'>
       {state.editorTabs.map((tab, index) => {
         const active = tab.id === state.activeEditorTabId;
         const dirty = tab.kind === 'file' && isFileEditorTabDirty(tab);
-        const relativePath = workspaceRelativePath(tab.path, state.workspaceRoot);
-        const label =
-          tab.kind === 'diff'
-            ? `${basename(tab.path)} ${tab.staged ? '（已暂存）' : '（工作树）'}`
-            : basename(tab.path);
+        const display = labels.get(tab.id);
+        if (!display) return null;
         return (
           <div
             ref={active ? activeRef : undefined}
-            className={`workspace-editor-tab ${active ? 'active' : ''} ${dirty ? 'dirty' : ''}`}
+            className={`workspace-editor-tab ${active ? 'active' : ''} ${dirty ? 'dirty' : ''} ${display.detail ? 'disambiguated' : ''}`}
             key={tab.id}
-            role='tab'
-            aria-selected={active}
-            aria-controls='workspace-editor-active-panel'
-            tabIndex={active ? 0 : -1}
-            title={tab.kind === 'diff' ? `${relativePath} · ${tab.staged ? '已暂存差异' : '工作树差异'}` : relativePath}
-            onClick={() => actions.activateEditorTab(tab.id)}
-            onAuxClick={(event) => {
-              if (event.button === 1) actions.closeEditorTab(tab.id);
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                actions.activateEditorTab(tab.id);
-              }
-              if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-                event.preventDefault();
-                const direction = event.key === 'ArrowRight' ? 1 : -1;
-                const next = state.editorTabs[(index + direction + state.editorTabs.length) % state.editorTabs.length];
-                actions.activateEditorTab(next.id);
-                requestAnimationFrame(() => activeRef.current?.focus());
-              }
-            }}
           >
-            {tab.kind === 'diff' ? (
-              <FileDiff className={`workspace-tab-icon ${tab.staged ? 'staged' : 'working'}`} size={14} />
-            ) : (
-              <WorkspaceFileIcon path={tab.path} size={14} />
-            )}
-            <span>{label}</span>
+            <button
+              ref={(element) => {
+                if (element) tabRefs.current.set(tab.id, element);
+                else tabRefs.current.delete(tab.id);
+              }}
+              type='button'
+              className='workspace-editor-tab-trigger'
+              role='tab'
+              aria-label={`${display.ariaLabel}${dirty ? '，未保存' : ''}`}
+              aria-selected={active}
+              aria-controls='workspace-editor-active-panel'
+              tabIndex={active ? 0 : -1}
+              title={display.title}
+              onClick={() => actions.activateEditorTab(tab.id)}
+              onAuxClick={(event) => {
+                if (event.button === 1) actions.closeEditorTab(tab.id);
+              }}
+              onKeyDown={(event) => {
+                let targetIndex: number | null = null;
+                if (event.key === 'ArrowLeft') targetIndex = index - 1;
+                if (event.key === 'ArrowRight') targetIndex = index + 1;
+                if (event.key === 'Home') targetIndex = 0;
+                if (event.key === 'End') targetIndex = state.editorTabs.length - 1;
+                if (targetIndex !== null) {
+                  event.preventDefault();
+                  const next = state.editorTabs[(targetIndex + state.editorTabs.length) % state.editorTabs.length];
+                  activateFromKeyboard(next.id);
+                  return;
+                }
+                if (event.key === 'Delete') {
+                  event.preventDefault();
+                  actions.closeEditorTab(tab.id);
+                }
+              }}
+            >
+              {tab.kind === 'diff' ? (
+                <FileDiff className={`workspace-tab-icon ${tab.staged ? 'staged' : 'working'}`} size={14} />
+              ) : (
+                <WorkspaceFileIcon path={tab.path} size={14} />
+              )}
+              <span className='workspace-tab-label'>
+                <span className='workspace-tab-name'>{display.name}</span>
+                {display.detail && <small className='workspace-tab-detail'>{display.detail}</small>}
+              </span>
+            </button>
             {tab.loading ? (
               <LoaderCircle className='workspace-tab-loading spin' size={12} />
             ) : (
               <button
                 type='button'
                 className='workspace-tab-close'
-                aria-label={`关闭 ${label}${dirty ? '，未保存' : ''}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  actions.closeEditorTab(tab.id);
-                }}
+                aria-label={`关闭 ${display.ariaLabel}${dirty ? '，未保存' : ''}`}
+                tabIndex={active ? 0 : -1}
+                onClick={() => actions.closeEditorTab(tab.id)}
               >
                 <span className='workspace-tab-dirty-dot' aria-hidden='true' />
                 <X className='workspace-tab-close-icon' size={12} />
@@ -79,8 +110,4 @@ export function WorkspaceEditorTabs({ actions }: { actions: WorkspaceActions }) 
       })}
     </div>
   );
-}
-
-function basename(path: string): string {
-  return path.split(/[\\/]/).filter(Boolean).pop() || path;
 }

--- a/apps/web/src/features/workspace/components/workspace-editor.tsx
+++ b/apps/web/src/features/workspace/components/workspace-editor.tsx
@@ -1,9 +1,11 @@
 import {
   ArrowLeft,
+  ArrowRight,
   CheckCircle2,
   ChevronRight,
   FileCode2,
   FileDiff,
+  FileSearch,
   LoaderCircle,
   MessageSquareText,
   Plus,
@@ -12,11 +14,9 @@ import {
   ShieldAlert,
   Wrench,
 } from 'lucide-react';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useSnapshot } from 'valtio';
 import { Button, IconButton } from '../../../design-system/primitives';
-import type { WorkspaceActions } from '../workspace-actions';
-import { isFileEditorTabDirty, workspaceRelativePath } from '../workspace-state';
 import {
   appendTaskInstruction,
   appState,
@@ -25,6 +25,13 @@ import {
   showToast,
   switchActiveTask,
 } from '../../../state/app-state';
+import type { WorkspaceActions } from '../workspace-actions';
+import { isFileEditorTabDirty, workspaceRelativePath } from '../workspace-state';
+import { type CodeEditorNavigationAction, CodeNavigationMenu } from './code-navigation-menu';
+import { LineEndingStatusControl } from './line-ending-status-control';
+import type { MonacoCodeEditorHandle } from './monaco-code-editor';
+import { workspaceEditorModelPath } from './monaco-editor-model-store';
+import type { MonacoEditorStatus } from './monaco-editor-status';
 import { WorkspaceEditorTabs } from './workspace-editor-tabs';
 import { WorkspaceFileIcon } from './workspace-file-icon';
 
@@ -37,12 +44,40 @@ const MonacoDiffEditor = lazy(() =>
 
 export function WorkspaceEditor({ actions }: { actions: WorkspaceActions }) {
   const state = useSnapshot(appState);
+  const rootRef = useRef<HTMLElement>(null);
+  const previousTabIdsRef = useRef(state.editorTabs.map((tab) => tab.id));
+  const previousActiveTabIdRef = useRef(state.activeEditorTabId);
+  const [pendingEditorFocusTabId, setPendingEditorFocusTabId] = useState<string | null>(null);
   const activeTab = state.editorTabs.find((tab) => tab.id === state.activeEditorTabId);
   const dark =
     state.theme === 'dark' || (state.theme === 'system' && document.documentElement.dataset.theme === 'dark');
 
+  useLayoutEffect(() => {
+    const currentTabIds = state.editorTabs.map((tab) => tab.id);
+    const removedTab = previousTabIdsRef.current.some((tabId) => !currentTabIds.includes(tabId));
+    const activeTabChanged = previousActiveTabIdRef.current !== state.activeEditorTabId;
+    previousTabIdsRef.current = currentTabIds;
+    previousActiveTabIdRef.current = state.activeEditorTabId;
+    if (!removedTab && !activeTabChanged) return;
+    const activeElement = document.activeElement;
+    const focusWasLost =
+      !(activeElement instanceof HTMLElement) || activeElement === document.body || !activeElement.isConnected;
+    if (!focusWasLost) return;
+    const target = state.activeEditorTabId
+      ? rootRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]')
+      : rootRef.current?.querySelector<HTMLElement>('.workspace-editor-empty button');
+    target?.focus({ preventScroll: true });
+  }, [state.activeEditorTabId, state.editorTabs]);
+
+  const completeEditorFocusRequest = useCallback((tabId: string) => {
+    setPendingEditorFocusTabId((pendingTabId) => (pendingTabId === tabId ? null : pendingTabId));
+  }, []);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || !(event.target instanceof Node) || !rootRef.current?.contains(event.target)) {
+        return;
+      }
       const modifier = event.metaKey || event.ctrlKey;
       if (modifier && event.key.toLowerCase() === 's' && activeTab?.kind === 'file') {
         event.preventDefault();
@@ -51,7 +86,14 @@ export function WorkspaceEditor({ actions }: { actions: WorkspaceActions }) {
       }
       if (modifier && event.key.toLowerCase() === 'w' && activeTab) {
         event.preventDefault();
+        const index = state.editorTabs.findIndex((tab) => tab.id === activeTab.id);
+        const next = state.editorTabs[index + 1] ?? state.editorTabs[index - 1];
+        const startedInEditor =
+          event.target instanceof Element && event.target.closest('.monaco-editor-surface') !== null;
         actions.closeEditorTab(activeTab.id);
+        if (startedInEditor && next && appState.activeEditorTabId === next.id) {
+          setPendingEditorFocusTabId(next.id);
+        }
         return;
       }
       if (event.ctrlKey && event.key === 'Tab' && state.editorTabs.length > 1) {
@@ -59,7 +101,18 @@ export function WorkspaceEditor({ actions }: { actions: WorkspaceActions }) {
         const index = state.editorTabs.findIndex((tab) => tab.id === state.activeEditorTabId);
         const offset = event.shiftKey ? -1 : 1;
         const next = state.editorTabs[(index + offset + state.editorTabs.length) % state.editorTabs.length];
+        const startedInEditor =
+          event.target instanceof Element && event.target.closest('.monaco-editor-surface') !== null;
+        setPendingEditorFocusTabId(startedInEditor ? next.id : null);
         actions.activateEditorTab(next.id);
+        return;
+      }
+      if (event.ctrlKey && !event.metaKey && !event.altKey && event.code === 'Minus') {
+        const navigate = event.shiftKey ? actions.navigateEditorForward : actions.navigateEditorBack;
+        const available = event.shiftKey ? actions.canNavigateEditorForward : actions.canNavigateEditorBack;
+        if (!available) return;
+        event.preventDefault();
+        void navigate();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
@@ -67,7 +120,7 @@ export function WorkspaceEditor({ actions }: { actions: WorkspaceActions }) {
   }, [actions, activeTab, state.activeEditorTabId, state.editorTabs]);
 
   return (
-    <main className='workspace-editor'>
+    <main ref={rootRef} className='workspace-editor'>
       <ReviewContext />
       <WorkspaceEditorTabs actions={actions} />
       {!activeTab ? (
@@ -81,11 +134,20 @@ export function WorkspaceEditor({ actions }: { actions: WorkspaceActions }) {
             activeTab.kind === 'diff' ? `差异 ${basename(activeTab.path)}` : `文件 ${basename(activeTab.path)}`
           }
         >
-          <EditorToolbar actions={actions} />
           {activeTab.kind === 'file' ? (
-            <FileEditorContent actions={actions} dark={dark} />
+            <FileEditorContent
+              actions={actions}
+              dark={dark}
+              focusRequested={pendingEditorFocusTabId === activeTab.id}
+              onFocusRequestHandled={completeEditorFocusRequest}
+            />
           ) : (
-            <DiffEditorContent actions={actions} dark={dark} />
+            <DiffEditorContent
+              actions={actions}
+              dark={dark}
+              focusRequested={pendingEditorFocusTabId === activeTab.id}
+              onFocusRequestHandled={completeEditorFocusRequest}
+            />
           )}
         </section>
       )}
@@ -93,7 +155,13 @@ export function WorkspaceEditor({ actions }: { actions: WorkspaceActions }) {
   );
 }
 
-function EditorToolbar({ actions }: { actions: WorkspaceActions }) {
+function EditorToolbar({
+  actions,
+  codeNavigation,
+}: {
+  actions: WorkspaceActions;
+  codeNavigation?: { disabled: boolean; onSelect: (action: CodeEditorNavigationAction) => void };
+}) {
   const state = useSnapshot(appState);
   const tab = state.editorTabs.find((candidate) => candidate.id === state.activeEditorTabId);
   if (!tab) return null;
@@ -115,6 +183,23 @@ function EditorToolbar({ actions }: { actions: WorkspaceActions }) {
         {dirty && <em className='workspace-unsaved-label'>未保存</em>}
       </div>
       <div className='workspace-editor-actions'>
+        <IconButton
+          label='返回上一个编辑位置'
+          tooltip='返回上一个编辑位置 (Ctrl -)'
+          disabled={!actions.canNavigateEditorBack}
+          onClick={() => void actions.navigateEditorBack()}
+        >
+          <ArrowLeft size={14} />
+        </IconButton>
+        <IconButton
+          label='前往下一个编辑位置'
+          tooltip='前往下一个编辑位置 (Ctrl Shift -)'
+          disabled={!actions.canNavigateEditorForward}
+          onClick={() => void actions.navigateEditorForward()}
+        >
+          <ArrowRight size={14} />
+        </IconButton>
+        {codeNavigation && <CodeNavigationMenu {...codeNavigation} />}
         {tab.kind === 'diff' && (
           <IconButton
             label='打开文件'
@@ -148,20 +233,54 @@ function EditorToolbar({ actions }: { actions: WorkspaceActions }) {
   );
 }
 
-function FileEditorContent({ actions, dark }: { actions: WorkspaceActions; dark: boolean }) {
+function FileEditorContent({
+  actions,
+  dark,
+  focusRequested,
+  onFocusRequestHandled,
+}: {
+  actions: WorkspaceActions;
+  dark: boolean;
+  focusRequested: boolean;
+  onFocusRequestHandled: (tabId: string) => void;
+}) {
   const state = useSnapshot(appState);
   const tab = state.editorTabs.find((candidate) => candidate.id === state.activeEditorTabId);
+  const editorRef = useRef<MonacoCodeEditorHandle>(null);
+  const [readyEditorModelPath, setReadyEditorModelPath] = useState<string | null>(null);
   const [intelligenceStatus, setIntelligenceStatus] = useState('代码导航连接中');
+  const [editorStatus, setEditorStatus] = useState<{
+    modelPath: string;
+    value: MonacoEditorStatus | null;
+  } | null>(null);
   useEffect(() => {
     setIntelligenceStatus('代码导航连接中');
   }, [tab?.id]);
   if (tab?.kind !== 'file') return null;
+  const editorModelPath = workspaceEditorModelPath(state.editorModelScope, tab.path);
   const dirty = isFileEditorTabDirty(tab);
   const isConfig = basename(tab.path) === 'config.acl';
   const selectingContext = state.reviewIntent === 'select-context';
+  const activeEditorStatus = editorStatus?.modelPath === editorModelPath ? editorStatus.value : null;
+  const selectionStatus = activeEditorStatus ? editorSelectionStatus(activeEditorStatus) : null;
+  const editorReady = readyEditorModelPath === editorModelPath;
 
   return (
     <>
+      <EditorToolbar
+        actions={actions}
+        codeNavigation={
+          !tab.isBinary && !tab.loading && !tab.loadError
+            ? {
+                disabled: !editorReady,
+                onSelect: (action) => {
+                  if (action === 'outline') editorRef.current?.showOutline();
+                  else editorRef.current?.navigate(action);
+                },
+              }
+            : undefined
+        }
+      />
       {isConfig && !tab.isBinary && tab.configValidation && (
         <section
           className={`config-validation ${tab.configValidation.valid ? 'valid' : 'invalid'}`}
@@ -236,8 +355,9 @@ function FileEditorContent({ actions, dark }: { actions: WorkspaceActions; dark:
             fallback={<EditorState icon={<LoaderCircle className='spin' size={18} />} title='正在启动编辑器' />}
           >
             <MonacoCodeEditor
-              key={tab.id}
+              ref={editorRef}
               path={tab.path}
+              modelPath={editorModelPath}
               value={tab.draft}
               location={tab.location}
               readOnly={selectingContext}
@@ -250,6 +370,25 @@ function FileEditorContent({ actions, dark }: { actions: WorkspaceActions; dark:
               onClose={() => actions.closeEditorTab(tab.id)}
               onNavigate={actions.selectFile}
               onStatusChange={setIntelligenceStatus}
+              onEditorStatusChange={(value) => {
+                setEditorStatus({ modelPath: editorModelPath, value });
+                if (value) {
+                  actions.updateEditorPosition?.(tab.id, {
+                    line: value.lineNumber,
+                    column: value.column,
+                  });
+                }
+              }}
+              onLocationApplied={() => actions.consumeEditorLocation(tab.id)}
+              onReadyChange={(ready) => {
+                setReadyEditorModelPath((readyModelPath) => {
+                  if (ready) return editorModelPath;
+                  return readyModelPath === editorModelPath ? null : readyModelPath;
+                });
+                if (ready && focusRequested && editorRef.current?.focus()) {
+                  onFocusRequestHandled(tab.id);
+                }
+              }}
             />
           </Suspense>
         )}
@@ -258,8 +397,19 @@ function FileEditorContent({ actions, dark }: { actions: WorkspaceActions; dark:
         left={languageLabel(tab.path)}
         items={[
           selectingContext ? '只读' : dirty ? '未保存' : '已保存',
-          'UTF-8',
-          'LF',
+          ...(activeEditorStatus
+            ? [
+                `行 ${activeEditorStatus.lineNumber}，列 ${activeEditorStatus.column}`,
+                ...(selectionStatus ? [selectionStatus] : []),
+                'UTF-8',
+                <LineEndingStatusControl
+                  key='line-ending'
+                  value={activeEditorStatus.lineEnding}
+                  disabled={selectingContext}
+                  onChange={(lineEnding) => editorRef.current?.setLineEnding(lineEnding)}
+                />,
+              ]
+            : []),
           ...(!tab.isBinary && !tab.loading && !tab.loadError ? [intelligenceStatus] : []),
         ]}
       />
@@ -267,12 +417,23 @@ function FileEditorContent({ actions, dark }: { actions: WorkspaceActions; dark:
   );
 }
 
-function DiffEditorContent({ actions, dark }: { actions: WorkspaceActions; dark: boolean }) {
+function DiffEditorContent({
+  actions,
+  dark,
+  focusRequested,
+  onFocusRequestHandled,
+}: {
+  actions: WorkspaceActions;
+  dark: boolean;
+  focusRequested: boolean;
+  onFocusRequestHandled: (tabId: string) => void;
+}) {
   const state = useSnapshot(appState);
   const tab = state.editorTabs.find((candidate) => candidate.id === state.activeEditorTabId);
   if (tab?.kind !== 'diff') return null;
   return (
     <>
+      <EditorToolbar actions={actions} />
       <div className='workspace-editor-content'>
         {tab.loading ? (
           <EditorState icon={<LoaderCircle className='spin' size={18} />} title='正在生成差异' />
@@ -307,6 +468,8 @@ function DiffEditorContent({ actions, dark }: { actions: WorkspaceActions; dark:
               original={tab.original}
               modified={tab.modified}
               dark={dark}
+              focusOnMount={focusRequested}
+              onFocusOnMount={() => onFocusRequestHandled(tab.id)}
             />
           </Suspense>
         )}
@@ -332,6 +495,15 @@ function WorkspaceEditorEmpty() {
             : '文件和差异会保留在同一标签栏，切换标签不会丢失草稿。'}
         </p>
         <div className='workspace-editor-shortcuts'>
+          <Button
+            tone='quiet'
+            onClick={() => {
+              appState.fileQuickOpenOpen = true;
+            }}
+          >
+            <FileSearch size={13} />
+            快速打开 <kbd>⌘/Ctrl P</kbd>
+          </Button>
           <span>
             保存 <kbd>⌘/Ctrl S</kbd>
           </span>
@@ -370,14 +542,20 @@ function EditorState({
   );
 }
 
-function EditorStatusBar({ left, items }: { left: string; items: string[] }) {
+function EditorStatusBar({ left, items }: { left: string; items: Array<string | React.ReactElement> }) {
   return (
     <footer className='workspace-editor-statusbar'>
       <span>{left}</span>
       <div>
-        {items.map((item) => (
-          <span key={item}>{item}</span>
-        ))}
+        {items.map((item, index) =>
+          typeof item === 'string' ? (
+            <span key={`${item}:${index}`} title={item}>
+              {item}
+            </span>
+          ) : (
+            item
+          )
+        )}
       </div>
     </footer>
   );
@@ -499,6 +677,14 @@ function languageLabel(path: string): string {
     yml: 'YAML',
   };
   return (extension && labels[extension]) || '纯文本';
+}
+
+function editorSelectionStatus(status: MonacoEditorStatus): string | null {
+  if (status.selectedCharacters > 0) {
+    const locations = status.selectionCount > 1 ? `（${status.selectionCount} 处）` : '';
+    return `已选择 ${status.selectedCharacters} 个字符${locations}`;
+  }
+  return status.selectionCount > 1 ? `${status.selectionCount} 个光标` : null;
 }
 
 function basename(path: string): string {

--- a/apps/web/src/features/workspace/components/workspace-explorer-state.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-explorer-state.test.tsx
@@ -1,0 +1,133 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { codeApi } from '../../../lib/api';
+import { appState } from '../../../state/app-state';
+import type { WorkspaceEntry } from '../../../types/api';
+import { useWorkspaceController } from '../use-workspace-controller';
+
+describe('Workspace Explorer cached state', () => {
+  afterEach(() => {
+    cleanup();
+    appState.workspaceRoot = '';
+    appState.filesByDirectory = {};
+    appState.expandedDirectories = {};
+    appState.directoryLoading = {};
+    appState.directoryErrors = {};
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    vi.restoreAllMocks();
+  });
+
+  it('preserves an expanded cached subtree when its directory is renamed', async () => {
+    appState.workspaceRoot = '/repo';
+    appState.filesByDirectory = {
+      '/repo': [directory('/repo/src')],
+      '/repo/src': [directory('/repo/src/nested'), textFile('/repo/src/app.ts')],
+      '/repo/src/nested': [textFile('/repo/src/nested/model.ts')],
+    };
+    appState.expandedDirectories = { '/repo/src': true, '/repo/src/nested': true };
+    appState.directoryLoading = { '/repo/src': false };
+    appState.directoryErrors = { '/repo/src/nested': 'retry child' };
+    vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockRejectedValue(new Error('parent refresh failed'));
+    const hook = renderHook(() => useWorkspaceController());
+
+    await act(() => hook.result.current.renameWorkspaceEntry('/repo/src', 'lib'));
+
+    expect(appState.filesByDirectory['/repo'].map((entry) => [entry.name, entry.path])).toEqual([['lib', '/repo/lib']]);
+    expect(appState.filesByDirectory['/repo/lib'].map((entry) => entry.path)).toEqual([
+      '/repo/lib/nested',
+      '/repo/lib/app.ts',
+    ]);
+    expect(appState.filesByDirectory['/repo/lib/nested'].map((entry) => entry.path)).toEqual([
+      '/repo/lib/nested/model.ts',
+    ]);
+    expect(appState.filesByDirectory['/repo/src']).toBeUndefined();
+    expect(appState.expandedDirectories).toMatchObject({ '/repo/lib': true, '/repo/lib/nested': true });
+    expect(appState.expandedDirectories['/repo/src']).toBeUndefined();
+    expect(appState.directoryLoading['/repo/lib']).toBe(false);
+    expect(appState.directoryErrors['/repo/lib/nested']).toBe('retry child');
+    hook.unmount();
+  });
+
+  it('removes a deleted subtree from every cache when parent refresh fails', async () => {
+    appState.workspaceRoot = '/repo';
+    appState.filesByDirectory = {
+      '/repo': [directory('/repo/deleted'), textFile('/repo/keep.ts')],
+      '/repo/deleted': [directory('/repo/deleted/nested')],
+      '/repo/deleted/nested': [],
+    };
+    appState.expandedDirectories = { '/repo/deleted': true, '/repo/deleted/nested': true };
+    appState.directoryLoading = { '/repo/deleted/nested': false };
+    appState.directoryErrors = { '/repo/deleted': 'old error' };
+    vi.spyOn(codeApi, 'deletePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockRejectedValue(new Error('parent refresh failed'));
+    const hook = renderHook(() => useWorkspaceController());
+
+    await act(() => hook.result.current.deleteWorkspaceEntry('/repo/deleted'));
+
+    expect(appState.filesByDirectory['/repo'].map((entry) => entry.path)).toEqual(['/repo/keep.ts']);
+    expect(Object.keys(appState.filesByDirectory)).not.toContain('/repo/deleted');
+    expect(Object.keys(appState.filesByDirectory)).not.toContain('/repo/deleted/nested');
+    expect(Object.keys(appState.expandedDirectories)).not.toContain('/repo/deleted');
+    expect(Object.keys(appState.directoryLoading)).not.toContain('/repo/deleted/nested');
+    expect(Object.keys(appState.directoryErrors)).not.toContain('/repo/deleted');
+    expect(appState.directoryErrors['/repo']).toBe('parent refresh failed');
+    hook.unmount();
+  });
+
+  it('ignores an old directory response after that subtree is renamed', async () => {
+    appState.workspaceRoot = '/repo';
+    appState.filesByDirectory = { '/repo': [directory('/repo/src')] };
+    let resolveOldRead!: (entries: WorkspaceEntry[]) => void;
+    const oldRead = new Promise<WorkspaceEntry[]>((resolve) => {
+      resolveOldRead = resolve;
+    });
+    vi.spyOn(codeApi, 'readDir').mockImplementation((path) =>
+      path === '/repo/src' ? oldRead : Promise.resolve([directory('/repo/lib')])
+    );
+    vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
+    const hook = renderHook(() => useWorkspaceController());
+
+    const refresh = hook.result.current.refreshDirectory('/repo/src');
+    await waitFor(() => expect(appState.directoryLoading['/repo/src']).toBe(true));
+    await act(() => hook.result.current.renameWorkspaceEntry('/repo/src', 'lib'));
+    await act(async () => {
+      resolveOldRead([textFile('/repo/src/stale.ts')]);
+      await refresh;
+    });
+
+    expect(appState.filesByDirectory['/repo/src']).toBeUndefined();
+    expect(appState.filesByDirectory['/repo/lib']).toBeUndefined();
+    expect(appState.filesByDirectory['/repo'].map((entry) => entry.path)).toEqual(['/repo/lib']);
+    expect(appState.directoryLoading['/repo/lib']).toBe(false);
+    hook.unmount();
+  });
+});
+
+function directory(path: string): WorkspaceEntry {
+  return {
+    name: basename(path),
+    path,
+    isDirectory: true,
+    isFile: false,
+    size: 0,
+    isBinary: false,
+  };
+}
+
+function textFile(path: string): WorkspaceEntry {
+  return {
+    name: basename(path),
+    path,
+    isDirectory: false,
+    isFile: true,
+    size: 10,
+    extension: path.split('.').pop(),
+    isBinary: false,
+  };
+}
+
+function basename(path: string): string {
+  return path.split('/').pop() ?? path;
+}

--- a/apps/web/src/features/workspace/components/workspace-explorer.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-explorer.test.tsx
@@ -14,10 +14,11 @@ const file = {
   isBinary: false,
 };
 
-describe('WorkspaceExplorer context menu operations', () => {
+describe('WorkspaceExplorer', () => {
   beforeEach(() => {
     appState.workspaceRoot = '/repo';
     appState.filesByDirectory = { '/repo': [file] };
+    appState.expandedDirectories = {};
     appState.directoryLoading = {};
     appState.directoryErrors = {};
     appState.editorTabs = [];
@@ -36,13 +37,62 @@ describe('WorkspaceExplorer context menu operations', () => {
     expect(screen.queryByRole('button', { name: '重命名 app.ts' })).not.toBeInTheDocument();
     fireEvent.contextMenu(screen.getByRole('treeitem', { name: 'app.ts' }), { clientX: 48, clientY: 72 });
     expect(screen.getByRole('menu', { name: 'app.ts 操作' })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('menuitem', { name: '重命名' }));
+    const renameItem = screen.getByRole('menuitem', { name: '重命名' });
+    expect(renameItem).toHaveTextContent('F2');
+    fireEvent.click(renameItem);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     const input = screen.getByRole('textbox', { name: '文件或文件夹名称' });
     fireEvent.change(input, { target: { value: 'main.ts' } });
     fireEvent.click(screen.getByRole('button', { name: '确认文件操作' }));
 
     await waitFor(() => expect(renameWorkspaceEntry).toHaveBeenCalledWith('/repo/app.ts', 'main.ts'));
+  });
+
+  it('starts an in-place rename with F2 on the focused file row', () => {
+    render(<WorkspaceExplorer actions={{} as WorkspaceActions} onOpenSearch={vi.fn()} />);
+    const row = screen.getByRole('treeitem', { name: 'app.ts' });
+    row.focus();
+
+    fireEvent.keyDown(row, { key: 'F2' });
+
+    const input = screen.getByRole('textbox', { name: '文件或文件夹名称' });
+    expect(input).toHaveValue('app.ts');
+    expect(input).toHaveFocus();
+  });
+
+  it('opens the in-place delete confirmation with Delete without deleting immediately', async () => {
+    const deleteWorkspaceEntry = vi.fn(async () => undefined);
+    render(
+      <WorkspaceExplorer actions={{ deleteWorkspaceEntry } as unknown as WorkspaceActions} onOpenSearch={vi.fn()} />
+    );
+    const row = screen.getByRole('treeitem', { name: 'app.ts' });
+    row.focus();
+
+    fireEvent.keyDown(row, { key: 'Delete' });
+
+    expect(screen.getByRole('group', { name: '确认删除 app.ts' })).toBeInTheDocument();
+    expect(deleteWorkspaceEntry).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: '确认删除 app.ts' }));
+    await waitFor(() => expect(deleteWorkspaceEntry).toHaveBeenCalledWith('/repo/app.ts'));
+  });
+
+  it('keeps keyboard focus inside the tree when rename and delete are cancelled', () => {
+    render(<WorkspaceExplorer actions={{} as WorkspaceActions} onOpenSearch={vi.fn()} />);
+    let row = screen.getByRole('treeitem', { name: 'app.ts' });
+    row.focus();
+
+    fireEvent.keyDown(row, { key: 'F2' });
+    const renameInput = screen.getByRole('textbox', { name: '文件或文件夹名称' });
+    expect(renameInput).toHaveFocus();
+    fireEvent.keyDown(renameInput, { key: 'Escape' });
+    row = screen.getByRole('treeitem', { name: 'app.ts' });
+    expect(row).toHaveFocus();
+
+    fireEvent.keyDown(row, { key: 'Delete' });
+    const cancelDelete = screen.getByRole('button', { name: '取消' });
+    expect(cancelDelete).toHaveFocus();
+    fireEvent.click(cancelDelete);
+    expect(screen.getByRole('treeitem', { name: 'app.ts' })).toHaveFocus();
   });
 
   it('keeps a failed delete confirmation at the same tree row', async () => {
@@ -77,4 +127,179 @@ describe('WorkspaceExplorer context menu operations', () => {
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     expect(row).toHaveFocus();
   });
+
+  it('passes binary directory metadata through the tree selection path', async () => {
+    const selectFile = vi.fn(async () => true);
+    appState.filesByDirectory = {
+      '/repo': [
+        {
+          ...file,
+          name: 'logo.png',
+          path: '/repo/logo.png',
+          extension: 'png',
+          isBinary: true,
+        },
+      ],
+    };
+    render(<WorkspaceExplorer actions={{ selectFile } as unknown as WorkspaceActions} onOpenSearch={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('treeitem', { name: 'logo.png' }));
+
+    await waitFor(() =>
+      expect(selectFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/repo/logo.png',
+          isBinary: true,
+        })
+      )
+    );
+  });
+
+  it('uses one roving tab stop and moves focus through visible rows without opening files', () => {
+    const selectFile = vi.fn(async () => true);
+    appState.filesByDirectory = {
+      '/repo': [directory('/repo/src'), textFile('/repo/README.md')],
+      '/repo/src': [textFile('/repo/src/app.ts'), directory('/repo/src/nested')],
+      '/repo/src/nested': [textFile('/repo/src/nested/model.ts')],
+    };
+    appState.expandedDirectories = { '/repo/src': true };
+    render(<WorkspaceExplorer actions={{ selectFile } as unknown as WorkspaceActions} onOpenSearch={vi.fn()} />);
+
+    const src = screen.getByRole('treeitem', { name: 'src' });
+    const app = screen.getByRole('treeitem', { name: 'app.ts' });
+    const nested = screen.getByRole('treeitem', { name: 'nested' });
+    const readme = screen.getByRole('treeitem', { name: 'README.md' });
+    expect(src).toHaveAttribute('tabindex', '0');
+    expect(app).toHaveAttribute('tabindex', '-1');
+    expect(nested).toHaveAttribute('tabindex', '-1');
+    expect(readme).toHaveAttribute('tabindex', '-1');
+
+    src.focus();
+    fireEvent.keyDown(src, { key: 'ArrowDown' });
+    expect(app).toHaveFocus();
+    fireEvent.keyDown(app, { key: 'ArrowDown' });
+    expect(nested).toHaveFocus();
+    fireEvent.keyDown(nested, { key: 'ArrowDown' });
+    expect(readme).toHaveFocus();
+    fireEvent.keyDown(readme, { key: 'ArrowDown' });
+    expect(readme).toHaveFocus();
+
+    fireEvent.keyDown(readme, { key: 'Home' });
+    expect(src).toHaveFocus();
+    fireEvent.keyDown(src, { key: 'ArrowUp' });
+    expect(src).toHaveFocus();
+    fireEvent.keyDown(src, { key: 'End' });
+    expect(readme).toHaveFocus();
+    expect(screen.getAllByRole('treeitem').filter((row) => row.tabIndex === 0)).toEqual([readme]);
+    expect(selectFile).not.toHaveBeenCalled();
+  });
+
+  it('uses the visible active editor path as the initial tree tab stop', () => {
+    appState.filesByDirectory = { '/repo': [file, textFile('/repo/README.md')] };
+    appState.editorTabs = [
+      {
+        id: 'readme',
+        kind: 'file',
+        path: '/repo/README.md',
+        content: '',
+        draft: '',
+        revision: null,
+        isBinary: false,
+        location: null,
+        loading: false,
+        loadError: null,
+        saving: false,
+        configValidation: null,
+      },
+    ];
+    appState.activeEditorTabId = 'readme';
+    render(<WorkspaceExplorer actions={{} as WorkspaceActions} onOpenSearch={vi.fn()} />);
+
+    expect(screen.getByRole('treeitem', { name: 'app.ts' })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('treeitem', { name: 'README.md' })).toHaveAttribute('tabindex', '0');
+  });
+
+  it('opens and collapses directories with horizontal arrows and moves between parent and first child', async () => {
+    appState.filesByDirectory = {
+      '/repo': [directory('/repo/src'), textFile('/repo/README.md')],
+      '/repo/src': [textFile('/repo/src/app.ts'), directory('/repo/src/nested')],
+    };
+    const toggleDirectory = vi.fn(async (path: string) => {
+      appState.expandedDirectories[path] = !appState.expandedDirectories[path];
+    });
+    render(<WorkspaceExplorer actions={{ toggleDirectory } as unknown as WorkspaceActions} onOpenSearch={vi.fn()} />);
+
+    const src = screen.getByRole('treeitem', { name: 'src' });
+    src.focus();
+    fireEvent.keyDown(src, { key: 'ArrowRight' });
+
+    await waitFor(() => expect(screen.getByRole('treeitem', { name: 'app.ts' })).toBeInTheDocument());
+    expect(src).toHaveFocus();
+    expect(toggleDirectory).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(src, { key: 'ArrowRight' });
+    const app = screen.getByRole('treeitem', { name: 'app.ts' });
+    expect(app).toHaveFocus();
+    fireEvent.keyDown(app, { key: 'ArrowLeft' });
+    expect(src).toHaveFocus();
+
+    fireEvent.keyDown(src, { key: 'ArrowLeft' });
+    await waitFor(() => expect(screen.queryByRole('treeitem', { name: 'app.ts' })).not.toBeInTheDocument());
+    expect(src).toHaveFocus();
+    expect(toggleDirectory).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(src, { key: 'ArrowLeft' });
+    expect(src).toHaveFocus();
+    expect(toggleDirectory).toHaveBeenCalledTimes(2);
+  });
+
+  it('navigates query-expanded ancestors without mutating their saved expansion state', () => {
+    const toggleDirectory = vi.fn(async () => undefined);
+    appState.filesByDirectory = {
+      '/repo': [directory('/repo/src'), textFile('/repo/README.md')],
+      '/repo/src': [textFile('/repo/src/app.ts'), directory('/repo/src/domain')],
+      '/repo/src/domain': [textFile('/repo/src/domain/model.ts')],
+    };
+    render(<WorkspaceExplorer actions={{ toggleDirectory } as unknown as WorkspaceActions} onOpenSearch={vi.fn()} />);
+
+    fireEvent.change(screen.getByRole('searchbox', { name: '筛选文件' }), { target: { value: 'model' } });
+    const src = screen.getByRole('treeitem', { name: 'src' });
+    const domain = screen.getByRole('treeitem', { name: 'domain' });
+    const model = screen.getByRole('treeitem', { name: 'model.ts' });
+    expect(screen.queryByRole('treeitem', { name: 'app.ts' })).not.toBeInTheDocument();
+
+    src.focus();
+    fireEvent.keyDown(src, { key: 'ArrowRight' });
+    expect(domain).toHaveFocus();
+    fireEvent.keyDown(domain, { key: 'ArrowRight' });
+    expect(model).toHaveFocus();
+    fireEvent.keyDown(model, { key: 'ArrowLeft' });
+    expect(domain).toHaveFocus();
+    fireEvent.keyDown(domain, { key: 'ArrowLeft' });
+    expect(src).toHaveFocus();
+    expect(toggleDirectory).not.toHaveBeenCalled();
+  });
 });
+
+function directory(path: string) {
+  return {
+    name: path.split('/').pop() ?? path,
+    path,
+    isDirectory: true,
+    isFile: false,
+    size: 0,
+    isBinary: false,
+  };
+}
+
+function textFile(path: string) {
+  return {
+    name: path.split('/').pop() ?? path,
+    path,
+    isDirectory: false,
+    isFile: true,
+    size: 10,
+    extension: path.split('.').pop(),
+    isBinary: false,
+  };
+}

--- a/apps/web/src/features/workspace/components/workspace-explorer.tsx
+++ b/apps/web/src/features/workspace/components/workspace-explorer.tsx
@@ -3,6 +3,7 @@ import {
   ChevronRight,
   Copy,
   FilePlus2,
+  FileSearch,
   FileText,
   FolderOpen,
   FolderPlus,
@@ -13,7 +14,7 @@ import {
   Search,
   Trash2,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { useSnapshot } from 'valtio';
 import { IconButton } from '../../../design-system/primitives';
 import { appState } from '../../../state/app-state';
@@ -23,6 +24,7 @@ import { isFileEditorTabDirty, normalizePath, workspaceRelativePath } from '../w
 import { WorkspaceFileIcon } from './workspace-file-icon';
 import { WorkspaceContextMenu, type WorkspaceContextMenuItem } from './workspace-context-menu';
 import { WorkspaceInlineEntry, type WorkspaceInlineAction, workspaceInlineActionKey } from './workspace-inline-entry';
+import { type ExplorerTreeProjection, useWorkspaceExplorerTree } from './use-workspace-explorer-tree';
 
 interface ContextMenuState {
   entry: Readonly<WorkspaceEntry> | null;
@@ -30,16 +32,71 @@ interface ContextMenuState {
   y: number;
 }
 
+interface InlineFocusOrigin {
+  element: HTMLElement | null;
+  path: string | null;
+  index: number;
+}
+
 export function WorkspaceExplorer({ actions, onOpenSearch }: { actions: WorkspaceActions; onOpenSearch: () => void }) {
   const state = useSnapshot(appState);
   const [query, setQuery] = useState('');
+  const [restoreInlineFocus, setRestoreInlineFocus] = useState(false);
   const [inlineAction, setInlineAction] = useState<WorkspaceInlineAction | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const inlineFocusOriginRef = useRef<InlineFocusOrigin | null>(null);
+  const activeTab = state.editorTabs.find((tab) => tab.id === state.activeEditorTabId);
+  const activePath =
+    activeTab?.kind === 'file'
+      ? activeTab.path
+      : activeTab?.kind === 'diff'
+        ? absoluteWorkspacePath(activeTab.path, state.workspaceRoot)
+        : null;
+  const { tree, rovingPath, setFocusedPath, registerItem, focusItem, handleKeyDown } = useWorkspaceExplorerTree({
+    root: state.workspaceRoot,
+    filesByDirectory: state.filesByDirectory,
+    expandedDirectories: state.expandedDirectories,
+    query,
+    activePath,
+    toggleDirectory: actions.toggleDirectory,
+  });
   const closeContextMenu = () => setContextMenu(null);
   const updateInlineAction = (action: WorkspaceInlineAction | null) => {
     closeContextMenu();
+    if (action) {
+      const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      const returnElement = activeElement?.closest('.workspace-context-menu') ? null : activeElement;
+      const path = 'entry' in action ? action.entry.path : rovingPath;
+      inlineFocusOriginRef.current = {
+        element: returnElement,
+        path,
+        index: path ? (tree.itemByPath.get(path)?.index ?? -1) : -1,
+      };
+      if (path) setFocusedPath(path);
+      setRestoreInlineFocus(false);
+    } else if (inlineFocusOriginRef.current) {
+      setRestoreInlineFocus(true);
+    }
     setInlineAction(action);
   };
+  useLayoutEffect(() => {
+    if (!restoreInlineFocus || inlineAction) return;
+    const origin = inlineFocusOriginRef.current;
+    const fallbackIndex = Math.min(Math.max(origin?.index ?? 0, 0), Math.max(tree.items.length - 1, 0));
+    const fallbackPath =
+      (origin?.path && tree.itemByPath.has(origin.path) ? origin.path : null) ??
+      (activePath && tree.itemByPath.has(activePath) ? activePath : null) ??
+      tree.items[fallbackIndex]?.entry.path ??
+      null;
+    if (origin?.element?.isConnected) {
+      origin.element.focus({ preventScroll: true });
+      origin.element.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    } else if (fallbackPath) {
+      focusItem(fallbackPath);
+    }
+    inlineFocusOriginRef.current = null;
+    setRestoreInlineFocus(false);
+  }, [activePath, focusItem, inlineAction, restoreInlineFocus, tree]);
   const contextItems = contextMenuItems(
     contextMenu?.entry ?? null,
     state.expandedDirectories,
@@ -54,18 +111,26 @@ export function WorkspaceExplorer({ actions, onOpenSearch }: { actions: Workspac
           <strong>{basename(state.workspaceRoot)}</strong>
         </div>
         <span className='explorer-header-actions'>
+          <IconButton
+            label='快速打开文件'
+            onClick={() => {
+              appState.fileQuickOpenOpen = true;
+            }}
+          >
+            <FileSearch size={15} />
+          </IconButton>
           <IconButton label='全局搜索' onClick={onOpenSearch}>
             <Search size={15} />
           </IconButton>
           <IconButton
             label='新建文件'
-            onClick={() => setInlineAction({ kind: 'create-file', parent: state.workspaceRoot })}
+            onClick={() => updateInlineAction({ kind: 'create-file', parent: state.workspaceRoot })}
           >
             <Plus size={15} />
           </IconButton>
           <IconButton
             label='新建文件夹'
-            onClick={() => setInlineAction({ kind: 'create-directory', parent: state.workspaceRoot })}
+            onClick={() => updateInlineAction({ kind: 'create-directory', parent: state.workspaceRoot })}
           >
             <FolderPlus size={15} />
           </IconButton>
@@ -92,6 +157,8 @@ export function WorkspaceExplorer({ actions, onOpenSearch }: { actions: Workspac
         className='workspace-tree'
         role='tree'
         aria-label='工作区文件树'
+        aria-orientation='vertical'
+        onKeyDown={handleKeyDown}
         onContextMenu={(event) => {
           event.preventDefault();
           setContextMenu({ entry: null, x: event.clientX, y: event.clientY });
@@ -101,11 +168,16 @@ export function WorkspaceExplorer({ actions, onOpenSearch }: { actions: Workspac
           directory={state.workspaceRoot}
           query={query}
           depth={0}
+          tree={tree}
+          activePath={activePath}
+          rovingPath={rovingPath}
           actions={actions}
           inlineAction={inlineAction}
           contextMenuPath={contextMenu?.entry?.path ?? null}
           onInlineAction={updateInlineAction}
           onContextMenu={(entry, x, y) => setContextMenu({ entry, x, y })}
+          onEntryFocus={setFocusedPath}
+          onEntryRef={registerItem}
         />
       </div>
       {contextMenu && (
@@ -125,43 +197,36 @@ function Directory({
   directory,
   query,
   depth,
+  tree,
+  activePath,
+  rovingPath,
   actions,
   inlineAction,
   contextMenuPath,
   onInlineAction,
   onContextMenu,
+  onEntryFocus,
+  onEntryRef,
 }: {
   directory: string;
   query: string;
   depth: number;
+  tree: ExplorerTreeProjection;
+  activePath: string | null;
+  rovingPath: string | null;
   actions: WorkspaceActions;
   inlineAction: WorkspaceInlineAction | null;
   contextMenuPath: string | null;
   onInlineAction: (action: WorkspaceInlineAction | null) => void;
   onContextMenu: (entry: Readonly<WorkspaceEntry>, x: number, y: number) => void;
+  onEntryFocus: (path: string) => void;
+  onEntryRef: (path: string, element: HTMLButtonElement | null) => void;
 }) {
   const state = useSnapshot(appState);
-  const activeTab = state.editorTabs.find((tab) => tab.id === state.activeEditorTabId);
-  const activePath =
-    activeTab?.kind === 'file'
-      ? activeTab.path
-      : activeTab?.kind === 'diff'
-        ? absoluteWorkspacePath(activeTab.path, state.workspaceRoot)
-        : null;
   const entries = state.filesByDirectory[directory] ?? [];
   const loading = state.directoryLoading[directory];
   const error = state.directoryErrors[directory];
-  const normalizedQuery = query.trim().toLowerCase();
-  const hasLoadedMatch = (path: string): boolean =>
-    (state.filesByDirectory[path] ?? []).some(
-      (entry) => entry.name.toLowerCase().includes(normalizedQuery) || (entry.isDirectory && hasLoadedMatch(entry.path))
-    );
-  const visible = entries.filter(
-    (entry) =>
-      !normalizedQuery ||
-      entry.name.toLowerCase().includes(normalizedQuery) ||
-      (entry.isDirectory && hasLoadedMatch(entry.path))
-  );
+  const visible = entries.filter((entry) => tree.visiblePaths.has(entry.path));
   const createAction =
     inlineAction &&
     (inlineAction.kind === 'create-file' || inlineAction.kind === 'create-directory') &&
@@ -211,26 +276,28 @@ function Directory({
             />
           );
         }
-        const expanded = Boolean(state.expandedDirectories[entry.path]);
-        const matchingDescendant = Boolean(normalizedQuery && entry.isDirectory && hasLoadedMatch(entry.path));
-        const displayExpanded = expanded || matchingDescendant;
+        const displayExpanded = tree.displayExpandedPaths.has(entry.path);
         const relativePath = normalizePath(workspaceRelativePath(entry.path, state.workspaceRoot));
         const gitFile = state.gitStatus?.files.find((file) => normalizePath(file.path) === relativePath);
         const gitDecoration = gitFile ? gitStatusDecoration(gitFile.indexStatus, gitFile.worktreeStatus) : null;
         return (
           <div className='explorer-entry' key={entry.path}>
             <button
+              ref={(element) => onEntryRef(entry.path, element)}
               type='button'
               role='treeitem'
+              data-explorer-path={entry.path}
               aria-expanded={entry.isDirectory ? displayExpanded : undefined}
               aria-level={depth + 1}
               aria-selected={activePath === entry.path}
+              tabIndex={rovingPath === entry.path ? 0 : -1}
               className={`explorer-row ${activePath === entry.path ? 'active' : ''} ${contextMenuPath === entry.path ? 'contextual' : ''}`}
               style={{ paddingLeft: 9 + depth * 14 }}
               onClick={() => {
                 if (entry.isDirectory) void actions.toggleDirectory(entry.path);
                 else void actions.selectFile(entry);
               }}
+              onFocus={() => onEntryFocus(entry.path)}
               onContextMenu={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
@@ -238,6 +305,16 @@ function Directory({
                 onContextMenu(entry, event.clientX, event.clientY);
               }}
               onKeyDown={(event) => {
+                if (event.key === 'F2') {
+                  event.preventDefault();
+                  onInlineAction({ kind: 'rename', entry });
+                  return;
+                }
+                if (event.key === 'Delete') {
+                  event.preventDefault();
+                  onInlineAction({ kind: 'delete', entry });
+                  return;
+                }
                 if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return;
                 event.preventDefault();
                 const bounds = event.currentTarget.getBoundingClientRect();
@@ -264,11 +341,16 @@ function Directory({
                 directory={entry.path}
                 query={query}
                 depth={depth + 1}
+                tree={tree}
+                activePath={activePath}
+                rovingPath={rovingPath}
                 actions={actions}
                 inlineAction={inlineAction}
                 contextMenuPath={contextMenuPath}
                 onInlineAction={onInlineAction}
                 onContextMenu={onContextMenu}
+                onEntryFocus={onEntryFocus}
+                onEntryRef={onEntryRef}
               />
             )}
           </div>
@@ -342,7 +424,9 @@ function contextMenuItems(
     {
       id: 'rename',
       label: '重命名',
+      ariaLabel: '重命名',
       icon: <Pencil size={14} />,
+      shortcut: 'F2',
       separatorBefore: true,
       onSelect: () => onInlineAction({ kind: 'rename', entry }),
     },
@@ -355,7 +439,9 @@ function contextMenuItems(
     {
       id: 'delete',
       label: '删除',
+      ariaLabel: '删除',
       icon: <Trash2 size={14} />,
+      shortcut: 'Delete',
       danger: true,
       separatorBefore: true,
       onSelect: () => onInlineAction({ kind: 'delete', entry }),

--- a/apps/web/src/features/workspace/components/workspace-flow.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-flow.test.tsx
@@ -1,14 +1,16 @@
 import { act, cleanup, fireEvent, render, renderHook, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, codeApi } from '../../../lib/api';
+import { appState, switchActiveTask } from '../../../state/app-state';
 import { WorkspacePage } from '../../code/pages/workspace-page';
-import { appState } from '../../../state/app-state';
-import type { WorkspaceActions } from '../workspace-actions';
-import { WorkspaceExplorer } from './workspace-explorer';
-import { WorkspaceEditor } from './workspace-editor';
-import { WorkspaceSearchPanel } from './workspace-search-panel';
 import { useWorkspaceController } from '../use-workspace-controller';
-import { codeApi } from '../../../lib/api';
+import type { WorkspaceActions } from '../workspace-actions';
+import { DEFAULT_WORKSPACE_SEARCH_EXCLUDE_PATTERN } from '../workspace-search';
 import { fileEditorTabId, type WorkspaceFileEditorTab } from '../workspace-state';
+import { clearWorkspaceEditorModels, workspaceEditorModelPath } from './monaco-editor-model-store';
+import { WorkspaceEditor } from './workspace-editor';
+import { WorkspaceExplorer } from './workspace-explorer';
+import { WorkspaceSearchPanel } from './workspace-search-panel';
 
 describe('Workspace review flow', () => {
   afterEach(() => {
@@ -18,7 +20,25 @@ describe('Workspace review flow', () => {
     appState.activeEditorTabId = null;
     appState.pendingEditorTabCloseId = null;
     appState.fileConflict = null;
+    appState.workspaceSearchResults = [];
+    appState.workspaceSearchQuery = '';
+    appState.workspaceSearchScope = 'source';
+    appState.workspaceSearchResultScope = null;
+    appState.workspaceSearchResultRoot = null;
+    appState.workspaceSearchResultsTruncated = false;
+    appState.workspaceSearchLoading = false;
     appState.workspaceSearchError = null;
+    appState.workspaceReplaceLoading = false;
+    appState.filesByDirectory = {};
+    appState.expandedDirectories = {};
+    appState.directoryLoading = {};
+    appState.directoryErrors = {};
+    appState.workspaceSnapshotsByTask = {};
+    appState.workspaceGeneration = 0;
+    appState.activeSessionId = null;
+    appState.sessions = [];
+    appState.draftsByTask = {};
+    clearWorkspaceEditorModels();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -59,6 +79,22 @@ describe('Workspace review flow', () => {
     const preserved = appState.editorTabs.find((tab) => tab.id === current.id);
     expect(preserved?.kind === 'file' ? preserved.draft : null).toBe('unsaved');
     expect(appState.activeEditorTabId).toBe(fileEditorTabId('/repo/next.ts'));
+    hook.unmount();
+  });
+
+  it('opens binary metadata without requesting text content', async () => {
+    const readFile = vi.spyOn(codeApi, 'readFile');
+    const hook = renderHook(() => useWorkspaceController());
+
+    await act(() => hook.result.current.selectFile({ path: '/repo/logo.png', isBinary: true }));
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(activeFileTab()).toMatchObject({
+      path: '/repo/logo.png',
+      isBinary: true,
+      loading: false,
+      loadError: null,
+    });
     hook.unmount();
   });
 
@@ -176,6 +212,8 @@ describe('Workspace review flow', () => {
     appState.workspaceRoot = '/repo';
     appState.workspaceSearchQuery = 'oldValue';
     appState.workspaceSearchLoading = false;
+    appState.workspaceSearchResultScope = 'source';
+    appState.workspaceSearchResultRoot = '/repo';
     appState.workspaceReplaceLoading = false;
     appState.workspaceSearchResults = [
       {
@@ -199,6 +237,8 @@ describe('Workspace review flow', () => {
     appState.workspaceRoot = '/repo';
     appState.workspaceSearchQuery = 'oldValue';
     appState.workspaceSearchLoading = false;
+    appState.workspaceSearchResultScope = 'source';
+    appState.workspaceSearchResultRoot = '/repo';
     appState.workspaceSearchResults = [
       {
         path: '/repo/app.ts',
@@ -224,13 +264,84 @@ describe('Workspace review flow', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('搜索失败');
     expect(screen.queryByText(/没有匹配结果/)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '重新搜索' }));
-    expect(searchWorkspace).toHaveBeenCalledWith('target');
+    expect(searchWorkspace).toHaveBeenCalledWith('target', { scope: 'source' });
+  });
+
+  it('searches the source scope by default', () => {
+    appState.workspaceRoot = '/repo';
+    const searchWorkspace = vi.fn(async () => undefined);
+
+    render(<WorkspaceSearchPanel actions={{ searchWorkspace } as unknown as WorkspaceActions} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: '全局搜索内容' }), { target: { value: 'target' } });
+    fireEvent.click(screen.getByRole('button', { name: '搜索' }));
+
+    expect(searchWorkspace).toHaveBeenCalledWith('target', { scope: 'source' });
+    expect(screen.getByRole('checkbox', { name: '包含依赖与构建目录' })).not.toBeChecked();
+  });
+
+  it('reruns the current query when dependency and build directories are included', () => {
+    appState.workspaceRoot = '/repo';
+    appState.workspaceSearchQuery = 'target';
+    appState.workspaceSearchScope = 'source';
+    appState.workspaceSearchResultScope = 'source';
+    appState.workspaceSearchResultRoot = '/repo';
+    appState.workspaceSearchResults = [
+      {
+        path: '/repo/src/app.ts',
+        matches: [{ line: 1, column: 1, text: 'target', matchStart: 0, matchEnd: 6 }],
+      },
+    ];
+    const searchWorkspace = vi.fn(async () => undefined);
+
+    render(<WorkspaceSearchPanel actions={{ searchWorkspace } as unknown as WorkspaceActions} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: '包含依赖与构建目录' }));
+
+    expect(searchWorkspace).toHaveBeenCalledWith('target', { scope: 'all' });
+    expect(screen.getByRole('button', { name: '替换全部' })).toBeDisabled();
+    expect(screen.getByText('搜索范围已变化；重新搜索后才能替换。')).toBeInTheDocument();
+  });
+
+  it('does not offer replacement when the displayed results reached the safety limit', () => {
+    appState.workspaceRoot = '/repo';
+    appState.workspaceSearchQuery = 'target';
+    appState.workspaceSearchResultScope = 'source';
+    appState.workspaceSearchResultRoot = '/repo';
+    appState.workspaceSearchResultsTruncated = true;
+    appState.workspaceSearchResults = [
+      {
+        path: '/repo/src/app.ts',
+        matches: [{ line: 1, column: 1, text: 'target', matchStart: 0, matchEnd: 6 }],
+      },
+    ];
+
+    render(<WorkspaceSearchPanel actions={{} as WorkspaceActions} onClose={vi.fn()} />);
+
+    expect(screen.getByText('结果超过 300 处；请缩小搜索范围后再替换。')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '替换全部' })).toBeDisabled();
+  });
+
+  it('preserves the selected search scope when the panel is reopened', async () => {
+    appState.workspaceRoot = '/repo';
+    const searchWorkspace = vi.fn(async (_query: string, options: { scope: 'source' | 'all' }) => {
+      appState.workspaceSearchScope = options.scope;
+    });
+    const actions = { searchWorkspace } as unknown as WorkspaceActions;
+    const first = render(<WorkspaceSearchPanel actions={actions} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '包含依赖与构建目录' }));
+    await waitFor(() => expect(appState.workspaceSearchScope).toBe('all'));
+    first.unmount();
+    render(<WorkspaceSearchPanel actions={actions} onClose={vi.fn()} />);
+
+    expect(screen.getByRole('checkbox', { name: '包含依赖与构建目录' })).toBeChecked();
   });
 
   it('blocks workspace replacement when the reviewed scope contains unsaved edits', () => {
     appState.workspaceRoot = '/repo';
     appState.workspaceSearchQuery = 'oldValue';
     appState.workspaceSearchLoading = false;
+    appState.workspaceSearchResultScope = 'source';
+    appState.workspaceSearchResultRoot = '/repo';
     appState.workspaceSearchResults = [
       {
         path: '/repo/app.ts',
@@ -256,6 +367,7 @@ describe('Workspace review flow', () => {
     const selectFile = vi.fn(async () => true);
     const onClose = vi.fn();
     render(<WorkspaceSearchPanel actions={{ selectFile } as unknown as WorkspaceActions} onClose={onClose} />);
+    expect(screen.getByText('target', { selector: 'mark' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '打开 app.ts 第 8 行' }));
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
     expect(selectFile).toHaveBeenCalledWith({ path: '/repo/app.ts', isBinary: false, line: 8, column: 4 });
@@ -304,27 +416,30 @@ describe('Workspace review flow', () => {
 
   it('detects external file changes before saving and preserves both versions', async () => {
     const tab = setOpenFileTab('/repo/app.ts', 'original', 'local edit');
+    tab.revision = 'sha256:original';
     appState.fileConflict = null;
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(
-        async () =>
-          new Response(JSON.stringify({ code: 200, data: { path: '/repo/app.ts', content: 'external edit' } }), {
-            status: 200,
-          })
-      )
-    );
+    const writeFile = vi.spyOn(codeApi, 'writeFile').mockRejectedValue(new ApiError('file changed', 412));
+    const readFile = vi
+      .spyOn(codeApi, 'readFile')
+      .mockResolvedValue({ content: 'external edit', revision: 'sha256:external' });
     const hook = renderHook(() => useWorkspaceController());
     await act(() => hook.result.current.saveEditorTab(tab.id));
+    expect(writeFile).toHaveBeenCalledWith('/repo/app.ts', 'local edit', {
+      expectedRevision: 'sha256:original',
+    });
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(writeFile.mock.invocationCallOrder[0]).toBeLessThan(readFile.mock.invocationCallOrder[0]);
     expect(appState.fileConflict).toEqual({
       tabId: tab.id,
       path: '/repo/app.ts',
       diskContent: 'external edit',
+      diskRevision: 'sha256:external',
     });
     expect(activeFileTab()?.draft).toBe('local edit');
     await act(() => hook.result.current.resolveFileConflict('reload'));
     expect(activeFileTab()?.content).toBe('external edit');
     expect(activeFileTab()?.draft).toBe('external edit');
+    expect(activeFileTab()?.revision).toBe('sha256:external');
     hook.unmount();
   });
 
@@ -339,9 +454,225 @@ describe('Workspace review flow', () => {
     hook.unmount();
   });
 
+  it('excludes dependency and build directories from workspace search by default', async () => {
+    appState.workspaceRoot = '/repo';
+    const searchWorkspace = vi.spyOn(codeApi, 'searchWorkspace').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    await act(() => hook.result.current.searchWorkspace(' target ', { scope: 'source' }));
+
+    expect(searchWorkspace).toHaveBeenCalledWith('/repo', 'target', {
+      excludePattern: DEFAULT_WORKSPACE_SEARCH_EXCLUDE_PATTERN,
+      maxResults: 301,
+    });
+    expect(appState.workspaceSearchQuery).toBe('target');
+    expect(appState.workspaceSearchScope).toBe('source');
+    expect(appState.workspaceSearchResultScope).toBe('source');
+    expect(appState.workspaceSearchResultRoot).toBe('/repo');
+    hook.unmount();
+  });
+
+  it('can deliberately search dependency and build directories', async () => {
+    appState.workspaceRoot = '/repo';
+    const searchWorkspace = vi.spyOn(codeApi, 'searchWorkspace').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    await act(() => hook.result.current.searchWorkspace('target', { scope: 'all' }));
+
+    expect(searchWorkspace).toHaveBeenCalledWith('/repo', 'target', { maxResults: 301 });
+    expect(appState.workspaceSearchScope).toBe('all');
+    expect(appState.workspaceSearchResultScope).toBe('all');
+    hook.unmount();
+  });
+
+  it('keeps one overflow match only as a replacement-safety signal', async () => {
+    appState.workspaceRoot = '/repo';
+    const matches = Array.from({ length: 301 }, (_, index) => ({
+      line: index + 1,
+      column: 1,
+      text: 'target',
+      matchStart: 0,
+      matchEnd: 6,
+    }));
+    vi.spyOn(codeApi, 'searchWorkspace').mockResolvedValue([{ path: '/repo/src/app.ts', matches }]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    await act(() => hook.result.current.searchWorkspace('target', { scope: 'source' }));
+
+    expect(appState.workspaceSearchResults[0]?.matches).toHaveLength(300);
+    expect(appState.workspaceSearchResultsTruncated).toBe(true);
+    hook.unmount();
+  });
+
+  it('keeps the latest search scope when an older request finishes last', async () => {
+    appState.workspaceRoot = '/repo';
+    type SearchResults = Awaited<ReturnType<typeof codeApi.searchWorkspace>>;
+    let resolveSource!: (results: SearchResults) => void;
+    let resolveAll!: (results: SearchResults) => void;
+    const sourceResponse = new Promise<SearchResults>((resolve) => {
+      resolveSource = resolve;
+    });
+    const allResponse = new Promise<SearchResults>((resolve) => {
+      resolveAll = resolve;
+    });
+    vi.spyOn(codeApi, 'searchWorkspace').mockImplementation((_root, _query, options) =>
+      options?.excludePattern ? sourceResponse : allResponse
+    );
+    const hook = renderHook(() => useWorkspaceController());
+
+    const sourceRequest = hook.result.current.searchWorkspace('target', { scope: 'source' });
+    const allRequest = hook.result.current.searchWorkspace('target', { scope: 'all' });
+    await act(async () => {
+      resolveAll([
+        {
+          path: '/repo/node_modules/pkg/index.ts',
+          matches: [{ line: 1, column: 1, text: 'target', matchStart: 0, matchEnd: 6 }],
+        },
+      ]);
+      await allRequest;
+    });
+    await act(async () => {
+      resolveSource([
+        {
+          path: '/repo/src/app.ts',
+          matches: [{ line: 2, column: 1, text: 'target', matchStart: 0, matchEnd: 6 }],
+        },
+      ]);
+      await sourceRequest;
+    });
+
+    expect(appState.workspaceSearchResultScope).toBe('all');
+    expect(appState.workspaceSearchResults.map((result) => result.path)).toEqual(['/repo/node_modules/pkg/index.ts']);
+    hook.unmount();
+  });
+
+  it('walks backward and forward through file locations without reloading open drafts', async () => {
+    appState.workspaceRoot = '/repo';
+    const source = setOpenFileTab('/repo/source.ts', 'source saved', 'source draft');
+    const readFile = vi.spyOn(codeApi, 'readFile').mockResolvedValue({ content: 'target saved' });
+    const hook = renderHook(() => useWorkspaceController());
+
+    expect(hook.result.current.canNavigateEditorBack).toBe(false);
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    act(() => hook.result.current.updateEditorPosition(source.id, { line: 4, column: 7 }));
+    await act(() => hook.result.current.selectFile({ path: '/repo/target.ts', isBinary: false, line: 12, column: 4 }));
+
+    expect(hook.result.current.canNavigateEditorBack).toBe(true);
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    act(() => hook.result.current.updateEditorPosition(fileEditorTabId('/repo/target.ts'), { line: 12, column: 4 }));
+    await act(() => hook.result.current.navigateEditorBack());
+
+    expect(activeFileTab()?.path).toBe('/repo/source.ts');
+    expect(activeFileTab()?.draft).toBe('source draft');
+    expect(activeFileTab()?.location).toEqual({ line: 4, column: 7 });
+    expect(hook.result.current.canNavigateEditorBack).toBe(false);
+    expect(hook.result.current.canNavigateEditorForward).toBe(true);
+
+    await act(() => hook.result.current.navigateEditorForward());
+
+    expect(activeFileTab()?.path).toBe('/repo/target.ts');
+    expect(activeFileTab()?.location).toEqual({ line: 12, column: 4 });
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(hook.result.current.canNavigateEditorBack).toBe(true);
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    hook.unmount();
+  });
+
+  it('does not add a navigation entry when the active file is selected without a target location', async () => {
+    appState.workspaceRoot = '/repo';
+    const tab = setOpenFileTab('/repo/app.ts', 'saved');
+    const hook = renderHook(() => useWorkspaceController());
+    act(() => hook.result.current.updateEditorPosition(tab.id, { line: 3, column: 2 }));
+
+    await act(() => hook.result.current.selectFile({ path: '/repo/app.ts', isBinary: false }));
+
+    expect(hook.result.current.canNavigateEditorBack).toBe(false);
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    hook.unmount();
+  });
+
+  it('starts a new location branch after going back', async () => {
+    appState.workspaceRoot = '/repo';
+    const source = setOpenFileTab('/repo/source.ts', 'source');
+    vi.spyOn(codeApi, 'readFile').mockImplementation(async (path) => ({ content: `content for ${path}` }));
+    const hook = renderHook(() => useWorkspaceController());
+    act(() => hook.result.current.updateEditorPosition(source.id, { line: 2, column: 3 }));
+    await act(() => hook.result.current.selectFile({ path: '/repo/first-target.ts', isBinary: false }));
+    await act(() => hook.result.current.navigateEditorBack());
+
+    expect(hook.result.current.canNavigateEditorForward).toBe(true);
+    await act(() => hook.result.current.selectFile({ path: '/repo/new-target.ts', isBinary: false }));
+
+    expect(activeFileTab()?.path).toBe('/repo/new-target.ts');
+    expect(hook.result.current.canNavigateEditorBack).toBe(true);
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    hook.unmount();
+  });
+
+  it('clears editor location history when the workspace changes', async () => {
+    appState.workspaceRoot = '/repo';
+    setOpenFileTab('/repo/source.ts', 'source');
+    vi.spyOn(codeApi, 'readFile').mockResolvedValue({ content: 'target' });
+    const hook = renderHook(() => useWorkspaceController());
+    await act(() => hook.result.current.selectFile({ path: '/repo/target.ts', isBinary: false }));
+    expect(hook.result.current.canNavigateEditorBack).toBe(true);
+
+    act(() => {
+      appState.workspaceRoot = '/other';
+    });
+
+    await waitFor(() => expect(hook.result.current.canNavigateEditorBack).toBe(false));
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    hook.unmount();
+  });
+
+  it('clears editor location history when switching between tasks in the same workspace', async () => {
+    appState.sessions = [taskSession('task-a', '/repo'), taskSession('task-b', '/repo')];
+    appState.activeSessionId = 'task-a';
+    appState.workspaceRoot = '/repo';
+    setOpenFileTab('/repo/source.ts', 'source');
+    vi.spyOn(codeApi, 'readFile').mockResolvedValue({ content: 'target' });
+    const hook = renderHook(() => useWorkspaceController());
+    await act(() => hook.result.current.selectFile({ path: '/repo/target.ts', isBinary: false }));
+    expect(hook.result.current.canNavigateEditorBack).toBe(true);
+
+    act(() => {
+      switchActiveTask('task-b');
+    });
+
+    await waitFor(() => expect(hook.result.current.canNavigateEditorBack).toBe(false));
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    hook.unmount();
+  });
+
+  it('drops an unreadable closed history target without replacing the active editor', async () => {
+    appState.workspaceRoot = '/repo';
+    const source = setOpenFileTab('/repo/source.ts', 'source');
+    const readFile = vi.spyOn(codeApi, 'readFile').mockResolvedValueOnce({ content: 'target' });
+    const hook = renderHook(() => useWorkspaceController());
+    act(() => hook.result.current.updateEditorPosition(source.id, { line: 2, column: 3 }));
+    await act(() => hook.result.current.selectFile({ path: '/repo/target.ts', isBinary: false }));
+    act(() => hook.result.current.closeEditorTab(source.id));
+    readFile.mockRejectedValueOnce(new Error('missing'));
+
+    await act(() => hook.result.current.navigateEditorBack());
+
+    expect(activeFileTab()?.path).toBe('/repo/target.ts');
+    expect(hook.result.current.canNavigateEditorBack).toBe(false);
+    expect(hook.result.current.canNavigateEditorForward).toBe(false);
+    hook.unmount();
+  });
+
   it('rebases the open file and conflict state when a parent directory is renamed', async () => {
+    appState.editorModelScope = 'rename-scope';
     const tab = setOpenFileTab('/repo/src/app.ts', 'saved', 'saved', { line: 2, column: 1 });
-    appState.fileConflict = { tabId: tab.id, path: '/repo/src/app.ts', diskContent: 'external' };
+    const modelPath = workspaceEditorModelPath(appState.editorModelScope, tab.path);
+    appState.fileConflict = {
+      tabId: tab.id,
+      path: '/repo/src/app.ts',
+      diskContent: 'external',
+      diskRevision: null,
+    };
     vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
     vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
     const hook = renderHook(() => useWorkspaceController());
@@ -350,6 +681,44 @@ describe('Workspace review flow', () => {
     expect(activeFileTab()?.location).toEqual({ line: 2, column: 1 });
     expect(appState.activeEditorTabId).toBe(fileEditorTabId('/repo/lib/app.ts'));
     expect(appState.fileConflict?.path).toBe('/repo/lib/app.ts');
+    expect(workspaceEditorModelPath(appState.editorModelScope, '/repo/lib/app.ts')).toBe(modelPath);
+    hook.unmount();
+  });
+
+  it('rebases saved navigation locations when a parent directory is renamed', async () => {
+    appState.workspaceRoot = '/repo';
+    const source = setOpenFileTab('/repo/src/source.ts', 'source');
+    vi.spyOn(codeApi, 'readFile').mockResolvedValue({ content: 'target' });
+    vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+    act(() => hook.result.current.updateEditorPosition(source.id, { line: 6, column: 5 }));
+    await act(() => hook.result.current.selectFile({ path: '/repo/target.ts', isBinary: false }));
+
+    await act(() => hook.result.current.renameWorkspaceEntry('/repo/src', 'lib'));
+    await act(() => hook.result.current.navigateEditorBack());
+
+    expect(activeFileTab()?.path).toBe('/repo/lib/source.ts');
+    expect(activeFileTab()?.location).toEqual({ line: 6, column: 5 });
+    hook.unmount();
+  });
+
+  it('prunes deleted paths from editor location history', async () => {
+    appState.workspaceRoot = '/repo';
+    const source = setOpenFileTab('/repo/source.ts', 'source');
+    vi.spyOn(codeApi, 'readFile').mockImplementation(async (path) => ({ content: `content for ${path}` }));
+    vi.spyOn(codeApi, 'deletePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+    act(() => hook.result.current.updateEditorPosition(source.id, { line: 3, column: 4 }));
+    await act(() => hook.result.current.selectFile({ path: '/repo/deleted/target.ts', isBinary: false }));
+    await act(() => hook.result.current.selectFile({ path: '/repo/current.ts', isBinary: false }));
+
+    await act(() => hook.result.current.deleteWorkspaceEntry('/repo/deleted'));
+    await act(() => hook.result.current.navigateEditorBack());
+
+    expect(activeFileTab()?.path).toBe('/repo/source.ts');
+    expect(activeFileTab()?.location).toEqual({ line: 3, column: 4 });
     hook.unmount();
   });
 
@@ -372,11 +741,72 @@ describe('Workspace review flow', () => {
   it('places the editor caret at the selected search match', () => {
     appState.reviewIntent = 'review';
     setOpenFileTab('/repo/app.ts', 'one\ntarget', 'one\ntarget', { line: 2, column: 2 });
+    const consumeEditorLocation = (tabId: string) => {
+      const tab = appState.editorTabs.find((candidate) => candidate.id === tabId);
+      if (tab?.kind === 'file') tab.location = null;
+    };
 
-    render(<WorkspaceEditor actions={{} as WorkspaceActions} />);
+    render(<WorkspaceEditor actions={{ consumeEditorLocation } as WorkspaceActions} />);
     const editor = screen.getByRole('textbox', { name: '编辑 app.ts' }) as HTMLTextAreaElement;
     expect(editor).toHaveFocus();
     expect(editor.selectionStart).toBe(5);
+    expect(activeFileTab()?.location).toBeNull();
+  });
+
+  it('exposes saved-document code navigation from the file toolbar', async () => {
+    appState.reviewIntent = 'review';
+    appState.workspaceRoot = '/repo';
+    setOpenFileTab('/repo/src/app.ts', 'export const value = target;');
+    vi.spyOn(codeApi, 'codeIntelligenceStatus').mockResolvedValue({
+      state: 'ready',
+      capabilities: {
+        documentSymbols: true,
+        workspaceSymbols: true,
+        definition: true,
+        declaration: true,
+        references: true,
+        implementations: true,
+        diagnostics: true,
+      },
+      languages: [],
+      message: null,
+    });
+    vi.spyOn(codeApi, 'codeDiagnostics').mockResolvedValue({
+      items: [],
+      truncated: false,
+      workspaceRevision: 2,
+      document: { revision: 2, contentHash: 'hash', stale: false },
+    });
+    const navigate = vi.spyOn(codeApi, 'codeNavigation').mockResolvedValue({
+      items: [],
+      truncated: false,
+      workspaceRevision: 2,
+      document: { revision: 2, contentHash: 'hash', stale: false },
+    });
+
+    render(
+      <WorkspaceEditor
+        actions={
+          {
+            selectFile: vi.fn(async () => true),
+            updateEditorDraft: vi.fn(),
+          } as unknown as WorkspaceActions
+        }
+      />
+    );
+
+    const trigger = await screen.findByRole('button', { name: '代码导航' });
+    await waitFor(() => expect(trigger).toBeEnabled());
+    fireEvent.click(trigger);
+    const menu = screen.getByRole('menu', { name: '代码导航' });
+    expect(within(menu).getByRole('menuitem', { name: /转到定义/ })).toHaveTextContent('F12');
+    expect(within(menu).getByRole('menuitem', { name: /转到声明/ })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /查找引用/ })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /转到实现/ })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /文件符号大纲/ })).toBeInTheDocument();
+
+    fireEvent.click(within(menu).getByRole('menuitem', { name: /转到定义/ }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('src/app.ts', 0, 0, 'definition', expect.any(Object)));
   });
 
   it('never exposes a binary file as editable text', () => {
@@ -475,6 +905,7 @@ function setOpenFileTab(
     path,
     content,
     draft,
+    revision: null,
     isBinary,
     location,
     loading: false,
@@ -490,4 +921,17 @@ function setOpenFileTab(
 function activeFileTab(): WorkspaceFileEditorTab | null {
   const tab = appState.editorTabs.find((candidate) => candidate.id === appState.activeEditorTabId);
   return tab?.kind === 'file' ? tab : null;
+}
+
+function taskSession(sessionId: string, workspace: string) {
+  return {
+    sessionId,
+    workspace,
+    cwd: workspace,
+    model: 'codex/gpt',
+    followDefaultModel: false,
+    permissionMode: 'default',
+    state: 'idle',
+    createdAt: 1,
+  };
 }

--- a/apps/web/src/features/workspace/components/workspace-inline-entry.tsx
+++ b/apps/web/src/features/workspace/components/workspace-inline-entry.tsx
@@ -27,13 +27,18 @@ export function WorkspaceInlineEntry({
   const [touched, setTouched] = useState(false);
   const [operationError, setOperationError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const deleteCancelRef = useRef<HTMLButtonElement>(null);
   const nameError = validateWorkspaceEntryName(name);
   const unchanged = action.kind === 'rename' && name.trim() === action.entry.name;
 
   useEffect(() => {
+    if (action.kind === 'delete') {
+      deleteCancelRef.current?.focus();
+      return;
+    }
     inputRef.current?.focus();
     inputRef.current?.select();
-  }, []);
+  }, [action.kind]);
 
   if (action.kind === 'delete') {
     return (
@@ -49,7 +54,7 @@ export function WorkspaceInlineEntry({
             {dirtyDescendant ? '包含未保存编辑' : action.entry.isDirectory ? '同时删除内部内容' : '此操作无法撤销'}
           </small>
         </span>
-        <button type='button' disabled={busy} onClick={onComplete}>
+        <button ref={deleteCancelRef} type='button' disabled={busy} onClick={onComplete}>
           取消
         </button>
         <button

--- a/apps/web/src/features/workspace/components/workspace-quick-open.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-quick-open.test.tsx
@@ -1,0 +1,132 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appState } from '../../../state/app-state';
+import type { WorkspaceFileCatalog } from '../../../types/api';
+import type { WorkspaceActions } from '../workspace-actions';
+import { fileEditorTabId } from '../workspace-state';
+import { WorkspaceQuickOpen } from './workspace-quick-open';
+
+describe('WorkspaceQuickOpen', () => {
+  beforeEach(() => {
+    appState.activeSessionId = 'task-1';
+    appState.workspaceRoot = '/repo';
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    appState.fileQuickOpenOpen = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    appState.activeSessionId = null;
+    appState.workspaceRoot = '';
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    appState.fileQuickOpenOpen = false;
+  });
+
+  it('puts open files first and opens the keyboard-selected result', async () => {
+    const readmeId = fileEditorTabId('/repo/README.md');
+    appState.editorTabs = [fileTab('/repo/README.md')];
+    appState.activeEditorTabId = readmeId;
+    const findWorkspaceFiles = vi
+      .fn()
+      .mockResolvedValue(catalog([file('/repo/src/app.ts', 'src/app.ts'), file('/repo/README.md', 'README.md')]));
+    const selectFile = vi.fn().mockResolvedValue(true);
+
+    render(<WorkspaceQuickOpen actions={{ findWorkspaceFiles, selectFile } as unknown as WorkspaceActions} />);
+
+    const input = screen.getByRole('combobox', { name: '按文件名或路径搜索' });
+    expect(input).toHaveFocus();
+    await screen.findByRole('option', { name: /README\.md/ });
+    await screen.findByRole('option', { name: /app\.ts/ });
+    expect(screen.getAllByRole('option')[0]).toHaveAccessibleName(/README\.md.*已打开/);
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(selectFile).toHaveBeenCalledWith({ path: '/repo/src/app.ts', isBinary: false }));
+    expect(appState.fileQuickOpenOpen).toBe(false);
+  });
+
+  it('publishes only the newest debounced query response', async () => {
+    const first = deferred<WorkspaceFileCatalog>();
+    const second = deferred<WorkspaceFileCatalog>();
+    const findWorkspaceFiles = vi.fn((query: string) => {
+      if (!query) return Promise.resolve(catalog([]));
+      return query === 'a' ? first.promise : second.promise;
+    });
+
+    render(<WorkspaceQuickOpen actions={{ findWorkspaceFiles, selectFile: vi.fn() } as unknown as WorkspaceActions} />);
+    const input = screen.getByRole('combobox', { name: '按文件名或路径搜索' });
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => expect(findWorkspaceFiles).toHaveBeenCalledWith('a', 120));
+    fireEvent.change(input, { target: { value: 'app' } });
+    await waitFor(() => expect(findWorkspaceFiles).toHaveBeenCalledWith('app', 120));
+
+    await act(async () => second.resolve(catalog([file('/repo/src/app.ts', 'src/app.ts')])));
+    expect(await screen.findByRole('option', { name: /app\.ts/ })).toBeInTheDocument();
+    await act(async () => first.resolve(catalog([file('/repo/archive.txt', 'archive.txt')])));
+    expect(screen.queryByRole('option', { name: /archive\.txt/ })).not.toBeInTheDocument();
+  });
+
+  it('reports truncation and retries a recoverable catalog failure', async () => {
+    const findWorkspaceFiles = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('index unavailable'))
+      .mockResolvedValueOnce({
+        ...catalog([file('/repo/src/recovered.ts', 'src/recovered.ts')]),
+        total: 321,
+        truncated: true,
+      });
+
+    render(<WorkspaceQuickOpen actions={{ findWorkspaceFiles, selectFile: vi.fn() } as unknown as WorkspaceActions} />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('index unavailable');
+    fireEvent.click(screen.getByRole('button', { name: /重试/ }));
+    expect(await screen.findByRole('option', { name: /recovered\.ts/ })).toBeInTheDocument();
+    expect(screen.getByText('显示前 1 / 321 个结果，请继续输入以缩小范围')).toBeInTheDocument();
+  });
+
+  it('announces binary file status as part of the result name', async () => {
+    const findWorkspaceFiles = vi
+      .fn()
+      .mockResolvedValue(catalog([file('/repo/public/logo.png', 'public/logo.png', true)]));
+
+    render(<WorkspaceQuickOpen actions={{ findWorkspaceFiles, selectFile: vi.fn() } as unknown as WorkspaceActions} />);
+
+    expect(await screen.findByRole('option', { name: /logo\.png.*二进制/ })).toBeInTheDocument();
+  });
+});
+
+function catalog(items: WorkspaceFileCatalog['items']): WorkspaceFileCatalog {
+  return { workspaceRoot: '/repo', items, total: items.length, truncated: false };
+}
+
+function file(path: string, relativePath: string, isBinary = false) {
+  return { path, relativePath, name: relativePath.split('/').pop() ?? relativePath, isBinary };
+}
+
+function fileTab(path: string) {
+  return {
+    id: fileEditorTabId(path),
+    kind: 'file' as const,
+    path,
+    content: '',
+    draft: '',
+    revision: null,
+    isBinary: false,
+    location: null,
+    loading: false,
+    loadError: null,
+    saving: false,
+    configValidation: null,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}

--- a/apps/web/src/features/workspace/components/workspace-quick-open.tsx
+++ b/apps/web/src/features/workspace/components/workspace-quick-open.tsx
@@ -1,0 +1,317 @@
+import { LoaderCircle, RotateCcw, Search } from 'lucide-react';
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useSnapshot } from 'valtio';
+import { appState, formatApiError } from '../../../state/app-state';
+import type { WorkspaceFileCatalog, WorkspaceFileCatalogItem } from '../../../types/api';
+import type { WorkspaceActions } from '../workspace-actions';
+import { normalizePath, workspaceRelativePath } from '../workspace-state';
+import { WorkspaceFileIcon } from './workspace-file-icon';
+
+const QUICK_OPEN_RESULT_LIMIT = 120;
+const QUERY_DELAY_MS = 90;
+
+export function WorkspaceQuickOpen({ actions }: { actions: WorkspaceActions }) {
+  const state = useSnapshot(appState);
+  const [query, setQuery] = useState('');
+  const [catalog, setCatalog] = useState<WorkspaceFileCatalog | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [openingPath, setOpeningPath] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const selectedIndexRef = useRef(0);
+  const requestIdRef = useRef(0);
+  const mountedRef = useRef(true);
+  const resultId = useId();
+  const normalizedQuery = query.trim();
+
+  useEffect(() => {
+    mountedRef.current = true;
+    restoreFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    inputRef.current?.focus();
+    return () => {
+      mountedRef.current = false;
+      const previous = restoreFocusRef.current;
+      if (previous?.isConnected) previous.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    const requestId = ++requestIdRef.current;
+    setCatalog(null);
+    setError(null);
+    setLoading(Boolean(state.workspaceRoot));
+    selectedIndexRef.current = 0;
+    setSelectedIndex(0);
+    if (!state.workspaceRoot) {
+      setError('当前任务没有可用的工作区。');
+      return;
+    }
+    const timer = window.setTimeout(
+      () => {
+        void actions
+          .findWorkspaceFiles(normalizedQuery, QUICK_OPEN_RESULT_LIMIT)
+          .then((result) => {
+            if (requestId !== requestIdRef.current) return;
+            setCatalog(result);
+          })
+          .catch((reason: unknown) => {
+            if (requestId !== requestIdRef.current) return;
+            setError(formatApiError(reason));
+          })
+          .finally(() => {
+            if (requestId === requestIdRef.current) setLoading(false);
+          });
+      },
+      normalizedQuery ? QUERY_DELAY_MS : 0
+    );
+    return () => window.clearTimeout(timer);
+  }, [actions.findWorkspaceFiles, normalizedQuery, reloadToken, state.workspaceGeneration, state.workspaceRoot]);
+
+  const options = useMemo(
+    () =>
+      quickOpenOptions(
+        catalog?.items ?? [],
+        normalizedQuery,
+        state.editorTabs,
+        state.activeEditorTabId,
+        state.workspaceRoot
+      ),
+    [catalog?.items, normalizedQuery, state.activeEditorTabId, state.editorTabs, state.workspaceRoot]
+  );
+  const openPaths = useMemo(
+    () =>
+      new Set(
+        state.editorTabs
+          .filter((tab) => tab.kind === 'file')
+          .map((tab) => comparablePath(tab.path, state.workspaceRoot))
+      ),
+    [state.editorTabs, state.workspaceRoot]
+  );
+
+  useLayoutEffect(() => {
+    const index = Math.min(selectedIndexRef.current, Math.max(0, options.length - 1));
+    selectedIndexRef.current = index;
+    setSelectedIndex(index);
+  }, [options.length]);
+  useEffect(() => {
+    optionRefs.current[selectedIndex]?.scrollIntoView?.({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  const close = () => {
+    appState.fileQuickOpenOpen = false;
+  };
+  const moveSelection = (offset: number) => {
+    if (!options.length) return;
+    const index = (selectedIndexRef.current + offset + options.length) % options.length;
+    selectedIndexRef.current = index;
+    setSelectedIndex(index);
+  };
+  const selectIndex = (index: number) => {
+    selectedIndexRef.current = index;
+    setSelectedIndex(index);
+  };
+  const choose = async (item: WorkspaceFileCatalogItem) => {
+    if (openingPath) return;
+    setOpeningPath(item.path);
+    setError(null);
+    try {
+      const opened = await actions.selectFile({ path: item.path, isBinary: item.isBinary });
+      if (opened) close();
+      else if (mountedRef.current) setError(`无法打开 ${item.name}。`);
+    } catch (reason) {
+      if (mountedRef.current) setError(formatApiError(reason));
+    } finally {
+      if (mountedRef.current) setOpeningPath(null);
+    }
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      open
+      className='palette-overlay workspace-quick-open-overlay'
+      aria-modal='true'
+      aria-label='快速打开文件'
+      onCancel={(event) => {
+        event.preventDefault();
+        close();
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) close();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          event.stopPropagation();
+          close();
+          return;
+        }
+        if (event.key !== 'Tab') return;
+        const focusable = [
+          ...(dialogRef.current?.querySelectorAll<HTMLElement>('input, button:not(:disabled), [tabindex="0"]') ?? []),
+        ];
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }}
+    >
+      <section className='command-palette workspace-quick-open'>
+        <label>
+          <Search size={16} />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder='按文件名或路径搜索'
+            aria-label='按文件名或路径搜索'
+            role='combobox'
+            aria-autocomplete='list'
+            aria-controls={resultId}
+            aria-expanded='true'
+            aria-activedescendant={options[selectedIndex] ? `${resultId}-${selectedIndex}` : undefined}
+            onKeyDown={(event) => {
+              if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'p') {
+                event.preventDefault();
+                moveSelection(1);
+              } else if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                moveSelection(1);
+              } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                moveSelection(-1);
+              } else if (event.key === 'Home') {
+                event.preventDefault();
+                selectIndex(0);
+              } else if (event.key === 'End') {
+                event.preventDefault();
+                selectIndex(Math.max(0, options.length - 1));
+              } else if (event.key === 'Enter') {
+                event.preventDefault();
+                const selected = options[selectedIndexRef.current];
+                if (selected) void choose(selected);
+              }
+            }}
+          />
+          {loading && <LoaderCircle className='spin workspace-quick-open-loader' size={15} aria-label='正在查找文件' />}
+        </label>
+        <div
+          className='palette-results workspace-quick-open-results'
+          id={resultId}
+          role='listbox'
+          aria-label='工作区文件'
+          aria-busy={loading}
+        >
+          <span>FILES · {basename(state.workspaceRoot)}</span>
+          {options.map((item, index) => {
+            const selected = index === selectedIndex;
+            const open = openPaths.has(comparablePath(item.path, state.workspaceRoot));
+            return (
+              <button
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
+                type='button'
+                role='option'
+                aria-selected={selected}
+                className={selected ? 'active' : ''}
+                id={`${resultId}-${index}`}
+                key={item.path}
+                disabled={openingPath !== null}
+                onClick={() => void choose(item)}
+                onMouseEnter={() => selectIndex(index)}
+              >
+                <WorkspaceFileIcon path={item.path} size={17} />
+                <span>
+                  <strong>{item.name}</strong>
+                  <small>{directoryLabel(item.relativePath)}</small>
+                </span>
+                <span className='workspace-quick-open-badges'>
+                  {open && <em>已打开</em>}
+                  {item.isBinary && <em>二进制</em>}
+                  {openingPath === item.path && <LoaderCircle className='spin' size={13} />}
+                </span>
+              </button>
+            );
+          })}
+          {loading && !options.length && <output className='workspace-quick-open-state'>正在索引工作区文件…</output>}
+          {!loading && error && (
+            <div className='workspace-quick-open-state error' role='alert'>
+              <span>{error}</span>
+              <button type='button' onClick={() => setReloadToken((value) => value + 1)}>
+                <RotateCcw size={13} />
+                重试
+              </button>
+            </div>
+          )}
+          {!loading && !error && !options.length && (
+            <p>{normalizedQuery ? `没有匹配“${normalizedQuery}”的文件` : '工作区中没有可打开的文件'}</p>
+          )}
+        </div>
+        <footer className='workspace-quick-open-footer'>
+          <span>
+            <kbd>↑↓</kbd> 选择　<kbd>Enter</kbd> 打开　<kbd>Esc</kbd> 关闭
+          </span>
+          {catalog?.truncated && (
+            <span>
+              显示前 {catalog.items.length} / {catalog.total} 个结果，请继续输入以缩小范围
+            </span>
+          )}
+        </footer>
+      </section>
+    </dialog>
+  );
+}
+
+function quickOpenOptions(
+  catalogItems: WorkspaceFileCatalogItem[],
+  query: string,
+  tabs: ReadonlyArray<{ id: string; kind: 'file' | 'diff'; path: string; isBinary: boolean }>,
+  activeTabId: string | null,
+  workspaceRoot: string
+): WorkspaceFileCatalogItem[] {
+  if (query) return [...catalogItems];
+  const openItems = tabs
+    .filter((tab) => tab.kind === 'file')
+    .map((tab) => ({
+      id: tab.id,
+      item: {
+        path: tab.path,
+        relativePath: workspaceRelativePath(tab.path, workspaceRoot),
+        name: basename(tab.path),
+        isBinary: tab.isBinary,
+      },
+    }))
+    .sort((left, right) => Number(right.id === activeTabId) - Number(left.id === activeTabId));
+  const seen = new Set(openItems.map(({ item }) => comparablePath(item.path, workspaceRoot)));
+  return [
+    ...openItems.map(({ item }) => item),
+    ...catalogItems.filter((item) => !seen.has(comparablePath(item.path, workspaceRoot))),
+  ];
+}
+
+function comparablePath(path: string, workspaceRoot: string): string {
+  const normalized = normalizePath(path);
+  return /^[A-Za-z]:[\\/]/.test(workspaceRoot) ? normalized.toLowerCase() : normalized;
+}
+
+function directoryLabel(relativePath: string): string {
+  const normalized = normalizePath(relativePath);
+  const index = normalized.lastIndexOf('/');
+  return index < 0 ? '工作区根目录' : normalized.slice(0, index);
+}
+
+function basename(path: string): string {
+  return normalizePath(path).split('/').filter(Boolean).pop() || path;
+}

--- a/apps/web/src/features/workspace/components/workspace-search-panel.tsx
+++ b/apps/web/src/features/workspace/components/workspace-search-panel.tsx
@@ -4,18 +4,23 @@ import { useSnapshot } from 'valtio';
 import { Button, Dialog, IconButton } from '../../../design-system/primitives';
 import { appState } from '../../../state/app-state';
 import type { WorkspaceActions } from '../workspace-actions';
+import { workspaceSearchMatchPreview, type WorkspaceSearchScope } from '../workspace-search';
 import { isFileEditorTabDirty } from '../workspace-state';
 
 export function WorkspaceSearchPanel({ actions, onClose }: { actions: WorkspaceActions; onClose: () => void }) {
   const state = useSnapshot(appState);
   const [query, setQuery] = useState(() => appState.workspaceSearchQuery);
+  const [scope, setScope] = useState<WorkspaceSearchScope>(() => appState.workspaceSearchScope);
   const [replacement, setReplacement] = useState('');
   const [replaceOpen, setReplaceOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const files = state.workspaceSearchResults;
   const searchedQuery = state.workspaceSearchQuery;
-  const resultsCurrent = Boolean(searchedQuery && searchedQuery === query.trim());
+  const queryCurrent = Boolean(searchedQuery && searchedQuery === query.trim());
+  const scopeCurrent = state.workspaceSearchResultScope === scope;
+  const rootCurrent = state.workspaceSearchResultRoot === state.workspaceRoot;
+  const resultsCurrent = queryCurrent && scopeCurrent && rootCurrent;
   const matchCount = files.reduce((count, file) => count + file.matches.length, 0);
   const dirtyInScope = Boolean(
     state.editorTabs.some(
@@ -27,8 +32,8 @@ export function WorkspaceSearchPanel({ actions, onClose }: { actions: WorkspaceA
     inputRef.current?.focus();
     return () => restoreFocusRef.current?.focus();
   }, []);
-  const search = () => {
-    if (query.trim()) void actions.searchWorkspace(query.trim());
+  const search = (nextScope = scope) => {
+    if (query.trim()) void actions.searchWorkspace(query.trim(), { scope: nextScope });
   };
   const replace = async () => {
     try {
@@ -63,7 +68,7 @@ export function WorkspaceSearchPanel({ actions, onClose }: { actions: WorkspaceA
         </IconButton>
       </header>
       <div className='workspace-search-form'>
-        <label>
+        <label className='workspace-search-input'>
           <Search size={14} />
           <input
             ref={inputRef}
@@ -76,7 +81,7 @@ export function WorkspaceSearchPanel({ actions, onClose }: { actions: WorkspaceA
             placeholder='搜索工作区内容'
           />
         </label>
-        <label>
+        <label className='workspace-search-input'>
           <Replace size={14} />
           <input
             aria-label='替换为'
@@ -86,15 +91,50 @@ export function WorkspaceSearchPanel({ actions, onClose }: { actions: WorkspaceA
           />
         </label>
         <div>
-          <Button tone='primary' disabled={!query.trim()} loading={state.workspaceSearchLoading} onClick={search}>
+          <Button
+            tone='primary'
+            disabled={!query.trim()}
+            loading={state.workspaceSearchLoading}
+            onClick={() => search()}
+          >
             搜索
           </Button>
-          <Button disabled={!matchCount || !resultsCurrent} onClick={() => setReplaceOpen(true)}>
+          <Button
+            disabled={
+              !matchCount || !resultsCurrent || state.workspaceSearchLoading || state.workspaceSearchResultsTruncated
+            }
+            onClick={() => setReplaceOpen(true)}
+          >
             替换全部
           </Button>
         </div>
+        <label className='workspace-search-scope'>
+          <input
+            type='checkbox'
+            aria-label='包含依赖与构建目录'
+            checked={scope === 'all'}
+            onChange={(event) => {
+              const nextScope = event.currentTarget.checked ? 'all' : 'source';
+              setScope(nextScope);
+              void actions.searchWorkspace(query.trim(), { scope: nextScope });
+            }}
+          />
+          <span>
+            包含依赖与构建目录
+            <small>默认忽略版本库元数据、依赖缓存和构建产物</small>
+          </span>
+        </label>
         {searchedQuery && !resultsCurrent && (
-          <p className='search-scope-notice'>当前结果来自“{searchedQuery}”；重新搜索后才能替换。</p>
+          <p className='search-scope-notice'>
+            {!queryCurrent
+              ? `当前结果来自“${searchedQuery}”；重新搜索后才能替换。`
+              : !scopeCurrent
+                ? '搜索范围已变化；重新搜索后才能替换。'
+                : '工作区已变化；重新搜索后才能替换。'}
+          </p>
+        )}
+        {resultsCurrent && state.workspaceSearchResultsTruncated && (
+          <p className='search-scope-notice'>结果超过 300 处；请缩小搜索范围后再替换。</p>
         )}
       </div>
       <div className='workspace-search-results'>
@@ -131,7 +171,7 @@ export function WorkspaceSearchPanel({ actions, onClose }: { actions: WorkspaceA
                 <p>
                   {state.workspaceSearchError} {files.length ? '当前仍显示上一次结果。' : '可以检查连接后重新搜索。'}
                 </p>
-                <Button tone='primary' onClick={search}>
+                <Button tone='primary' onClick={() => search()}>
                   重新搜索
                 </Button>
               </div>
@@ -151,29 +191,36 @@ export function WorkspaceSearchPanel({ actions, onClose }: { actions: WorkspaceA
                   <strong>{relativePath(file.path, state.workspaceRoot)}</strong>
                   <span>{file.matches.length}</span>
                 </button>
-                {file.matches.map((match) => (
-                  <button
-                    type='button'
-                    className='workspace-search-match'
-                    aria-label={`打开 ${relativePath(file.path, state.workspaceRoot)} 第 ${match.line} 行`}
-                    key={`${match.line}:${match.column}`}
-                    onClick={() => {
-                      void actions
-                        .selectFile({
-                          path: file.path,
-                          isBinary: false,
-                          line: match.line,
-                          column: match.column,
-                        })
-                        .then((selected) => {
-                          if (selected) onClose();
-                        });
-                    }}
-                  >
-                    <span>{match.line}</span>
-                    <code>{match.text.trim()}</code>
-                  </button>
-                ))}
+                {file.matches.map((match) => {
+                  const preview = workspaceSearchMatchPreview(match, searchedQuery);
+                  return (
+                    <button
+                      type='button'
+                      className='workspace-search-match'
+                      aria-label={`打开 ${relativePath(file.path, state.workspaceRoot)} 第 ${match.line} 行`}
+                      key={`${match.line}:${match.column}`}
+                      onClick={() => {
+                        void actions
+                          .selectFile({
+                            path: file.path,
+                            isBinary: false,
+                            line: match.line,
+                            column: match.column,
+                          })
+                          .then((selected) => {
+                            if (selected) onClose();
+                          });
+                      }}
+                    >
+                      <span>{match.line}</span>
+                      <code>
+                        {preview.before}
+                        {preview.match && <mark>{preview.match}</mark>}
+                        {preview.after}
+                      </code>
+                    </button>
+                  );
+                })}
               </section>
             ))}
             {!files.length && !state.workspaceSearchError && (

--- a/apps/web/src/features/workspace/use-editor-navigation-history.ts
+++ b/apps/web/src/features/workspace/use-editor-navigation-history.ts
@@ -1,0 +1,192 @@
+import { useMemoizedFn } from 'ahooks';
+import { useEffect, useRef, useState } from 'react';
+import { useSnapshot } from 'valtio';
+import { appState, navigateTask } from '../../state/app-state';
+import { fileEditorTabId, normalizePath, type WorkspaceFileSelection } from './workspace-state';
+
+const historyLimit = 100;
+
+type OpenFile = (
+  file: WorkspaceFileSelection,
+  options?: { forceReload?: boolean; activate?: boolean }
+) => Promise<WorkspaceFileSelection | null>;
+
+interface EditorNavigationHistory {
+  workspaceGeneration: number;
+  workspaceRoot: string;
+  back: WorkspaceFileSelection[];
+  forward: WorkspaceFileSelection[];
+}
+
+export function useEditorNavigationHistory(openFile: OpenFile) {
+  const state = useSnapshot(appState);
+  const positionsRef = useRef(new Map<string, { line: number; column: number }>());
+  const navigationRequestIdRef = useRef(0);
+  const historyRef = useRef<EditorNavigationHistory>({
+    workspaceGeneration: appState.workspaceGeneration,
+    workspaceRoot: appState.workspaceRoot,
+    back: [],
+    forward: [],
+  });
+  const [availability, setAvailability] = useState({ back: false, forward: false });
+
+  const syncAvailability = useMemoizedFn(() => {
+    const history = historyRef.current;
+    setAvailability((current) => {
+      const next = { back: history.back.length > 0, forward: history.forward.length > 0 };
+      return current.back === next.back && current.forward === next.forward ? current : next;
+    });
+  });
+
+  const reset = useMemoizedFn(() => {
+    navigationRequestIdRef.current += 1;
+    historyRef.current = {
+      workspaceGeneration: appState.workspaceGeneration,
+      workspaceRoot: appState.workspaceRoot,
+      back: [],
+      forward: [],
+    };
+    positionsRef.current.clear();
+    syncAvailability();
+  });
+
+  const ensureWorkspace = useMemoizedFn(() => {
+    if (
+      historyRef.current.workspaceGeneration !== appState.workspaceGeneration ||
+      historyRef.current.workspaceRoot !== appState.workspaceRoot
+    ) {
+      reset();
+    }
+  });
+
+  useEffect(() => {
+    reset();
+  }, [reset, state.workspaceGeneration, state.workspaceRoot]);
+
+  const currentLocation = useMemoizedFn((): WorkspaceFileSelection | null => {
+    const tab = appState.editorTabs.find((candidate) => candidate.id === appState.activeEditorTabId);
+    if (tab?.kind !== 'file') return null;
+    const position = positionsRef.current.get(tab.id) ?? tab.location ?? { line: 1, column: 1 };
+    return { path: tab.path, isBinary: tab.isBinary, ...position };
+  });
+
+  const selectFile = useMemoizedFn(async (file: WorkspaceFileSelection): Promise<boolean> => {
+    ensureWorkspace();
+    const requestId = ++navigationRequestIdRef.current;
+    const source = currentLocation();
+    const newLocation = !source || !sameLocation(source, file);
+    const selected = await openFile(file);
+    if (!selected) return false;
+    if (requestId !== navigationRequestIdRef.current) return true;
+
+    rememberTargetPosition(selected);
+    if (newLocation) {
+      if (source) pushLocation(historyRef.current.back, source);
+      historyRef.current.forward = [];
+      syncAvailability();
+    }
+    return true;
+  });
+
+  const navigate = useMemoizedFn(async (direction: 'back' | 'forward'): Promise<boolean> => {
+    ensureWorkspace();
+    const history = historyRef.current;
+    const sourceStack = direction === 'back' ? history.back : history.forward;
+    const destinationStack = direction === 'back' ? history.forward : history.back;
+    const target = sourceStack.at(-1);
+    if (!target) {
+      syncAvailability();
+      return false;
+    }
+    const requestId = ++navigationRequestIdRef.current;
+
+    const source = currentLocation();
+    // Load a closed target without replacing the active editor until the read
+    // succeeds. A broken history entry therefore never strands the user on an
+    // error tab or destroys the remaining navigation branch.
+    const selected = await openFile(target, { activate: false });
+    if (requestId !== navigationRequestIdRef.current) return false;
+    if (!selected) {
+      popMatchingLocation(sourceStack, target);
+      syncAvailability();
+      return false;
+    }
+
+    popMatchingLocation(sourceStack, target, selected);
+    rememberTargetPosition(selected);
+    if (source) pushLocation(destinationStack, source);
+    appState.activeEditorTabId = fileEditorTabId(selected.path);
+    appState.fileLoadError = null;
+    navigateTask('review');
+    syncAvailability();
+    return true;
+  });
+
+  const updatePosition = useMemoizedFn((tabId: string, position: { line: number; column: number }) => {
+    const tab = appState.editorTabs.find((candidate) => candidate.id === tabId);
+    if (tab?.kind !== 'file' || position.line < 1 || position.column < 1) return;
+    positionsRef.current.set(tabId, position);
+  });
+
+  const rebasePaths = useMemoizedFn(
+    (transform: (path: string) => string, rebasedTabIds: ReadonlyMap<string, string>) => {
+      for (const stack of [historyRef.current.back, historyRef.current.forward]) {
+        for (const location of stack) location.path = transform(location.path);
+      }
+      for (const [previousId, nextId] of rebasedTabIds) {
+        const position = positionsRef.current.get(previousId);
+        if (!position) continue;
+        positionsRef.current.delete(previousId);
+        positionsRef.current.set(nextId, position);
+      }
+    }
+  );
+
+  const removePaths = useMemoizedFn((matches: (path: string) => boolean, removedTabIds: readonly string[]) => {
+    for (const id of removedTabIds) positionsRef.current.delete(id);
+    historyRef.current.back = historyRef.current.back.filter((location) => !matches(location.path));
+    historyRef.current.forward = historyRef.current.forward.filter((location) => !matches(location.path));
+    syncAvailability();
+  });
+
+  const navigateBack = useMemoizedFn(() => navigate('back'));
+  const navigateForward = useMemoizedFn(() => navigate('forward'));
+
+  const rememberTargetPosition = (location: WorkspaceFileSelection): void => {
+    if (location.line == null) return;
+    positionsRef.current.set(fileEditorTabId(location.path), {
+      line: location.line,
+      column: Math.max(1, location.column ?? 1),
+    });
+  };
+
+  return {
+    canNavigateBack: availability.back,
+    canNavigateForward: availability.forward,
+    selectFile,
+    navigateBack,
+    navigateForward,
+    updatePosition,
+    rebasePaths,
+    removePaths,
+  };
+}
+
+function sameLocation(left: WorkspaceFileSelection, right: WorkspaceFileSelection): boolean {
+  if (normalizePath(left.path) !== normalizePath(right.path)) return false;
+  if (right.line == null) return true;
+  return left.line === right.line && left.column === Math.max(1, right.column ?? 1);
+}
+
+function pushLocation(stack: WorkspaceFileSelection[], location: WorkspaceFileSelection): void {
+  const value = { ...location };
+  const last = stack.at(-1);
+  if (last && sameLocation(last, value)) return;
+  stack.push(value);
+  if (stack.length > historyLimit) stack.splice(0, stack.length - historyLimit);
+}
+
+function popMatchingLocation(stack: WorkspaceFileSelection[], ...candidates: readonly WorkspaceFileSelection[]): void {
+  const last = stack.at(-1);
+  if (last && candidates.some((candidate) => sameLocation(last, candidate))) stack.pop();
+}

--- a/apps/web/src/features/workspace/use-workspace-controller-concurrency.test.tsx
+++ b/apps/web/src/features/workspace/use-workspace-controller-concurrency.test.tsx
@@ -1,0 +1,748 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { codeApi } from '../../lib/api';
+import { appState, switchActiveTask } from '../../state/app-state';
+import { useWorkspaceController } from './use-workspace-controller';
+import { fileEditorTabId, type WorkspaceFileEditorTab } from './workspace-state';
+
+describe('useWorkspaceController file operation ordering', () => {
+  afterEach(() => {
+    cleanup();
+    appState.workspaceRoot = '';
+    appState.filesByDirectory = {};
+    appState.expandedDirectories = {};
+    appState.directoryLoading = {};
+    appState.directoryErrors = {};
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    appState.pendingEditorTabCloseId = null;
+    appState.fileLoadError = null;
+    appState.fileConflict = null;
+    appState.workspaceSnapshotsByTask = {};
+    appState.workspaceGeneration = 0;
+    appState.activeSessionId = null;
+    appState.sessions = [];
+    appState.draftsByTask = {};
+    appState.workspaceSearchResults = [];
+    appState.workspaceSearchQuery = '';
+    appState.workspaceSearchLoading = false;
+    appState.gitStatus = null;
+    appState.gitStatusLoading = false;
+    vi.restoreAllMocks();
+  });
+
+  it('finishes a pending file read against the same tab after its parent is renamed', async () => {
+    appState.workspaceRoot = '/repo';
+    const read = deferred<{ content: string; revision: string }>();
+    vi.spyOn(codeApi, 'readFile').mockReturnValue(read.promise);
+    vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let selection!: Promise<boolean>;
+    act(() => {
+      selection = hook.result.current.selectFile({ path: '/repo/src/app.ts', isBinary: false });
+    });
+    await waitFor(() => expect(codeApi.readFile).toHaveBeenCalledWith('/repo/src/app.ts'));
+
+    await act(() => hook.result.current.renameWorkspaceEntry('/repo/src', 'lib'));
+    expect(activeFileTab()).toMatchObject({
+      id: fileEditorTabId('/repo/lib/app.ts'),
+      path: '/repo/lib/app.ts',
+      loading: true,
+    });
+
+    await act(async () => {
+      read.resolve({ content: 'export const renamed = true;\n', revision: 'sha256:renamed' });
+      await selection;
+    });
+
+    expect(activeFileTab()).toMatchObject({
+      id: fileEditorTabId('/repo/lib/app.ts'),
+      path: '/repo/lib/app.ts',
+      content: 'export const renamed = true;\n',
+      draft: 'export const renamed = true;\n',
+      revision: 'sha256:renamed',
+      loading: false,
+      loadError: null,
+    });
+    hook.unmount();
+  });
+
+  it('retries a pending file read at its rebased path when the old path disappears', async () => {
+    appState.workspaceRoot = '/repo';
+    const oldPathRead = deferred<{ content: string }>();
+    const readFile = vi
+      .spyOn(codeApi, 'readFile')
+      .mockReturnValueOnce(oldPathRead.promise)
+      .mockResolvedValueOnce({ content: 'export const retried = true;\n' });
+    vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let selection!: Promise<boolean>;
+    act(() => {
+      selection = hook.result.current.selectFile({ path: '/repo/src/app.ts', isBinary: false });
+    });
+    await waitFor(() => expect(readFile).toHaveBeenCalledWith('/repo/src/app.ts'));
+    await act(() => hook.result.current.renameWorkspaceEntry('/repo/src', 'lib'));
+
+    await act(async () => {
+      oldPathRead.reject(new Error('old path no longer exists'));
+      await selection;
+    });
+
+    expect(readFile).toHaveBeenNthCalledWith(2, '/repo/lib/app.ts');
+    expect(activeFileTab()).toMatchObject({
+      path: '/repo/lib/app.ts',
+      content: 'export const retried = true;\n',
+      loading: false,
+      loadError: null,
+    });
+    expect(appState.fileLoadError).toBeNull();
+    hook.unmount();
+  });
+
+  it('does not publish a late read error after the pending tab is deleted', async () => {
+    appState.workspaceRoot = '/repo';
+    const read = deferred<{ content: string }>();
+    vi.spyOn(codeApi, 'readFile').mockReturnValue(read.promise);
+    vi.spyOn(codeApi, 'deletePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let selection!: Promise<boolean>;
+    act(() => {
+      selection = hook.result.current.selectFile({ path: '/repo/src/app.ts', isBinary: false });
+    });
+    await waitFor(() => expect(codeApi.readFile).toHaveBeenCalledWith('/repo/src/app.ts'));
+    await act(() => hook.result.current.deleteWorkspaceEntry('/repo/src'));
+
+    await act(async () => {
+      read.reject(new Error('path disappeared'));
+      await selection;
+    });
+
+    expect(appState.editorTabs).toEqual([]);
+    expect(appState.fileLoadError).toBeNull();
+    hook.unmount();
+  });
+
+  it('keeps the latest requested location in navigation history while the initial read is pending', async () => {
+    appState.workspaceRoot = '/repo';
+    const read = deferred<{ content: string }>();
+    vi.spyOn(codeApi, 'readFile').mockReturnValue(read.promise);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let initialSelection!: Promise<boolean>;
+    act(() => {
+      initialSelection = hook.result.current.selectFile({
+        path: '/repo/app.ts',
+        isBinary: false,
+        line: 2,
+        column: 1,
+      });
+    });
+    await waitFor(() => expect(codeApi.readFile).toHaveBeenCalledWith('/repo/app.ts'));
+    await act(() => hook.result.current.selectFile({ path: '/repo/app.ts', isBinary: false, line: 20, column: 7 }));
+
+    await act(async () => {
+      read.resolve({ content: 'export const value = 1;\n' });
+      await initialSelection;
+    });
+
+    expect(activeFileTab()?.location).toEqual({ line: 20, column: 7 });
+    await act(() => hook.result.current.selectFile({ path: '/repo/other.ts', isBinary: false, line: 1, column: 1 }));
+    await act(() => hook.result.current.navigateEditorBack());
+    expect(activeFileTab()).toMatchObject({
+      path: '/repo/app.ts',
+      location: { line: 20, column: 7 },
+    });
+    hook.unmount();
+  });
+
+  it('saves against the loaded revision without a client-side read-before-write request', async () => {
+    appState.workspaceRoot = '/repo';
+    const tab = setOpenFileTab('/repo/app.ts', 'saved', 'local edit');
+    tab.revision = 'sha256:saved';
+    const readFile = vi.spyOn(codeApi, 'readFile').mockResolvedValue({
+      content: 'saved',
+      revision: 'sha256:saved',
+    });
+    const writeFile = vi.spyOn(codeApi, 'writeFile').mockResolvedValue({
+      success: true,
+      revision: 'sha256:local-edit',
+    });
+    const hook = renderHook(() => useWorkspaceController());
+
+    await act(() => hook.result.current.saveEditorTab(tab.id));
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalledWith('/repo/app.ts', 'local edit', {
+      expectedRevision: 'sha256:saved',
+    });
+    expect(activeFileTab()).toMatchObject({
+      content: 'local edit',
+      draft: 'local edit',
+      revision: 'sha256:local-edit',
+      saving: false,
+    });
+    hook.unmount();
+  });
+
+  it('waits for an in-flight save before renaming its parent directory', async () => {
+    appState.workspaceRoot = '/repo';
+    const tab = setOpenFileTab('/repo/src/app.ts', 'saved', 'local edit');
+    const write = deferred<{ success: boolean }>();
+    vi.spyOn(codeApi, 'writeFile').mockReturnValue(write.promise);
+    const renamePath = vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let save!: Promise<boolean>;
+    act(() => {
+      save = hook.result.current.saveEditorTab(tab.id);
+    });
+    await waitFor(() =>
+      expect(codeApi.writeFile).toHaveBeenCalledWith('/repo/src/app.ts', 'local edit', {
+        expectedContent: 'saved',
+      })
+    );
+
+    let rename!: Promise<void>;
+    act(() => {
+      rename = hook.result.current.renameWorkspaceEntry('/repo/src', 'lib');
+    });
+    expect(renamePath).not.toHaveBeenCalled();
+
+    await act(async () => {
+      write.resolve({ success: true });
+      await save;
+      await rename;
+    });
+
+    expect(renamePath).toHaveBeenCalledWith('/repo/src', '/repo/lib');
+    expect(activeFileTab()).toMatchObject({
+      path: '/repo/lib/app.ts',
+      content: 'local edit',
+      draft: 'local edit',
+      saving: false,
+    });
+    hook.unmount();
+  });
+
+  it('orders a rename requested in the same turn immediately after save', async () => {
+    appState.workspaceRoot = '/repo';
+    const tab = setOpenFileTab('/repo/src/app.ts', 'saved', 'local edit');
+    const write = deferred<{ success: boolean }>();
+    vi.spyOn(codeApi, 'writeFile').mockReturnValue(write.promise);
+    const renamePath = vi.spyOn(codeApi, 'renamePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let save!: Promise<boolean>;
+    let rename!: Promise<void>;
+    act(() => {
+      save = hook.result.current.saveEditorTab(tab.id);
+      rename = hook.result.current.renameWorkspaceEntry('/repo/src', 'lib');
+    });
+    await waitFor(() =>
+      expect(codeApi.writeFile).toHaveBeenCalledWith('/repo/src/app.ts', 'local edit', {
+        expectedContent: 'saved',
+      })
+    );
+    expect(renamePath).not.toHaveBeenCalled();
+
+    await act(async () => {
+      write.resolve({ success: true });
+      await save;
+      await rename;
+    });
+
+    expect(renamePath).toHaveBeenCalledWith('/repo/src', '/repo/lib');
+    expect(activeFileTab()).toMatchObject({ path: '/repo/lib/app.ts', content: 'local edit', saving: false });
+    hook.unmount();
+  });
+
+  it('waits for an in-flight save before deleting its parent directory', async () => {
+    appState.workspaceRoot = '/repo';
+    const tab = setOpenFileTab('/repo/src/app.ts', 'saved', 'local edit');
+    const write = deferred<{ success: boolean }>();
+    vi.spyOn(codeApi, 'writeFile').mockReturnValue(write.promise);
+    const deletePath = vi.spyOn(codeApi, 'deletePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let save!: Promise<boolean>;
+    act(() => {
+      save = hook.result.current.saveEditorTab(tab.id);
+    });
+    await waitFor(() =>
+      expect(codeApi.writeFile).toHaveBeenCalledWith('/repo/src/app.ts', 'local edit', {
+        expectedContent: 'saved',
+      })
+    );
+
+    let remove!: Promise<void>;
+    act(() => {
+      remove = hook.result.current.deleteWorkspaceEntry('/repo/src');
+    });
+    expect(deletePath).not.toHaveBeenCalled();
+
+    await act(async () => {
+      write.resolve({ success: true });
+      await save;
+      await remove;
+    });
+
+    expect(deletePath).toHaveBeenCalledWith('/repo/src');
+    expect(appState.editorTabs).toEqual([]);
+    hook.unmount();
+  });
+
+  it('saves to the new path when save is requested during a rename', async () => {
+    appState.workspaceRoot = '/repo';
+    const tab = setOpenFileTab('/repo/src/app.ts', 'saved', 'local edit');
+    const rename = deferred<{ success: boolean }>();
+    vi.spyOn(codeApi, 'renamePath').mockReturnValue(rename.promise);
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const readFile = vi.spyOn(codeApi, 'readFile').mockResolvedValue({ content: 'saved' });
+    const writeFile = vi.spyOn(codeApi, 'writeFile').mockResolvedValue({ success: true });
+    const hook = renderHook(() => useWorkspaceController());
+
+    let renameOperation!: Promise<void>;
+    act(() => {
+      renameOperation = hook.result.current.renameWorkspaceEntry('/repo/src', 'lib');
+    });
+    await waitFor(() => expect(codeApi.renamePath).toHaveBeenCalledWith('/repo/src', '/repo/lib'));
+
+    let save!: Promise<boolean>;
+    act(() => {
+      save = hook.result.current.saveEditorTab(tab.id);
+    });
+    expect(readFile).not.toHaveBeenCalled();
+
+    await act(async () => {
+      rename.resolve({ success: true });
+      await renameOperation;
+      await save;
+    });
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalledWith('/repo/lib/app.ts', 'local edit', {
+      expectedContent: 'saved',
+    });
+    expect(activeFileTab()).toMatchObject({ path: '/repo/lib/app.ts', content: 'local edit', saving: false });
+    hook.unmount();
+  });
+
+  it('also defers saving a file opened after its parent rename has started', async () => {
+    appState.workspaceRoot = '/repo';
+    const rename = deferred<{ success: boolean }>();
+    vi.spyOn(codeApi, 'renamePath').mockReturnValue(rename.promise);
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const readFile = vi.spyOn(codeApi, 'readFile').mockResolvedValue({ content: 'saved' });
+    const writeFile = vi.spyOn(codeApi, 'writeFile').mockResolvedValue({ success: true });
+    const hook = renderHook(() => useWorkspaceController());
+
+    let renameOperation!: Promise<void>;
+    act(() => {
+      renameOperation = hook.result.current.renameWorkspaceEntry('/repo/src', 'lib');
+    });
+    await waitFor(() => expect(codeApi.renamePath).toHaveBeenCalledWith('/repo/src', '/repo/lib'));
+    await act(() => hook.result.current.selectFile({ path: '/repo/src/app.ts', isBinary: false }));
+    const tab = activeFileTab();
+    expect(tab).not.toBeNull();
+    act(() => hook.result.current.updateEditorDraft(tab!.id, 'local edit'));
+
+    let save!: Promise<boolean>;
+    act(() => {
+      save = hook.result.current.saveEditorTab(tab!.id);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(writeFile).not.toHaveBeenCalled();
+
+    await act(async () => {
+      rename.resolve({ success: true });
+      await renameOperation;
+      await save;
+    });
+
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(writeFile).toHaveBeenCalledWith('/repo/lib/app.ts', 'local edit', {
+      expectedContent: 'saved',
+    });
+    expect(activeFileTab()).toMatchObject({ path: '/repo/lib/app.ts', content: 'local edit', saving: false });
+    hook.unmount();
+  });
+
+  it('waits for an in-flight conflict overwrite before deleting the file', async () => {
+    appState.workspaceRoot = '/repo';
+    const tab = setOpenFileTab('/repo/app.ts', 'saved', 'local edit');
+    appState.fileConflict = {
+      tabId: tab.id,
+      path: tab.path,
+      diskContent: 'external edit',
+      diskRevision: null,
+    };
+    const write = deferred<{ success: boolean }>();
+    vi.spyOn(codeApi, 'writeFile').mockReturnValue(write.promise);
+    const deletePath = vi.spyOn(codeApi, 'deletePath').mockResolvedValue({ success: true });
+    vi.spyOn(codeApi, 'readDir').mockResolvedValue([]);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let overwrite!: Promise<void>;
+    act(() => {
+      overwrite = hook.result.current.resolveFileConflict('overwrite');
+    });
+    await waitFor(() => expect(codeApi.writeFile).toHaveBeenCalledWith('/repo/app.ts', 'local edit'));
+
+    let remove!: Promise<void>;
+    act(() => {
+      remove = hook.result.current.deleteWorkspaceEntry('/repo/app.ts');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(deletePath).not.toHaveBeenCalled();
+
+    await act(async () => {
+      write.resolve({ success: true });
+      await overwrite;
+      await remove;
+    });
+
+    expect(deletePath).toHaveBeenCalledWith('/repo/app.ts');
+    expect(appState.editorTabs).toEqual([]);
+    expect(appState.fileConflict).toBeNull();
+    hook.unmount();
+  });
+
+  it('does not publish a pending file read into another task that uses the same workspace', async () => {
+    setTaskSwitchFixture();
+    const read = deferred<{ content: string }>();
+    vi.spyOn(codeApi, 'readFile').mockReturnValue(read.promise);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let selection!: Promise<boolean>;
+    act(() => {
+      selection = hook.result.current.selectFile({ path: '/repo/a.ts', isBinary: false });
+    });
+    await waitFor(() => expect(codeApi.readFile).toHaveBeenCalledWith('/repo/a.ts'));
+
+    act(() => {
+      switchActiveTask('task-b');
+    });
+    expect(appState.editorTabs).toEqual([]);
+
+    await act(async () => {
+      read.resolve({ content: 'late A content' });
+      await selection;
+    });
+
+    expect(appState.activeSessionId).toBe('task-b');
+    expect(appState.editorTabs).toEqual([]);
+    expect(appState.fileLoadError).toBeNull();
+
+    act(() => {
+      switchActiveTask('task-a');
+    });
+    expect(appState.editorTabs).toHaveLength(1);
+    expect(appState.editorTabs[0]).toMatchObject({
+      path: '/repo/a.ts',
+      content: '',
+      draft: '',
+      loading: false,
+    });
+    hook.unmount();
+  });
+
+  it('keeps a completed save scoped to its source task after switching away', async () => {
+    setTaskSwitchFixture();
+    const tab = setOpenFileTab('/repo/a.ts', 'saved A', 'draft A');
+    const write = deferred<{ success: boolean }>();
+    vi.spyOn(codeApi, 'writeFile').mockReturnValue(write.promise);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let save!: Promise<boolean>;
+    act(() => {
+      save = hook.result.current.saveEditorTab(tab.id);
+    });
+    await waitFor(() =>
+      expect(codeApi.writeFile).toHaveBeenCalledWith('/repo/a.ts', 'draft A', {
+        expectedContent: 'saved A',
+      })
+    );
+
+    act(() => {
+      switchActiveTask('task-b');
+    });
+    const tabB = setOpenFileTab('/repo/b.ts', 'saved B');
+    appState.toast = null;
+
+    await act(async () => {
+      write.resolve({ success: true });
+      await save;
+    });
+
+    expect(appState.activeSessionId).toBe('task-b');
+    expect(appState.editorTabs).toHaveLength(1);
+    expect(appState.editorTabs[0]).toMatchObject({ id: tabB.id, content: 'saved B' });
+    expect(appState.toast).toBeNull();
+
+    act(() => {
+      switchActiveTask('task-a');
+    });
+    expect(appState.editorTabs[0]).toMatchObject({
+      id: tab.id,
+      content: 'saved A',
+      draft: 'draft A',
+      saving: false,
+    });
+    hook.unmount();
+  });
+
+  it('ignores stale search and Git status responses after a same-root task switch', async () => {
+    setTaskSwitchFixture();
+    const search = deferred<Array<{ path: string; matches: [] }>>();
+    const status = deferred<{ isGitRepo: boolean; branch: string; files: [] }>();
+    vi.spyOn(codeApi, 'searchWorkspace').mockReturnValue(search.promise);
+    vi.spyOn(codeApi, 'gitStatus').mockReturnValue(status.promise);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let searchRequest!: Promise<void>;
+    let statusRequest!: Promise<void>;
+    act(() => {
+      searchRequest = hook.result.current.searchWorkspace('needle', { scope: 'source' });
+      statusRequest = hook.result.current.refreshGitStatus();
+    });
+    await waitFor(() => expect(codeApi.searchWorkspace).toHaveBeenCalled());
+    await waitFor(() => expect(codeApi.gitStatus).toHaveBeenCalledWith('/repo'));
+
+    act(() => {
+      switchActiveTask('task-b');
+      appState.workspaceSearchQuery = 'task B query';
+      appState.gitStatus = { isGitRepo: true, branch: 'task-b', files: [] };
+    });
+
+    await act(async () => {
+      search.resolve([{ path: '/repo/a.ts', matches: [] }]);
+      status.resolve({ isGitRepo: true, branch: 'task-a', files: [] });
+      await Promise.all([searchRequest, statusRequest]);
+    });
+
+    expect(appState.workspaceSearchQuery).toBe('task B query');
+    expect(appState.workspaceSearchResults).toEqual([]);
+    expect(appState.workspaceSearchLoading).toBe(false);
+    expect(appState.gitStatus?.branch).toBe('task-b');
+    expect(appState.gitStatusLoading).toBe(false);
+    hook.unmount();
+  });
+
+  it('does not let a stale directory or replace response alter the destination task', async () => {
+    setTaskSwitchFixture();
+    const directory =
+      deferred<
+        Array<{
+          name: string;
+          path: string;
+          isDirectory: boolean;
+          isFile: boolean;
+          size: number;
+          isBinary: boolean;
+        }>
+      >();
+    const replacement = deferred<{
+      filesModified: number;
+      totalReplacements: number;
+      files: Array<{ path: string; replacements: number }>;
+    }>();
+    vi.spyOn(codeApi, 'readDir').mockReturnValue(directory.promise);
+    vi.spyOn(codeApi, 'replaceWorkspace').mockReturnValue(replacement.promise);
+    const search = vi.spyOn(codeApi, 'searchWorkspace');
+    const hook = renderHook(() => useWorkspaceController());
+
+    let directoryRequest!: Promise<void>;
+    let replaceRequest!: Promise<void>;
+    act(() => {
+      directoryRequest = hook.result.current.refreshDirectory('/repo/src');
+      replaceRequest = hook.result.current.replaceWorkspace('before', 'after', ['/repo/a.ts']);
+    });
+    await waitFor(() => expect(codeApi.readDir).toHaveBeenCalledWith('/repo/src'));
+    await waitFor(() => expect(codeApi.replaceWorkspace).toHaveBeenCalled());
+
+    act(() => {
+      switchActiveTask('task-b');
+      appState.filesByDirectory['/repo/src'] = [workspaceEntry('/repo/src/b.ts')];
+      appState.workspaceSearchQuery = 'task B search';
+      appState.toast = null;
+    });
+
+    await act(async () => {
+      directory.resolve([workspaceEntry('/repo/src/a.ts')]);
+      replacement.resolve({
+        filesModified: 1,
+        totalReplacements: 2,
+        files: [{ path: '/repo/a.ts', replacements: 2 }],
+      });
+      await Promise.all([directoryRequest, replaceRequest]);
+    });
+
+    expect(appState.filesByDirectory['/repo/src']).toEqual([workspaceEntry('/repo/src/b.ts')]);
+    expect(appState.workspaceSearchQuery).toBe('task B search');
+    expect(appState.workspaceReplaceLoading).toBe(false);
+    expect(search).not.toHaveBeenCalled();
+    expect(appState.toast).toBeNull();
+    hook.unmount();
+  });
+
+  it('keeps stale Git diff and staging results out of the destination task', async () => {
+    setTaskSwitchFixture();
+    const diff = deferred<{
+      path: string;
+      staged: boolean;
+      content: string;
+      original: string;
+      modified: string;
+      isBinary: boolean;
+    }>();
+    const staged = deferred<{ isGitRepo: boolean; branch: string; files: [] }>();
+    vi.spyOn(codeApi, 'gitDiff').mockReturnValue(diff.promise);
+    vi.spyOn(codeApi, 'gitStage').mockReturnValue(staged.promise);
+    const hook = renderHook(() => useWorkspaceController());
+
+    let diffRequest!: Promise<void>;
+    let stageRequest!: Promise<void>;
+    act(() => {
+      diffRequest = hook.result.current.loadGitDiff('a.ts');
+      stageRequest = hook.result.current.setGitStaged(['a.ts'], true);
+    });
+    await waitFor(() => expect(codeApi.gitDiff).toHaveBeenCalledWith('/repo', 'a.ts', false));
+    await waitFor(() => expect(codeApi.gitStage).toHaveBeenCalledWith('/repo', ['a.ts']));
+
+    act(() => {
+      switchActiveTask('task-b');
+      appState.gitStatus = { isGitRepo: true, branch: 'task-b', files: [] };
+      appState.toast = null;
+    });
+
+    await act(async () => {
+      diff.resolve({
+        path: 'a.ts',
+        staged: false,
+        content: 'late diff',
+        original: 'before',
+        modified: 'after',
+        isBinary: false,
+      });
+      staged.resolve({ isGitRepo: true, branch: 'task-a', files: [] });
+      await Promise.all([diffRequest, stageRequest]);
+    });
+
+    expect(appState.editorTabs).toEqual([]);
+    expect(appState.gitStatus?.branch).toBe('task-b');
+    expect(appState.gitActionLoading).toBe(false);
+    expect(appState.toast).toBeNull();
+
+    act(() => {
+      switchActiveTask('task-a');
+    });
+    expect(appState.editorTabs).toHaveLength(1);
+    expect(appState.editorTabs[0]).toMatchObject({
+      kind: 'diff',
+      path: 'a.ts',
+      original: '',
+      modified: '',
+      loading: false,
+    });
+    hook.unmount();
+  });
+});
+
+function setTaskSwitchFixture(): void {
+  appState.sessions = [
+    {
+      sessionId: 'task-a',
+      workspace: '/repo',
+      cwd: '/repo',
+      model: 'codex/gpt',
+      followDefaultModel: false,
+      permissionMode: 'default',
+      state: 'idle',
+      createdAt: 1,
+    },
+    {
+      sessionId: 'task-b',
+      workspace: '/repo',
+      cwd: '/repo',
+      model: 'codex/gpt',
+      followDefaultModel: false,
+      permissionMode: 'default',
+      state: 'idle',
+      createdAt: 2,
+    },
+  ];
+  appState.activeSessionId = 'task-a';
+  appState.workspaceRoot = '/repo';
+  appState.editorTabs = [];
+  appState.activeEditorTabId = null;
+  appState.workspaceSearchResults = [];
+  appState.workspaceSearchQuery = '';
+  appState.workspaceSearchLoading = false;
+  appState.gitStatus = null;
+  appState.gitStatusLoading = false;
+  appState.draftsByTask = {};
+}
+
+function workspaceEntry(path: string) {
+  return {
+    name: path.split('/').at(-1) ?? path,
+    path,
+    isDirectory: false,
+    isFile: true,
+    size: 1,
+    isBinary: false,
+  };
+}
+
+function setOpenFileTab(path: string, content: string, draft = content): WorkspaceFileEditorTab {
+  const tab: WorkspaceFileEditorTab = {
+    id: fileEditorTabId(path),
+    kind: 'file',
+    path,
+    content,
+    draft,
+    revision: null,
+    isBinary: false,
+    location: null,
+    loading: false,
+    loadError: null,
+    saving: false,
+    configValidation: null,
+  };
+  appState.editorTabs = [tab];
+  appState.activeEditorTabId = tab.id;
+  return appState.editorTabs[0] as WorkspaceFileEditorTab;
+}
+
+function activeFileTab(): WorkspaceFileEditorTab | null {
+  const tab = appState.editorTabs.find((candidate) => candidate.id === appState.activeEditorTabId);
+  return tab?.kind === 'file' ? tab : null;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason?: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/apps/web/src/features/workspace/use-workspace-controller.ts
+++ b/apps/web/src/features/workspace/use-workspace-controller.ts
@@ -1,6 +1,22 @@
 import { useMemoizedFn } from 'ahooks';
-import { codeApi } from '../../lib/api';
-import { appState, formatApiError, navigateTask, showToast } from '../../state/app-state';
+import { useRef } from 'react';
+import { ApiError, codeApi } from '../../lib/api';
+import {
+  appState,
+  captureWorkspaceContext,
+  formatApiError,
+  isWorkspaceContextCurrent,
+  navigateTask,
+  showToast,
+} from '../../state/app-state';
+import { useEditorNavigationHistory } from './use-editor-navigation-history';
+import { rebaseWorkspaceEditorModelPath } from './components/monaco-editor-model-store';
+import {
+  DEFAULT_WORKSPACE_SEARCH_EXCLUDE_PATTERN,
+  limitWorkspaceSearchResults,
+  WORKSPACE_SEARCH_RESULT_LIMIT,
+  type WorkspaceSearchOptions,
+} from './workspace-search';
 import {
   diffEditorTabId,
   fileEditorTabId,
@@ -38,11 +54,59 @@ function pathInside(parent: string, candidate: string): boolean {
   return value === base || value.startsWith(`${base}/`);
 }
 
+function samePath(left: string, right: string): boolean {
+  return pathInside(left, right) && pathInside(right, left);
+}
+
 function rebasePath(candidate: string, source: string, destination: string): string {
   const normalizedCandidate = normalizePath(candidate);
   const normalizedSource = normalizePath(source);
   const suffix = normalizedCandidate.slice(normalizedSource.length);
   return pathInside(source, candidate) ? `${normalizePath(destination)}${suffix}` : candidate;
+}
+
+function rebaseWorkspaceDirectoryState(source: string, destination: string): void {
+  for (const entries of Object.values(appState.filesByDirectory)) {
+    for (const entry of entries) {
+      const previousPath = entry.path;
+      if (!pathInside(source, previousPath)) continue;
+      entry.path = rebasePath(previousPath, source, destination);
+      if (samePath(previousPath, source)) entry.name = basename(destination);
+    }
+  }
+  rebaseRecordSubtree(appState.filesByDirectory, source, destination);
+  rebaseRecordSubtree(appState.expandedDirectories, source, destination);
+  rebaseRecordSubtree(appState.directoryLoading, source, destination);
+  rebaseRecordSubtree(appState.directoryErrors, source, destination);
+  for (const path of Object.keys(appState.directoryLoading)) {
+    if (pathInside(destination, path)) appState.directoryLoading[path] = false;
+  }
+}
+
+function removeWorkspaceDirectoryState(path: string): void {
+  for (const [directory, entries] of Object.entries(appState.filesByDirectory)) {
+    if (pathInside(path, directory)) {
+      delete appState.filesByDirectory[directory];
+      continue;
+    }
+    const remaining = entries.filter((entry) => !pathInside(path, entry.path));
+    if (remaining.length !== entries.length) appState.filesByDirectory[directory] = remaining;
+  }
+  removeRecordSubtree(appState.expandedDirectories, path);
+  removeRecordSubtree(appState.directoryLoading, path);
+  removeRecordSubtree(appState.directoryErrors, path);
+}
+
+function rebaseRecordSubtree<T>(record: Record<string, T>, source: string, destination: string): void {
+  const moved = Object.entries(record).filter(([path]) => pathInside(source, path));
+  for (const [path] of moved) delete record[path];
+  for (const [path, value] of moved) record[rebasePath(path, source, destination)] = value;
+}
+
+function removeRecordSubtree<T>(record: Record<string, T>, path: string): void {
+  for (const key of Object.keys(record)) {
+    if (pathInside(path, key)) delete record[key];
+  }
 }
 
 function absoluteWorkspacePath(path: string): string {
@@ -58,6 +122,10 @@ function fileTab(path: string): WorkspaceFileEditorTab | null {
 function activeFileTab(): WorkspaceFileEditorTab | null {
   const tab = appState.editorTabs.find((candidate) => candidate.id === appState.activeEditorTabId);
   return tab?.kind === 'file' ? tab : null;
+}
+
+function isOpenFileTab(tab: WorkspaceFileEditorTab): boolean {
+  return appState.editorTabs.some((candidate) => candidate === tab);
 }
 
 function removeEditorTabs(predicate: (tab: WorkspaceEditorTab) => boolean): void {
@@ -87,17 +155,35 @@ function updateDiffTab(tabId: string, update: (tab: WorkspaceDiffEditorTab) => v
 }
 
 export function useWorkspaceController() {
+  const workspaceSearchRequestId = useRef(0);
+  const directoryRequestIds = useRef(new Map<string, number>());
+  const fileLoadOperations = useRef(new WeakMap<WorkspaceFileEditorTab, symbol>());
+  const fileWriteOperations = useRef(new WeakMap<WorkspaceFileEditorTab, Promise<unknown>>());
+  const pathMutationBarriers = useRef(new Map<string, Promise<void>>());
+  const invalidateDirectoryRequests = useMemoizedFn((path: string) => {
+    for (const [candidate, requestId] of directoryRequestIds.current) {
+      if (pathInside(path, candidate)) directoryRequestIds.current.set(candidate, requestId + 1);
+    }
+  });
   const refreshDirectory = useMemoizedFn(async (path = appState.workspaceRoot) => {
+    const context = captureWorkspaceContext();
+    const requestId = (directoryRequestIds.current.get(path) ?? 0) + 1;
+    directoryRequestIds.current.set(path, requestId);
     appState.directoryLoading[path] = true;
     delete appState.directoryErrors[path];
     try {
-      appState.filesByDirectory[path] = await codeApi.readDir(path);
+      const entries = await codeApi.readDir(path);
+      if (!isWorkspaceContextCurrent(context) || directoryRequestIds.current.get(path) !== requestId) return;
+      appState.filesByDirectory[path] = entries;
     } catch (error) {
+      if (!isWorkspaceContextCurrent(context) || directoryRequestIds.current.get(path) !== requestId) return;
       const message = formatApiError(error);
       appState.directoryErrors[path] = message;
       showToast(message, 'error');
     } finally {
-      appState.directoryLoading[path] = false;
+      if (isWorkspaceContextCurrent(context) && directoryRequestIds.current.get(path) === requestId) {
+        appState.directoryLoading[path] = false;
+      }
     }
   });
 
@@ -107,14 +193,63 @@ export function useWorkspaceController() {
     if (next && !appState.filesByDirectory[path]) await refreshDirectory(path);
   });
 
+  const findWorkspaceFiles = useMemoizedFn((query: string, maxResults = 120) => {
+    const workspaceRoot = appState.workspaceRoot;
+    return codeApi.workspaceFiles(workspaceRoot, query, maxResults);
+  });
+
+  const pendingFileMutations = useMemoizedFn((path: string): Promise<void>[] => {
+    const barriers = new Set<Promise<void>>();
+    for (const [mutationPath, barrier] of pathMutationBarriers.current) {
+      if (pathInside(mutationPath, path)) barriers.add(barrier);
+    }
+    return [...barriers];
+  });
+
+  const runWithFileMutationBarrier = useMemoizedFn(
+    async (paths: readonly string[], operation: () => Promise<void>): Promise<void> => {
+      const mutationPaths = [...new Set(paths.map(normalizePath))];
+      const overlapsMutation = (candidate: string) =>
+        mutationPaths.some((path) => pathInside(path, candidate) || pathInside(candidate, path));
+      const affectedTabs = appState.editorTabs.filter(
+        (tab): tab is WorkspaceFileEditorTab => tab.kind === 'file' && overlapsMutation(tab.path)
+      );
+      const precedingOperations = new Set<Promise<unknown>>();
+      for (const [path, mutation] of pathMutationBarriers.current) {
+        if (overlapsMutation(path)) precedingOperations.add(mutation);
+      }
+      for (const tab of affectedTabs) {
+        const write = fileWriteOperations.current.get(tab);
+        if (write) precedingOperations.add(write);
+      }
+
+      let releaseBarrier!: () => void;
+      const barrier = new Promise<void>((resolve) => {
+        releaseBarrier = resolve;
+      });
+      for (const path of mutationPaths) pathMutationBarriers.current.set(path, barrier);
+
+      try {
+        await Promise.all(precedingOperations);
+        await operation();
+      } finally {
+        releaseBarrier();
+        for (const path of mutationPaths) {
+          if (pathMutationBarriers.current.get(path) === barrier) pathMutationBarriers.current.delete(path);
+        }
+      }
+    }
+  );
+
   const openFile = useMemoizedFn(
     async (
       file: WorkspaceFileSelection,
       options: { forceReload?: boolean; activate?: boolean } = {}
-    ): Promise<boolean> => {
+    ): Promise<WorkspaceFileSelection | null> => {
+      const context = captureWorkspaceContext();
       const id = fileEditorTabId(file.path);
       const location = file.line == null ? null : { line: file.line, column: Math.max(1, file.column ?? 1) };
-      const existing = fileTab(file.path);
+      let tab = fileTab(file.path);
       const activate = options.activate ?? true;
       if (activate) {
         appState.activeEditorTabId = id;
@@ -122,18 +257,19 @@ export function useWorkspaceController() {
       }
       appState.fileLoadError = null;
 
-      if (existing && !options.forceReload && !existing.loadError) {
-        existing.location = location;
-        return true;
+      if (tab && !options.forceReload && !tab.loadError) {
+        tab.location = location;
+        return { ...file, path: tab.path, isBinary: tab.isBinary };
       }
 
-      if (!existing) {
+      if (!tab) {
         appState.editorTabs.push({
           id,
           kind: 'file',
           path: file.path,
           content: '',
           draft: '',
+          revision: null,
           isBinary: file.isBinary,
           location,
           loading: !file.isBinary,
@@ -141,43 +277,63 @@ export function useWorkspaceController() {
           saving: false,
           configValidation: null,
         });
+        tab = fileTab(file.path);
       } else {
-        existing.location = location;
-        existing.loadError = null;
-        existing.loading = !file.isBinary;
-        existing.isBinary = file.isBinary;
+        tab.location = location;
+        tab.loadError = null;
+        tab.loading = !file.isBinary;
+        tab.isBinary = file.isBinary;
       }
 
-      if (file.isBinary) return true;
+      if (!tab) return null;
+      if (file.isBinary) {
+        fileLoadOperations.current.delete(tab);
+        return { ...file, path: tab.path, isBinary: true };
+      }
 
+      const loadOperation = Symbol('file-load');
+      fileLoadOperations.current.set(tab, loadOperation);
+      const isCurrentLoad = () =>
+        isWorkspaceContextCurrent(context) &&
+        isOpenFileTab(tab) &&
+        fileLoadOperations.current.get(tab) === loadOperation;
       try {
-        const result = await codeApi.readFile(file.path);
-        updateFileTab(id, (tab) => {
+        let readPath = file.path;
+        for (;;) {
+          let result: Awaited<ReturnType<typeof codeApi.readFile>>;
+          try {
+            result = await codeApi.readFile(readPath);
+          } catch (error) {
+            if (!isCurrentLoad()) return null;
+            if (!samePath(readPath, tab.path)) {
+              readPath = tab.path;
+              continue;
+            }
+            const message = formatApiError(error);
+            tab.loadError = message;
+            appState.fileLoadError = { selection: { ...file, path: tab.path }, message };
+            showToast(message, 'error');
+            return null;
+          }
+          if (!isCurrentLoad()) return null;
           tab.content = result.content;
           tab.draft = result.content;
+          tab.revision = result.revision ?? null;
           tab.isBinary = false;
-          tab.location = location;
           tab.loadError = null;
           tab.configValidation = null;
-        });
-        return true;
-      } catch (error) {
-        const message = formatApiError(error);
-        updateFileTab(id, (tab) => {
-          tab.loadError = message;
-        });
-        appState.fileLoadError = { selection: file, message };
-        showToast(message, 'error');
-        return false;
+          return { ...file, path: tab.path, isBinary: false };
+        }
       } finally {
-        updateFileTab(id, (tab) => {
+        if (isCurrentLoad()) {
           tab.loading = false;
-        });
+          fileLoadOperations.current.delete(tab);
+        }
       }
     }
   );
-
-  const selectFile = useMemoizedFn(async (file: WorkspaceFileSelection) => openFile(file));
+  const editorNavigation = useEditorNavigationHistory(openFile);
+  const selectFile = editorNavigation.selectFile;
 
   const activateEditorTab = useMemoizedFn((tabId: string) => {
     if (!appState.editorTabs.some((tab) => tab.id === tabId)) return;
@@ -216,74 +372,131 @@ export function useWorkspaceController() {
     });
   });
 
+  const consumeEditorLocation = useMemoizedFn((tabId: string) => {
+    updateFileTab(tabId, (tab) => {
+      tab.location = null;
+    });
+  });
+
   const saveEditorTab = useMemoizedFn(async (requestedTabId?: string): Promise<boolean> => {
+    const context = captureWorkspaceContext();
     const requestedTab = requestedTabId
       ? appState.editorTabs.find((candidate) => candidate.id === requestedTabId)
       : activeFileTab();
     const tab = requestedTab?.kind === 'file' ? requestedTab : null;
     if (!tab || tab.isBinary || tab.loading || tab.saving) return false;
+    for (;;) {
+      const mutations = pendingFileMutations(tab.path);
+      if (mutations.length === 0) break;
+      await Promise.all(mutations);
+      if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab)) return false;
+    }
+    if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab) || tab.isBinary || tab.loading || tab.saving) {
+      return false;
+    }
     if (!isFileEditorTabDirty(tab)) return true;
     const tabId = tab.id;
     const path = tab.path;
     const baseContent = tab.content;
+    const baseRevision = tab.revision;
     const draftToSave = tab.draft;
     tab.saving = true;
-    try {
-      const disk = await codeApi.readFile(path);
-      if (disk.content !== baseContent) {
-        appState.fileConflict = { tabId, path, diskContent: disk.content };
-        showToast('文件已在外部修改，请选择保留版本', 'info');
+    const operation = (async (): Promise<boolean> => {
+      try {
+        const saved = await codeApi.writeFile(
+          path,
+          draftToSave,
+          baseRevision ? { expectedRevision: baseRevision } : { expectedContent: baseContent }
+        );
+        if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab)) return false;
+        tab.content = draftToSave;
+        tab.revision = saved.revision ?? null;
+        showToast('文件已保存', 'success');
+        return true;
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 412) {
+          try {
+            const disk = await codeApi.readFile(path);
+            if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab)) return false;
+            appState.fileConflict = {
+              tabId,
+              path,
+              diskContent: disk.content,
+              diskRevision: disk.revision ?? null,
+            };
+            showToast('文件已在外部修改，请选择保留版本', 'info');
+          } catch (readError) {
+            if (isWorkspaceContextCurrent(context)) showToast(formatApiError(readError), 'error');
+          }
+          return false;
+        }
+        if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
         return false;
+      } finally {
+        if (isWorkspaceContextCurrent(context) && isOpenFileTab(tab)) tab.saving = false;
       }
-      await codeApi.writeFile(path, draftToSave);
-      updateFileTab(tabId, (current) => {
-        current.content = draftToSave;
-      });
-      showToast('文件已保存', 'success');
-      return true;
-    } catch (error) {
-      showToast(formatApiError(error), 'error');
-      return false;
+    })();
+    fileWriteOperations.current.set(tab, operation);
+    try {
+      return await operation;
     } finally {
-      updateFileTab(tabId, (current) => {
-        current.saving = false;
-      });
+      if (fileWriteOperations.current.get(tab) === operation) fileWriteOperations.current.delete(tab);
     }
   });
 
   const resolveFileConflict = useMemoizedFn(async (resolution: 'reload' | 'overwrite') => {
-    const conflict = appState.fileConflict;
-    if (!conflict) return;
-    const tab = appState.editorTabs.find((candidate) => candidate.id === conflict.tabId);
+    const context = captureWorkspaceContext();
+    const initialConflict = appState.fileConflict;
+    if (!initialConflict) return;
+    const tab = appState.editorTabs.find((candidate) => candidate.id === initialConflict.tabId);
     if (tab?.kind !== 'file') {
       appState.fileConflict = null;
       return;
     }
+    if (tab.saving) return;
+    for (;;) {
+      const mutations = pendingFileMutations(tab.path);
+      if (mutations.length === 0) break;
+      await Promise.all(mutations);
+      if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab)) return;
+    }
+    if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab) || tab.saving) return;
+    const conflict = appState.fileConflict;
+    if (!conflict || conflict.tabId !== tab.id) return;
+
     tab.saving = true;
-    try {
-      if (resolution === 'reload') {
-        const disk = await codeApi.readFile(conflict.path);
-        updateFileTab(conflict.tabId, (current) => {
-          current.content = disk.content;
-          current.draft = disk.content;
-          current.configValidation = null;
-        });
-        showToast('已重新加载最新磁盘版本', 'success');
-      } else {
-        const draftToSave = tab.draft;
-        await codeApi.writeFile(conflict.path, draftToSave);
-        updateFileTab(conflict.tabId, (current) => {
-          current.content = draftToSave;
-        });
-        showToast('已用当前编辑覆盖磁盘版本', 'success');
+    const operation = (async (): Promise<void> => {
+      try {
+        if (resolution === 'reload') {
+          const disk = await codeApi.readFile(conflict.path);
+          if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab)) return;
+          tab.content = disk.content;
+          tab.draft = disk.content;
+          tab.revision = disk.revision ?? null;
+          tab.configValidation = null;
+          showToast('已重新加载最新磁盘版本', 'success');
+        } else {
+          const draftToSave = tab.draft;
+          const saved = await codeApi.writeFile(conflict.path, draftToSave);
+          if (!isWorkspaceContextCurrent(context) || !isOpenFileTab(tab)) return;
+          tab.content = draftToSave;
+          tab.revision = saved.revision ?? null;
+          showToast('已用当前编辑覆盖磁盘版本', 'success');
+        }
+        if (appState.fileConflict?.tabId === tab.id && samePath(appState.fileConflict.path, conflict.path)) {
+          appState.fileConflict = null;
+        }
+      } catch (error) {
+        if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
+      } finally {
+        if (isWorkspaceContextCurrent(context) && isOpenFileTab(tab)) tab.saving = false;
       }
-      appState.fileConflict = null;
-    } catch (error) {
-      showToast(formatApiError(error), 'error');
+    })();
+    fileWriteOperations.current.set(tab, operation);
+    try {
+      await operation;
     } finally {
-      updateFileTab(conflict.tabId, (current) => {
-        current.saving = false;
-      });
+      if (fileWriteOperations.current.get(tab) === operation) fileWriteOperations.current.delete(tab);
     }
   });
 
@@ -292,12 +505,14 @@ export function useWorkspaceController() {
   });
 
   const validateActiveConfig = useMemoizedFn(async () => {
+    const context = captureWorkspaceContext();
     const tab = activeFileTab();
     if (!tab || tab.isBinary || basename(tab.path) !== 'config.acl') return;
     const tabId = tab.id;
     const content = tab.draft;
     try {
       const validation = await codeApi.validateConfig(content);
+      if (!isWorkspaceContextCurrent(context)) return;
       const current = appState.editorTabs.find((candidate) => candidate.id === tabId);
       if (current?.kind !== 'file' || current.draft !== content) {
         showToast('配置在验证期间已修改，请重新验证', 'info');
@@ -306,112 +521,162 @@ export function useWorkspaceController() {
       current.configValidation = validation;
       showToast(validation.valid ? '配置语法有效' : '配置存在问题', validation.valid ? 'success' : 'error');
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
     }
   });
 
   const createWorkspaceEntry = useMemoizedFn(async (parent: string, name: string, kind: 'file' | 'directory') => {
+    const context = captureWorkspaceContext();
     const path = childPath(parent, name.trim());
     try {
       if (kind === 'directory') await codeApi.createDirectory(path);
       else await codeApi.createFile(path);
+      if (!isWorkspaceContextCurrent(context)) return;
       await refreshDirectory(parent);
+      if (!isWorkspaceContextCurrent(context)) return;
       appState.expandedDirectories[parent] = true;
       if (kind === 'file') await selectFile({ path, isBinary: false });
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
       throw error;
     }
   });
 
   const renameWorkspaceEntry = useMemoizedFn(async (path: string, name: string) => {
+    const context = captureWorkspaceContext();
     const destination = siblingPath(path, name.trim());
     try {
-      await codeApi.renamePath(path, destination);
-      await refreshDirectory(parentPath(path));
-      const rebasedIds = new Map<string, string>();
-      for (const tab of appState.editorTabs) {
-        const absolutePath = tab.kind === 'file' ? tab.path : absoluteWorkspacePath(tab.path);
-        if (!pathInside(path, absolutePath)) continue;
-        const nextAbsolutePath = rebasePath(absolutePath, path, destination);
-        const previousId = tab.id;
-        if (tab.kind === 'file') {
-          tab.path = nextAbsolutePath;
-          tab.id = fileEditorTabId(nextAbsolutePath);
-        } else {
-          tab.path = workspaceRelativePath(nextAbsolutePath, appState.workspaceRoot);
-          tab.id = diffEditorTabId(tab.path, tab.staged);
+      await runWithFileMutationBarrier([path, destination], async () => {
+        await codeApi.renamePath(path, destination);
+        if (!isWorkspaceContextCurrent(context)) return;
+        invalidateDirectoryRequests(path);
+        rebaseWorkspaceDirectoryState(path, destination);
+        const rebasedIds = new Map<string, string>();
+        for (const tab of appState.editorTabs) {
+          const absolutePath = tab.kind === 'file' ? tab.path : absoluteWorkspacePath(tab.path);
+          if (!pathInside(path, absolutePath)) continue;
+          const nextAbsolutePath = rebasePath(absolutePath, path, destination);
+          const previousId = tab.id;
+          if (tab.kind === 'file') {
+            rebaseWorkspaceEditorModelPath(appState.editorModelScope, tab.path, nextAbsolutePath);
+            tab.path = nextAbsolutePath;
+            tab.id = fileEditorTabId(nextAbsolutePath);
+          } else {
+            tab.path = workspaceRelativePath(nextAbsolutePath, appState.workspaceRoot);
+            tab.id = diffEditorTabId(tab.path, tab.staged);
+          }
+          rebasedIds.set(previousId, tab.id);
         }
-        rebasedIds.set(previousId, tab.id);
-      }
-      if (appState.activeEditorTabId) {
-        appState.activeEditorTabId = rebasedIds.get(appState.activeEditorTabId) ?? appState.activeEditorTabId;
-      }
-      if (appState.pendingEditorTabCloseId) {
-        appState.pendingEditorTabCloseId =
-          rebasedIds.get(appState.pendingEditorTabCloseId) ?? appState.pendingEditorTabCloseId;
-      }
-      if (appState.fileConflict) {
-        appState.fileConflict.tabId = rebasedIds.get(appState.fileConflict.tabId) ?? appState.fileConflict.tabId;
-        appState.fileConflict.path = rebasePath(appState.fileConflict.path, path, destination);
-      }
-      if (appState.fileLoadError) {
-        appState.fileLoadError.selection.path = rebasePath(appState.fileLoadError.selection.path, path, destination);
-      }
+        if (appState.activeEditorTabId) {
+          appState.activeEditorTabId = rebasedIds.get(appState.activeEditorTabId) ?? appState.activeEditorTabId;
+        }
+        if (appState.pendingEditorTabCloseId) {
+          appState.pendingEditorTabCloseId =
+            rebasedIds.get(appState.pendingEditorTabCloseId) ?? appState.pendingEditorTabCloseId;
+        }
+        if (appState.fileConflict) {
+          appState.fileConflict.tabId = rebasedIds.get(appState.fileConflict.tabId) ?? appState.fileConflict.tabId;
+          appState.fileConflict.path = rebasePath(appState.fileConflict.path, path, destination);
+        }
+        if (appState.fileLoadError) {
+          appState.fileLoadError.selection.path = rebasePath(appState.fileLoadError.selection.path, path, destination);
+        }
+        editorNavigation.rebasePaths((candidate) => rebasePath(candidate, path, destination), rebasedIds);
+        await refreshDirectory(parentPath(path));
+      });
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
       throw error;
     }
   });
 
   const copyWorkspaceEntry = useMemoizedFn(async (path: string, name: string) => {
+    const context = captureWorkspaceContext();
     const destination = siblingPath(path, name.trim());
     try {
       await codeApi.copyPath(path, destination);
+      if (!isWorkspaceContextCurrent(context)) return;
       await refreshDirectory(parentPath(path));
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
       throw error;
     }
   });
 
   const deleteWorkspaceEntry = useMemoizedFn(async (path: string) => {
+    const context = captureWorkspaceContext();
     try {
-      await codeApi.deletePath(path);
-      await refreshDirectory(parentPath(path));
-      removeEditorTabs((tab) => pathInside(path, tab.kind === 'file' ? tab.path : absoluteWorkspacePath(tab.path)));
-      if (appState.fileConflict && pathInside(path, appState.fileConflict.path)) appState.fileConflict = null;
-      if (appState.fileLoadError && pathInside(path, appState.fileLoadError.selection.path))
-        appState.fileLoadError = null;
+      await runWithFileMutationBarrier([path], async () => {
+        await codeApi.deletePath(path);
+        if (!isWorkspaceContextCurrent(context)) return;
+        invalidateDirectoryRequests(path);
+        removeWorkspaceDirectoryState(path);
+        const removedFileIds = appState.editorTabs
+          .filter((tab) => tab.kind === 'file' && pathInside(path, tab.path))
+          .map((tab) => tab.id);
+        removeEditorTabs((tab) => pathInside(path, tab.kind === 'file' ? tab.path : absoluteWorkspacePath(tab.path)));
+        editorNavigation.removePaths((candidate) => pathInside(path, candidate), removedFileIds);
+        if (appState.fileConflict && pathInside(path, appState.fileConflict.path)) appState.fileConflict = null;
+        if (appState.fileLoadError && pathInside(path, appState.fileLoadError.selection.path))
+          appState.fileLoadError = null;
+        await refreshDirectory(parentPath(path));
+      });
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
       throw error;
     }
   });
 
-  const searchWorkspace = useMemoizedFn(async (query: string) => {
-    if (!query.trim()) {
+  const searchWorkspace = useMemoizedFn(async (query: string, options: WorkspaceSearchOptions) => {
+    const context = captureWorkspaceContext();
+    const requestId = ++workspaceSearchRequestId.current;
+    const normalized = query.trim();
+    const workspaceRoot = appState.workspaceRoot;
+    appState.workspaceSearchScope = options.scope;
+    if (!normalized) {
       appState.workspaceSearchResults = [];
       appState.workspaceSearchQuery = '';
+      appState.workspaceSearchResultScope = null;
+      appState.workspaceSearchResultRoot = null;
+      appState.workspaceSearchResultsTruncated = false;
+      appState.workspaceSearchLoading = false;
       appState.workspaceSearchError = null;
       return;
     }
     appState.workspaceSearchLoading = true;
     appState.workspaceSearchError = null;
     try {
-      const normalized = query.trim();
-      appState.workspaceSearchResults = await codeApi.searchWorkspace(appState.workspaceRoot, normalized);
+      const results = await codeApi.searchWorkspace(workspaceRoot, normalized, {
+        ...(options.scope === 'source' ? { excludePattern: DEFAULT_WORKSPACE_SEARCH_EXCLUDE_PATTERN } : {}),
+        maxResults: WORKSPACE_SEARCH_RESULT_LIMIT + 1,
+      });
+      if (requestId !== workspaceSearchRequestId.current || !isWorkspaceContextCurrent(context)) return;
+      const bounded = limitWorkspaceSearchResults(results);
+      appState.workspaceSearchResults = bounded.results;
+      appState.workspaceSearchResultsTruncated = bounded.truncated;
       appState.workspaceSearchQuery = normalized;
+      appState.workspaceSearchResultScope = options.scope;
+      appState.workspaceSearchResultRoot = workspaceRoot;
     } catch (error) {
+      if (requestId !== workspaceSearchRequestId.current || !isWorkspaceContextCurrent(context)) return;
       const message = formatApiError(error);
       appState.workspaceSearchError = message;
       showToast(message, 'error');
     } finally {
-      appState.workspaceSearchLoading = false;
+      if (requestId === workspaceSearchRequestId.current && isWorkspaceContextCurrent(context)) {
+        appState.workspaceSearchLoading = false;
+      }
     }
   });
 
   const replaceWorkspace = useMemoizedFn(async (query: string, replacement: string, filePaths: string[]) => {
+    const context = captureWorkspaceContext();
+    const workspaceRoot = appState.workspaceRoot;
+    if (appState.workspaceSearchResultsTruncated) {
+      const error = new Error('搜索结果超过安全展示上限，请缩小搜索范围后再替换。');
+      showToast(error.message, 'error');
+      throw error;
+    }
     const dirtyTab = appState.editorTabs.find(
       (tab) => tab.kind === 'file' && filePaths.includes(tab.path) && isFileEditorTabDirty(tab)
     );
@@ -423,13 +688,14 @@ export function useWorkspaceController() {
     appState.workspaceReplaceLoading = true;
     try {
       const result = await codeApi.replaceWorkspace({
-        rootPath: appState.workspaceRoot,
+        rootPath: workspaceRoot,
         query,
         replacement,
         filePaths,
       });
+      if (!isWorkspaceContextCurrent(context)) return;
       showToast(`已在 ${result.filesModified} 个文件中完成 ${result.totalReplacements} 处替换`, 'success');
-      await searchWorkspace(query);
+      await searchWorkspace(query, { scope: appState.workspaceSearchResultScope ?? appState.workspaceSearchScope });
       const openPaths = appState.editorTabs
         .filter((tab): tab is WorkspaceFileEditorTab => tab.kind === 'file' && filePaths.includes(tab.path))
         .map((tab) => tab.path);
@@ -437,28 +703,35 @@ export function useWorkspaceController() {
         openPaths.map((path) => openFile({ path, isBinary: false }, { forceReload: true, activate: false }))
       );
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
       throw error;
     } finally {
-      appState.workspaceReplaceLoading = false;
+      if (isWorkspaceContextCurrent(context)) appState.workspaceReplaceLoading = false;
     }
   });
 
   const refreshGitStatus = useMemoizedFn(async () => {
+    const context = captureWorkspaceContext();
+    const workspaceRoot = appState.workspaceRoot;
     appState.gitStatusLoading = true;
     appState.gitStatusError = null;
     try {
-      appState.gitStatus = await codeApi.gitStatus(appState.workspaceRoot);
+      const status = await codeApi.gitStatus(workspaceRoot);
+      if (!isWorkspaceContextCurrent(context)) return;
+      appState.gitStatus = status;
     } catch (error) {
+      if (!isWorkspaceContextCurrent(context)) return;
       const message = formatApiError(error);
       appState.gitStatusError = message;
       showToast(message, 'error');
     } finally {
-      appState.gitStatusLoading = false;
+      if (isWorkspaceContextCurrent(context)) appState.gitStatusLoading = false;
     }
   });
 
   const loadGitDiff = useMemoizedFn(async (path: string, staged = false) => {
+    const context = captureWorkspaceContext();
+    const workspaceRoot = appState.workspaceRoot;
     const id = diffEditorTabId(path, staged);
     const existing = appState.editorTabs.find((tab) => tab.id === id);
     if (existing?.kind === 'diff') {
@@ -482,7 +755,8 @@ export function useWorkspaceController() {
     appState.gitDiffError = null;
     navigateTask('review');
     try {
-      const diff = await codeApi.gitDiff(appState.workspaceRoot, path, staged);
+      const diff = await codeApi.gitDiff(workspaceRoot, path, staged);
+      if (!isWorkspaceContextCurrent(context)) return;
       updateDiffTab(id, (tab) => {
         tab.path = diff.path || path;
         tab.original = diff.original;
@@ -492,6 +766,7 @@ export function useWorkspaceController() {
         tab.loadError = null;
       });
     } catch (error) {
+      if (!isWorkspaceContextCurrent(context)) return;
       const message = formatApiError(error);
       updateDiffTab(id, (tab) => {
         tab.loadError = message;
@@ -499,33 +774,42 @@ export function useWorkspaceController() {
       appState.gitDiffError = { path, staged, message };
       showToast(message, 'error');
     } finally {
-      updateDiffTab(id, (tab) => {
-        tab.loading = false;
-      });
+      if (isWorkspaceContextCurrent(context)) {
+        updateDiffTab(id, (tab) => {
+          tab.loading = false;
+        });
+      }
     }
   });
 
   const setGitStaged = useMemoizedFn(async (paths: string[], staged: boolean) => {
+    const context = captureWorkspaceContext();
+    const workspaceRoot = appState.workspaceRoot;
     appState.gitActionLoading = true;
     appState.lastCommitReceipt = null;
     try {
-      appState.gitStatus = staged
-        ? await codeApi.gitStage(appState.workspaceRoot, paths)
-        : await codeApi.gitUnstage(appState.workspaceRoot, paths);
+      const status = staged
+        ? await codeApi.gitStage(workspaceRoot, paths)
+        : await codeApi.gitUnstage(workspaceRoot, paths);
+      if (!isWorkspaceContextCurrent(context)) return;
+      appState.gitStatus = status;
       removeEditorTabs((tab) => tab.kind === 'diff');
       appState.gitDiffError = null;
       showToast(staged ? '已加入暂存区' : '已移出暂存区', 'success');
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
     } finally {
-      appState.gitActionLoading = false;
+      if (isWorkspaceContextCurrent(context)) appState.gitActionLoading = false;
     }
   });
 
   const commitGitChanges = useMemoizedFn(async (message: string) => {
+    const context = captureWorkspaceContext();
+    const workspaceRoot = appState.workspaceRoot;
     appState.gitActionLoading = true;
     try {
-      const result = await codeApi.gitCommit(appState.workspaceRoot, message);
+      const result = await codeApi.gitCommit(workspaceRoot, message);
+      if (!isWorkspaceContextCurrent(context)) return;
       appState.gitStatus = result.status;
       removeEditorTabs((tab) => tab.kind === 'diff');
       appState.gitDiffError = null;
@@ -536,17 +820,24 @@ export function useWorkspaceController() {
       };
       showToast(result.summary.split('\n')[0] || '提交已创建', 'success');
     } catch (error) {
-      showToast(formatApiError(error), 'error');
+      if (isWorkspaceContextCurrent(context)) showToast(formatApiError(error), 'error');
       throw error;
     } finally {
-      appState.gitActionLoading = false;
+      if (isWorkspaceContextCurrent(context)) appState.gitActionLoading = false;
     }
   });
 
   return {
+    canNavigateEditorBack: editorNavigation.canNavigateBack,
+    canNavigateEditorForward: editorNavigation.canNavigateForward,
     refreshDirectory,
     toggleDirectory,
+    findWorkspaceFiles,
     selectFile,
+    navigateEditorBack: editorNavigation.navigateBack,
+    navigateEditorForward: editorNavigation.navigateForward,
+    updateEditorPosition: editorNavigation.updatePosition,
+    consumeEditorLocation,
     activateEditorTab,
     closeEditorTab,
     confirmEditorTabClose,

--- a/apps/web/src/features/workspace/use-workspace-editor-model-lifecycle.test.tsx
+++ b/apps/web/src/features/workspace/use-workspace-editor-model-lifecycle.test.tsx
@@ -1,0 +1,128 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { editor } from 'monaco-editor';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appState } from '../../state/app-state';
+import {
+  clearWorkspaceEditorModels,
+  saveWorkspaceEditorModel,
+  workspaceEditorModelPath,
+} from './components/monaco-editor-model-store';
+import { useWorkspaceController } from './use-workspace-controller';
+import { useWorkspaceEditorModelLifecycle } from './use-workspace-editor-model-lifecycle';
+import {
+  captureWorkspaceTaskSnapshot,
+  createWorkspaceTaskState,
+  fileEditorTabId,
+  type WorkspaceFileEditorTab,
+} from './workspace-state';
+
+describe('workspace editor model lifecycle', () => {
+  beforeEach(() => {
+    appState.activeSessionId = 'task-a';
+    appState.editorModelScope = 'scope-a';
+    appState.workspaceRoot = '/repo';
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    appState.pendingEditorTabCloseId = null;
+    appState.workspaceSnapshotsByTask = {};
+  });
+
+  afterEach(() => {
+    clearWorkspaceEditorModels();
+    appState.activeSessionId = null;
+    appState.editorTabs = [];
+    appState.activeEditorTabId = null;
+    appState.pendingEditorTabCloseId = null;
+    appState.workspaceSnapshotsByTask = {};
+  });
+
+  it('retains models owned by the active task and inactive task snapshots while disposing orphans', async () => {
+    const activeTab = fileTab('/repo/a.ts', false);
+    appState.editorTabs = [activeTab];
+    appState.activeEditorTabId = activeTab.id;
+    const inactive = createWorkspaceTaskState('/repo');
+    inactive.editorModelScope = 'scope-b';
+    inactive.editorTabs = [fileTab('/repo/b.ts', false)];
+    inactive.activeEditorTabId = inactive.editorTabs[0].id;
+    appState.workspaceSnapshotsByTask = {
+      'task-a': captureWorkspaceTaskSnapshot(createWorkspaceTaskState('/stale'), 'review'),
+      'task-b': captureWorkspaceTaskSnapshot(inactive, 'review'),
+    };
+    const activeModel = fakeModel();
+    const inactiveModel = fakeModel();
+    const orphanModel = fakeModel();
+    saveWorkspaceEditorModel(workspaceEditorModelPath('scope-a', activeTab.path), activeModel.value, null);
+    saveWorkspaceEditorModel(
+      workspaceEditorModelPath('scope-b', inactive.editorTabs[0].path),
+      inactiveModel.value,
+      null
+    );
+    saveWorkspaceEditorModel(workspaceEditorModelPath('scope-orphan', '/repo/orphan.ts'), orphanModel.value, null);
+
+    renderHook(() => useWorkspaceEditorModelLifecycle());
+
+    await waitFor(() => expect(orphanModel.dispose).toHaveBeenCalledTimes(1));
+    expect(activeModel.dispose).not.toHaveBeenCalled();
+    expect(inactiveModel.dispose).not.toHaveBeenCalled();
+
+    act(() => {
+      appState.editorTabs = [];
+      appState.activeEditorTabId = null;
+    });
+    await waitFor(() => expect(activeModel.dispose).toHaveBeenCalledTimes(1));
+    expect(inactiveModel.dispose).not.toHaveBeenCalled();
+  });
+
+  it('keeps a dirty model until close confirmation removes its tab', async () => {
+    const tab = fileTab('/repo/dirty.ts', true);
+    appState.editorTabs = [tab];
+    appState.activeEditorTabId = tab.id;
+    const model = fakeModel();
+    saveWorkspaceEditorModel(workspaceEditorModelPath('scope-a', tab.path), model.value, null);
+    const hook = renderHook(() => {
+      const actions = useWorkspaceController();
+      useWorkspaceEditorModelLifecycle();
+      return actions;
+    });
+
+    act(() => hook.result.current.closeEditorTab(tab.id));
+    expect(appState.pendingEditorTabCloseId).toBe(tab.id);
+    expect(model.dispose).not.toHaveBeenCalled();
+
+    act(() => hook.result.current.confirmEditorTabClose());
+    await waitFor(() => expect(model.dispose).toHaveBeenCalledTimes(1));
+    expect(appState.editorTabs).toEqual([]);
+  });
+});
+
+function fileTab(path: string, dirty: boolean): WorkspaceFileEditorTab {
+  return {
+    id: fileEditorTabId(path),
+    kind: 'file',
+    path,
+    content: 'saved',
+    draft: dirty ? 'unsaved' : 'saved',
+    revision: null,
+    isBinary: false,
+    location: null,
+    loading: false,
+    loadError: null,
+    saving: false,
+    configValidation: null,
+  };
+}
+
+function fakeModel(): { value: editor.ITextModel; dispose: ReturnType<typeof vi.fn> } {
+  const dispose = vi.fn();
+  let disposed = false;
+  dispose.mockImplementation(() => {
+    disposed = true;
+  });
+  return {
+    value: {
+      dispose,
+      isDisposed: () => disposed,
+    } as unknown as editor.ITextModel,
+    dispose,
+  };
+}

--- a/apps/web/src/features/workspace/use-workspace-editor-model-lifecycle.ts
+++ b/apps/web/src/features/workspace/use-workspace-editor-model-lifecycle.ts
@@ -1,0 +1,33 @@
+import { useEffect, useMemo } from 'react';
+import { useSnapshot } from 'valtio';
+import { appState } from '../../state/app-state';
+import { taskDraftKey } from '../tasks/task-state';
+import { disposeWorkspaceEditorModelsExcept, workspaceEditorModelPath } from './components/monaco-editor-model-store';
+
+export function useWorkspaceEditorModelLifecycle(): void {
+  const state = useSnapshot(appState);
+  const retainedModelPaths = useMemo(() => {
+    const retained = new Set<string>();
+    addFileTabModelPaths(retained, state.editorModelScope, state.editorTabs);
+    const activeTaskKey = taskDraftKey(state.activeSessionId);
+    for (const [taskKey, snapshot] of Object.entries(state.workspaceSnapshotsByTask)) {
+      if (taskKey === activeTaskKey) continue;
+      addFileTabModelPaths(retained, snapshot.state.editorModelScope, snapshot.state.editorTabs);
+    }
+    return retained;
+  }, [state.activeSessionId, state.editorModelScope, state.editorTabs, state.workspaceSnapshotsByTask]);
+
+  useEffect(() => {
+    disposeWorkspaceEditorModelsExcept(retainedModelPaths);
+  }, [retainedModelPaths]);
+}
+
+function addFileTabModelPaths(
+  target: Set<string>,
+  scope: string,
+  tabs: ReadonlyArray<{ kind: 'file' | 'diff'; path: string }>
+): void {
+  for (const tab of tabs) {
+    if (tab.kind === 'file') target.add(workspaceEditorModelPath(scope, tab.path));
+  }
+}

--- a/apps/web/src/features/workspace/use-workspace-persistence.ts
+++ b/apps/web/src/features/workspace/use-workspace-persistence.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { subscribe } from 'valtio';
+import { appState, reportTaskPersistenceResult } from '../../state/app-state';
+import { taskDraftKey } from '../tasks/task-state';
+import { persistWorkspaceTaskSnapshots } from './workspace-state';
+
+const persistenceDelayMs = 300;
+
+function persistActiveWorkspace(): void {
+  reportTaskPersistenceResult(
+    persistWorkspaceTaskSnapshots(
+      appState.workspaceSnapshotsByTask,
+      taskDraftKey(appState.activeSessionId),
+      appState,
+      appState.taskView
+    )
+  );
+}
+
+export function useWorkspacePersistence(): void {
+  useEffect(() => {
+    let timer: number | null = null;
+    const flush = () => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = null;
+      persistActiveWorkspace();
+    };
+    const schedule = () => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = window.setTimeout(flush, persistenceDelayMs);
+    };
+    const unsubscribe = subscribe(appState, schedule);
+    window.addEventListener('pagehide', flush);
+    schedule();
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      unsubscribe();
+      flush();
+    };
+  }, []);
+}

--- a/apps/web/src/features/workspace/workspace-actions.ts
+++ b/apps/web/src/features/workspace/workspace-actions.ts
@@ -1,9 +1,18 @@
+import type { WorkspaceFileCatalog } from '../../types/api';
 import type { WorkspaceFileSelection } from './workspace-state';
+import type { WorkspaceSearchOptions } from './workspace-search';
 
 export interface WorkspaceActions {
+  canNavigateEditorBack: boolean;
+  canNavigateEditorForward: boolean;
   refreshDirectory(path?: string): Promise<void>;
   toggleDirectory(path: string): Promise<void>;
+  findWorkspaceFiles(query: string, maxResults?: number): Promise<WorkspaceFileCatalog>;
   selectFile(file: WorkspaceFileSelection): Promise<boolean>;
+  navigateEditorBack(): Promise<boolean>;
+  navigateEditorForward(): Promise<boolean>;
+  updateEditorPosition(tabId: string, position: { line: number; column: number }): void;
+  consumeEditorLocation(tabId: string): void;
   activateEditorTab(tabId: string): void;
   closeEditorTab(tabId: string): void;
   confirmEditorTabClose(): void;
@@ -17,7 +26,7 @@ export interface WorkspaceActions {
   renameWorkspaceEntry(path: string, name: string): Promise<void>;
   copyWorkspaceEntry(path: string, name: string): Promise<void>;
   deleteWorkspaceEntry(path: string): Promise<void>;
-  searchWorkspace(query: string): Promise<void>;
+  searchWorkspace(query: string, options: WorkspaceSearchOptions): Promise<void>;
   replaceWorkspace(query: string, replacement: string, filePaths: string[]): Promise<void>;
   refreshGitStatus(): Promise<void>;
   loadGitDiff(path: string, staged?: boolean): Promise<void>;

--- a/apps/web/src/features/workspace/workspace-persistence.test.tsx
+++ b/apps/web/src/features/workspace/workspace-persistence.test.tsx
@@ -1,0 +1,286 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { appState } from '../../state/app-state';
+import {
+  captureWorkspaceTaskSnapshot,
+  createWorkspaceState,
+  createWorkspaceTaskState,
+  fileEditorTabId,
+  persistWorkspaceTaskSnapshots,
+  workspaceSnapshotsStorageKey,
+} from './workspace-state';
+import { useWorkspacePersistence } from './use-workspace-persistence';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  localStorage.removeItem(workspaceSnapshotsStorageKey);
+  appState.activeSessionId = null;
+  appState.workspaceSnapshotsByTask = {};
+  appState.workspaceRoot = '';
+  appState.editorTabs = [];
+  appState.activeEditorTabId = null;
+  appState.taskView = 'conversation';
+});
+
+describe('workspace task persistence', () => {
+  it('restores task-scoped tabs and dirty drafts after a fresh state initialization', () => {
+    const taskA = createWorkspaceTaskState('/repo');
+    const taskATab = {
+      id: fileEditorTabId('/repo/src/a.ts'),
+      kind: 'file' as const,
+      path: '/repo/src/a.ts',
+      content: 'saved A',
+      draft: 'dirty A',
+      revision: 'sha256:saved-a',
+      isBinary: false,
+      location: { line: 7, column: 3 },
+      loading: false,
+      loadError: null,
+      saving: false,
+      configValidation: null,
+    };
+    taskA.editorTabs = [taskATab];
+    taskA.activeEditorTabId = taskATab.id;
+    taskA.workspaceSearchQuery = 'needle';
+    taskA.workspacePresentation = 'fullscreen';
+    const taskB = createWorkspaceTaskState('/repo');
+    taskB.editorTabs = [
+      {
+        ...taskATab,
+        id: fileEditorTabId('/repo/src/b.ts'),
+        path: '/repo/src/b.ts',
+        content: 'saved B',
+        draft: 'saved B',
+      },
+    ];
+    taskB.activeEditorTabId = taskB.editorTabs[0].id;
+
+    expect(
+      persistWorkspaceTaskSnapshots(
+        { 'task-b': captureWorkspaceTaskSnapshot(taskB, 'activity') },
+        'task-a',
+        taskA,
+        'review'
+      )
+    ).toBe(true);
+
+    const restoredA = createWorkspaceState('task-a');
+    expect(restoredA.workspaceRoot).toBe('/repo');
+    expect(restoredA.editorModelScope).toBe(taskA.editorModelScope);
+    expect(restoredA.activeEditorTabId).toBe(taskATab.id);
+    expect(restoredA.editorTabs[0]).toMatchObject({
+      path: taskATab.path,
+      content: 'saved A',
+      draft: 'dirty A',
+      revision: 'sha256:saved-a',
+      location: { line: 7, column: 3 },
+    });
+    expect(restoredA.workspaceSearchQuery).toBe('needle');
+    expect(restoredA.workspacePresentation).toBe('fullscreen');
+    expect(restoredA.workspaceSnapshotsByTask['task-a']?.taskView).toBe('review');
+    expect(restoredA.workspaceSnapshotsByTask['task-b']?.taskView).toBe('activity');
+
+    const restoredB = createWorkspaceState('task-b');
+    expect(restoredB.editorModelScope).toBe(taskB.editorModelScope);
+    expect(restoredB.editorModelScope).not.toBe(restoredA.editorModelScope);
+    expect(restoredB.editorTabs[0]).toMatchObject({ path: '/repo/src/b.ts', draft: 'saved B' });
+    expect(restoredB.activeEditorTabId).toBe(fileEditorTabId('/repo/src/b.ts'));
+  });
+
+  it('ignores malformed persisted snapshots instead of breaking application startup', () => {
+    localStorage.setItem(
+      workspaceSnapshotsStorageKey,
+      JSON.stringify({
+        version: 1,
+        snapshots: { 'task-a': { taskView: 'review', state: { workspaceRoot: '/repo' } } },
+      })
+    );
+
+    expect(() => createWorkspaceState('task-a')).not.toThrow();
+    const restored = createWorkspaceState('task-a');
+    expect(restored.workspaceRoot).toBe('');
+    expect(restored.editorTabs).toEqual([]);
+    expect(restored.workspaceSnapshotsByTask).toEqual({});
+  });
+
+  it('restores pre-presentation snapshots as docked workspaces', () => {
+    const legacy = captureWorkspaceTaskSnapshot(createWorkspaceTaskState('/repo'), 'review');
+    Reflect.deleteProperty(legacy.state, 'workspacePresentation');
+    localStorage.setItem(workspaceSnapshotsStorageKey, JSON.stringify({ version: 1, snapshots: { 'task-a': legacy } }));
+
+    const restored = createWorkspaceState('task-a');
+
+    expect(restored.workspaceRoot).toBe('/repo');
+    expect(restored.workspacePresentation).toBe('docked');
+    expect(restored.workspaceSnapshotsByTask['task-a']?.taskView).toBe('review');
+  });
+
+  it('restores legacy file tabs without revisions using content-based save compatibility', () => {
+    const state = createWorkspaceTaskState('/repo');
+    state.editorTabs = [
+      {
+        id: fileEditorTabId('/repo/legacy.ts'),
+        kind: 'file',
+        path: '/repo/legacy.ts',
+        content: 'saved legacy content',
+        draft: 'unsaved legacy content',
+        revision: 'sha256:legacy',
+        isBinary: false,
+        location: null,
+        loading: false,
+        loadError: null,
+        saving: false,
+        configValidation: null,
+      },
+    ];
+    state.activeEditorTabId = state.editorTabs[0].id;
+    const legacy = captureWorkspaceTaskSnapshot(state, 'review');
+    Reflect.deleteProperty(legacy.state.editorTabs[0], 'revision');
+    localStorage.setItem(workspaceSnapshotsStorageKey, JSON.stringify({ version: 1, snapshots: { legacy } }));
+
+    const restored = createWorkspaceState('legacy');
+
+    expect(restored.editorTabs[0]).toMatchObject({
+      path: '/repo/legacy.ts',
+      content: 'saved legacy content',
+      draft: 'unsaved legacy content',
+      revision: null,
+    });
+  });
+
+  it('upgrades a legacy task snapshot with a stable editor model scope', () => {
+    const legacy = captureWorkspaceTaskSnapshot(createWorkspaceTaskState('/repo'), 'review');
+    Reflect.deleteProperty(legacy.state, 'editorModelScope');
+    localStorage.setItem(workspaceSnapshotsStorageKey, JSON.stringify({ version: 1, snapshots: { 'task-a': legacy } }));
+
+    const firstRestore = createWorkspaceState('task-a');
+    expect(firstRestore.editorModelScope).toEqual(expect.any(String));
+    expect(firstRestore.editorModelScope).not.toBe('');
+    expect(firstRestore.workspaceSnapshotsByTask['task-a']?.state.editorModelScope).toBe(firstRestore.editorModelScope);
+
+    persistWorkspaceTaskSnapshots(firstRestore.workspaceSnapshotsByTask, 'task-a', firstRestore, 'review');
+    const secondRestore = createWorkspaceState('task-a');
+    expect(secondRestore.editorModelScope).toBe(firstRestore.editorModelScope);
+  });
+
+  it('falls back to dirty-draft recovery when the complete snapshot exceeds browser storage', () => {
+    const state = createWorkspaceTaskState('/repo');
+    state.editorTabs = [
+      {
+        id: fileEditorTabId('/repo/dirty.ts'),
+        kind: 'file',
+        path: '/repo/dirty.ts',
+        content: 'saved dirty file',
+        draft: 'unsaved dirty file',
+        revision: null,
+        isBinary: false,
+        location: null,
+        loading: false,
+        loadError: null,
+        saving: false,
+        configValidation: null,
+      },
+      {
+        id: fileEditorTabId('/repo/clean.ts'),
+        kind: 'file',
+        path: '/repo/clean.ts',
+        content: 'large clean content',
+        draft: 'large clean content',
+        revision: null,
+        isBinary: false,
+        location: null,
+        loading: false,
+        loadError: null,
+        saving: false,
+        configValidation: null,
+      },
+      {
+        id: 'diff:working:/repo/changed.ts',
+        kind: 'diff',
+        path: '/repo/changed.ts',
+        staged: false,
+        original: 'large original diff',
+        modified: 'large modified diff',
+        unified: 'large unified diff',
+        isBinary: false,
+        loading: false,
+        loadError: null,
+      },
+    ];
+    state.activeEditorTabId = state.editorTabs[0].id;
+    const setItem = Storage.prototype.setItem;
+    let snapshotWrites = 0;
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === workspaceSnapshotsStorageKey && snapshotWrites++ === 0) {
+        throw new DOMException('Quota exceeded', 'QuotaExceededError');
+      }
+      return setItem.call(this, key, value);
+    });
+
+    expect(persistWorkspaceTaskSnapshots({}, 'task-a', state, 'review')).toBe(true);
+
+    const restored = createWorkspaceState('task-a');
+    expect(restored.editorTabs[0]).toMatchObject({
+      path: '/repo/dirty.ts',
+      content: 'saved dirty file',
+      draft: 'unsaved dirty file',
+      loadError: null,
+    });
+    expect(restored.editorTabs[1]).toMatchObject({
+      path: '/repo/clean.ts',
+      content: '',
+      draft: '',
+      loadError: '文件内容未随刷新恢复，请重试。',
+    });
+    expect(restored.editorTabs[2]).toMatchObject({
+      path: '/repo/changed.ts',
+      original: '',
+      modified: '',
+      unified: '',
+      loadError: '差异内容未随刷新恢复，请重试。',
+    });
+  });
+
+  it('flushes the active dirty editor state on pagehide before a refresh', () => {
+    vi.useFakeTimers();
+    const tab = {
+      id: fileEditorTabId('/repo/src/live.ts'),
+      kind: 'file' as const,
+      path: '/repo/src/live.ts',
+      content: 'saved',
+      draft: 'saved',
+      revision: null,
+      isBinary: false,
+      location: null,
+      loading: false,
+      loadError: null,
+      saving: false,
+      configValidation: null,
+    };
+    appState.activeSessionId = 'task-live';
+    appState.workspaceRoot = '/repo';
+    appState.editorTabs = [tab];
+    appState.activeEditorTabId = tab.id;
+    appState.taskView = 'review';
+    appState.workspacePresentation = 'fullscreen';
+    const hook = renderHook(() => useWorkspacePersistence());
+
+    act(() => {
+      const activeTab = appState.editorTabs[0];
+      if (activeTab.kind === 'file') activeTab.draft = 'unsaved before refresh';
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    const restored = createWorkspaceState('task-live');
+    expect(restored.activeEditorTabId).toBe(tab.id);
+    expect(restored.editorTabs[0]).toMatchObject({
+      path: tab.path,
+      content: 'saved',
+      draft: 'unsaved before refresh',
+    });
+    expect(restored.workspaceSnapshotsByTask['task-live']?.taskView).toBe('review');
+    expect(restored.workspacePresentation).toBe('fullscreen');
+    hook.unmount();
+  });
+});

--- a/apps/web/src/features/workspace/workspace-search.test.ts
+++ b/apps/web/src/features/workspace/workspace-search.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { limitWorkspaceSearchResults, workspaceSearchMatchPreview } from './workspace-search';
+
+describe('workspace search match previews', () => {
+  it('bounds legacy full-line results around the selected match', () => {
+    const line = `${'a'.repeat(1_000)}target${'b'.repeat(1_000)}`;
+    const preview = workspaceSearchMatchPreview(
+      { line: 1, column: 1_001, text: line, matchStart: 1_000, matchEnd: 1_006 },
+      'target'
+    );
+
+    expect(preview.match).toBe('target');
+    expect(preview.before.startsWith('…')).toBe(true);
+    expect(preview.before.length).toBeLessThanOrEqual(49);
+    expect(preview.after.endsWith('…')).toBe(true);
+    expect(`${preview.before}${preview.match}${preview.after}`.length).toBeLessThanOrEqual(328);
+  });
+
+  it('recovers a legacy byte offset that is not a valid UTF-16 match', () => {
+    const preview = workspaceSearchMatchPreview(
+      { line: 1, column: 4, text: 'İTARGET', matchStart: 3, matchEnd: 9 },
+      'target'
+    );
+
+    expect(preview).toEqual({ before: 'İ', match: 'TARGET', after: '' });
+  });
+});
+
+describe('workspace search result limit', () => {
+  it('preserves file grouping while reserving one match as an overflow signal', () => {
+    const bounded = limitWorkspaceSearchResults(
+      [
+        {
+          path: '/repo/first.ts',
+          matches: Array.from({ length: 2 }, (_, index) => ({
+            line: index + 1,
+            column: 1,
+            text: 'target',
+            matchStart: 0,
+            matchEnd: 6,
+          })),
+        },
+        {
+          path: '/repo/second.ts',
+          matches: Array.from({ length: 2 }, (_, index) => ({
+            line: index + 1,
+            column: 1,
+            text: 'target',
+            matchStart: 0,
+            matchEnd: 6,
+          })),
+        },
+      ],
+      3
+    );
+
+    expect(bounded.truncated).toBe(true);
+    expect(bounded.results.map((file) => [file.path, file.matches.length])).toEqual([
+      ['/repo/first.ts', 2],
+      ['/repo/second.ts', 1],
+    ]);
+  });
+});

--- a/apps/web/src/features/workspace/workspace-search.ts
+++ b/apps/web/src/features/workspace/workspace-search.ts
@@ -1,0 +1,139 @@
+import type { WorkspaceSearchFile, WorkspaceSearchMatch } from '../../types/api';
+
+const SEARCH_MATCH_LEADING_CONTEXT_UNITS = 48;
+const SEARCH_MATCH_TRAILING_CONTEXT_UNITS = 160;
+export const WORKSPACE_SEARCH_RESULT_LIMIT = 300;
+
+const defaultExcludedDirectories = [
+  '.git/',
+  '.a3s/',
+  'node_modules/',
+  'target/',
+  'dist/',
+  'build/',
+  'coverage/',
+  '.next/',
+  '.venv/',
+  'venv/',
+];
+
+export const DEFAULT_WORKSPACE_SEARCH_EXCLUDE_PATTERN = defaultExcludedDirectories
+  .flatMap((directory) => [`${directory}*`, `*/${directory}*`])
+  .join(',');
+
+export type WorkspaceSearchScope = 'source' | 'all';
+
+export interface WorkspaceSearchOptions {
+  scope: WorkspaceSearchScope;
+}
+
+export interface WorkspaceSearchMatchPreview {
+  before: string;
+  match: string;
+  after: string;
+}
+
+export function limitWorkspaceSearchResults(
+  files: WorkspaceSearchFile[],
+  limit = WORKSPACE_SEARCH_RESULT_LIMIT
+): { results: WorkspaceSearchFile[]; truncated: boolean } {
+  const boundedLimit = Math.max(0, Math.trunc(limit));
+  const truncated = files.reduce((total, file) => total + file.matches.length, 0) > boundedLimit;
+  const results: WorkspaceSearchFile[] = [];
+  let remaining = boundedLimit;
+  for (const file of files) {
+    if (remaining === 0) break;
+    const matches = file.matches.slice(0, remaining);
+    if (matches.length) results.push({ ...file, matches });
+    remaining -= matches.length;
+  }
+  return { results, truncated };
+}
+
+export function workspaceSearchMatchPreview(match: WorkspaceSearchMatch, query: string): WorkspaceSearchMatchPreview {
+  const text = match.text;
+  let start = utf16Boundary(text, clampOffset(match.matchStart, text.length), 'backward');
+  let end = utf16Boundary(text, clampOffset(match.matchEnd, text.length), 'forward');
+  if (end < start) end = start;
+
+  if (query && text.slice(start, end).toLowerCase() !== query.toLowerCase()) {
+    const recovered = closestCaseInsensitiveMatch(text, query, start);
+    if (recovered) [start, end] = recovered;
+  }
+
+  const previewStart = retreatCodePoints(text, start, SEARCH_MATCH_LEADING_CONTEXT_UNITS);
+  const previewEnd = advanceCodePoints(text, end, SEARCH_MATCH_TRAILING_CONTEXT_UNITS);
+  return {
+    before: `${previewStart > 0 ? '…' : ''}${text.slice(previewStart, start)}`,
+    match: text.slice(start, end),
+    after: `${text.slice(end, previewEnd)}${previewEnd < text.length ? '…' : ''}`,
+  };
+}
+
+function closestCaseInsensitiveMatch(text: string, query: string, approximateStart: number): [number, number] | null {
+  const pattern = new RegExp(escapeRegExp(query), 'giu');
+  let closest: [number, number] | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of text.matchAll(pattern)) {
+    const start = candidate.index;
+    const distance = Math.abs(start - approximateStart);
+    if (distance < closestDistance) {
+      closest = [start, start + candidate[0].length];
+      closestDistance = distance;
+    }
+  }
+  return closest;
+}
+
+function retreatCodePoints(text: string, index: number, count: number): number {
+  let cursor = index;
+  for (let remaining = count; remaining > 0 && cursor > 0; remaining -= 1) {
+    cursor -= 1;
+    if (cursor > 0 && isLowSurrogate(text.charCodeAt(cursor)) && isHighSurrogate(text.charCodeAt(cursor - 1))) {
+      cursor -= 1;
+    }
+  }
+  return cursor;
+}
+
+function advanceCodePoints(text: string, index: number, count: number): number {
+  let cursor = index;
+  for (let remaining = count; remaining > 0 && cursor < text.length; remaining -= 1) {
+    const width =
+      isHighSurrogate(text.charCodeAt(cursor)) &&
+      cursor + 1 < text.length &&
+      isLowSurrogate(text.charCodeAt(cursor + 1))
+        ? 2
+        : 1;
+    cursor += width;
+  }
+  return cursor;
+}
+
+function utf16Boundary(text: string, index: number, direction: 'backward' | 'forward'): number {
+  if (
+    index > 0 &&
+    index < text.length &&
+    isHighSurrogate(text.charCodeAt(index - 1)) &&
+    isLowSurrogate(text.charCodeAt(index))
+  ) {
+    return direction === 'backward' ? index - 1 : index + 1;
+  }
+  return index;
+}
+
+function clampOffset(value: number, length: number): number {
+  return Math.min(length, Math.max(0, Number.isFinite(value) ? Math.trunc(value) : 0));
+}
+
+function isHighSurrogate(value: number): boolean {
+  return value >= 0xd800 && value <= 0xdbff;
+}
+
+function isLowSurrogate(value: number): boolean {
+  return value >= 0xdc00 && value <= 0xdfff;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/apps/web/src/features/workspace/workspace-state.ts
+++ b/apps/web/src/features/workspace/workspace-state.ts
@@ -1,4 +1,9 @@
 import type { ConfigValidation, GitStatus, WorkspaceEntry, WorkspaceSearchFile } from '../../types/api';
+import type { TaskView } from '../code/code-state';
+import type { WorkspaceSearchScope } from './workspace-search';
+
+export const workspaceSnapshotsStorageKey = 'a3s-code-web.workspace-task-snapshots';
+const workspaceSnapshotsStorageVersion = 1;
 
 export interface WorkspaceFileSelection {
   path: string;
@@ -13,6 +18,7 @@ export interface WorkspaceFileEditorTab {
   path: string;
   content: string;
   draft: string;
+  revision: string | null;
   isBinary: boolean;
   location: { line: number; column: number } | null;
   loading: boolean;
@@ -35,12 +41,19 @@ export interface WorkspaceDiffEditorTab {
 }
 
 export type WorkspaceEditorTab = WorkspaceFileEditorTab | WorkspaceDiffEditorTab;
+export type WorkspacePresentation = 'docked' | 'fullscreen';
 
-export interface WorkspaceState {
+export interface WorkspaceTaskState {
+  editorModelScope: string;
+  workspacePresentation: WorkspacePresentation;
   reviewSourceTaskId: string | null;
   reviewIntent: 'review' | 'select-context';
   workspaceSearchResults: WorkspaceSearchFile[];
   workspaceSearchQuery: string;
+  workspaceSearchScope: WorkspaceSearchScope;
+  workspaceSearchResultScope: WorkspaceSearchScope | null;
+  workspaceSearchResultRoot: string | null;
+  workspaceSearchResultsTruncated: boolean;
   workspaceSearchLoading: boolean;
   workspaceSearchError: string | null;
   gitStatus: GitStatus | null;
@@ -58,16 +71,32 @@ export interface WorkspaceState {
   activeEditorTabId: string | null;
   pendingEditorTabCloseId: string | null;
   fileLoadError: { selection: WorkspaceFileSelection; message: string } | null;
-  fileConflict: { tabId: string; path: string; diskContent: string } | null;
+  fileConflict: { tabId: string; path: string; diskContent: string; diskRevision: string | null } | null;
   workspaceReplaceLoading: boolean;
 }
 
-export function createWorkspaceState(): WorkspaceState {
+export interface WorkspaceTaskSnapshot {
+  taskView: TaskView;
+  state: WorkspaceTaskState;
+}
+
+export interface WorkspaceState extends WorkspaceTaskState {
+  workspaceSnapshotsByTask: Record<string, WorkspaceTaskSnapshot>;
+  workspaceGeneration: number;
+}
+
+export function createWorkspaceTaskState(workspaceRoot = ''): WorkspaceTaskState {
   return {
+    editorModelScope: createEditorModelScope(),
+    workspacePresentation: 'docked',
     reviewSourceTaskId: null,
     reviewIntent: 'review',
     workspaceSearchResults: [],
     workspaceSearchQuery: '',
+    workspaceSearchScope: 'source',
+    workspaceSearchResultScope: null,
+    workspaceSearchResultRoot: null,
+    workspaceSearchResultsTruncated: false,
     workspaceSearchLoading: false,
     workspaceSearchError: null,
     gitStatus: null,
@@ -76,7 +105,7 @@ export function createWorkspaceState(): WorkspaceState {
     gitDiffError: null,
     gitActionLoading: false,
     lastCommitReceipt: null,
-    workspaceRoot: '',
+    workspaceRoot,
     filesByDirectory: {},
     expandedDirectories: {},
     directoryLoading: {},
@@ -87,6 +116,245 @@ export function createWorkspaceState(): WorkspaceState {
     fileLoadError: null,
     fileConflict: null,
     workspaceReplaceLoading: false,
+  };
+}
+
+export function createWorkspaceState(activeTaskKey?: string): WorkspaceState {
+  const workspaceSnapshotsByTask = readWorkspaceTaskSnapshots();
+  const activeSnapshot = activeTaskKey ? workspaceSnapshotsByTask[activeTaskKey] : undefined;
+  return {
+    ...(activeSnapshot ? cloneWorkspaceTaskState(activeSnapshot.state) : createWorkspaceTaskState()),
+    workspaceSnapshotsByTask,
+    workspaceGeneration: 0,
+  };
+}
+
+export function persistWorkspaceTaskSnapshots(
+  snapshots: Readonly<Record<string, WorkspaceTaskSnapshot>>,
+  activeTaskKey: string,
+  activeState: WorkspaceTaskState,
+  activeTaskView: TaskView
+): boolean {
+  const nextSnapshots = Object.fromEntries(
+    Object.entries(snapshots).map(([key, snapshot]) => [
+      key,
+      captureWorkspaceTaskSnapshot(snapshot.state, snapshot.taskView),
+    ])
+  );
+  nextSnapshots[activeTaskKey] = captureWorkspaceTaskSnapshot(activeState, activeTaskView);
+  const payload = { version: workspaceSnapshotsStorageVersion, snapshots: nextSnapshots };
+  if (writeWorkspaceTaskSnapshots(payload)) return true;
+
+  const recoveryPayload = {
+    version: workspaceSnapshotsStorageVersion,
+    snapshots: Object.fromEntries(
+      Object.entries(nextSnapshots).map(([key, snapshot]) => [key, compactWorkspaceSnapshot(snapshot)])
+    ),
+  };
+  return writeWorkspaceTaskSnapshots(recoveryPayload);
+}
+
+function readWorkspaceTaskSnapshots(): Record<string, WorkspaceTaskSnapshot> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(workspaceSnapshotsStorageKey) ?? 'null') as unknown;
+    if (!isRecord(parsed) || parsed.version !== workspaceSnapshotsStorageVersion || !isRecord(parsed.snapshots)) {
+      return {};
+    }
+    const snapshots: Record<string, WorkspaceTaskSnapshot> = {};
+    for (const [key, value] of Object.entries(parsed.snapshots)) {
+      const snapshot = normalizeWorkspaceTaskSnapshot(value);
+      if (snapshot) snapshots[key] = snapshot;
+    }
+    return snapshots;
+  } catch {
+    return {};
+  }
+}
+
+function writeWorkspaceTaskSnapshots(payload: {
+  version: number;
+  snapshots: Record<string, WorkspaceTaskSnapshot>;
+}): boolean {
+  try {
+    const serialized = JSON.stringify(payload);
+    if (localStorage.getItem(workspaceSnapshotsStorageKey) !== serialized) {
+      localStorage.setItem(workspaceSnapshotsStorageKey, serialized);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeWorkspaceTaskSnapshot(value: unknown): WorkspaceTaskSnapshot | null {
+  if (!isRecord(value) || !isTaskView(value.taskView) || !isWorkspaceTaskStateShape(value.state)) return null;
+  try {
+    const snapshot = captureWorkspaceTaskSnapshot(value.state as unknown as WorkspaceTaskState, value.taskView);
+    return snapshot.state.editorTabs.every(isWorkspaceEditorTab) ? snapshot : null;
+  } catch {
+    return null;
+  }
+}
+
+function isWorkspaceTaskStateShape(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const arrayKeys = ['workspaceSearchResults', 'editorTabs'] as const;
+  const recordKeys = ['filesByDirectory', 'expandedDirectories', 'directoryLoading', 'directoryErrors'] as const;
+  if (!arrayKeys.every((key) => Array.isArray(value[key]))) return false;
+  if (!recordKeys.every((key) => isRecord(value[key]))) return false;
+  const filesByDirectory = value.filesByDirectory;
+  if (!isRecord(filesByDirectory) || !Object.values(filesByDirectory).every(Array.isArray)) return false;
+  if (typeof value.workspaceRoot !== 'string' || typeof value.workspaceSearchQuery !== 'string') return false;
+  return (value.workspaceSearchResults as unknown[]).every((file) => isRecord(file) && Array.isArray(file.matches));
+}
+
+function isWorkspaceEditorTab(value: WorkspaceEditorTab): boolean {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.path !== 'string') return false;
+  if (value.kind === 'diff') {
+    return (
+      typeof value.original === 'string' &&
+      typeof value.modified === 'string' &&
+      typeof value.unified === 'string' &&
+      typeof value.staged === 'boolean'
+    );
+  }
+  return value.kind === 'file' && typeof value.content === 'string' && typeof value.draft === 'string';
+}
+
+function isTaskView(value: unknown): value is TaskView {
+  return value === 'conversation' || value === 'review' || value === 'activity';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function compactWorkspaceSnapshot(snapshot: WorkspaceTaskSnapshot): WorkspaceTaskSnapshot {
+  const state = cloneWorkspaceTaskState(snapshot.state);
+  state.workspaceSearchResults = [];
+  state.workspaceSearchResultScope = null;
+  state.workspaceSearchResultRoot = null;
+  state.workspaceSearchResultsTruncated = false;
+  state.workspaceSearchError = null;
+  state.gitStatus = null;
+  state.gitStatusError = null;
+  state.gitDiffError = null;
+  state.filesByDirectory = {};
+  state.directoryLoading = {};
+  state.directoryErrors = {};
+  state.fileLoadError = null;
+  state.fileConflict = null;
+  state.pendingEditorTabCloseId = null;
+  state.editorTabs = state.editorTabs.map(compactEditorTab);
+  return { taskView: snapshot.taskView, state };
+}
+
+function compactEditorTab(tab: WorkspaceEditorTab): WorkspaceEditorTab {
+  if (tab.kind === 'diff') {
+    return {
+      ...tab,
+      original: '',
+      modified: '',
+      unified: '',
+      loading: false,
+      loadError: '差异内容未随刷新恢复，请重试。',
+    };
+  }
+  if (isFileEditorTabDirty(tab)) {
+    return { ...tab, loading: false, saving: false, configValidation: null };
+  }
+  return {
+    ...tab,
+    content: '',
+    draft: '',
+    loading: false,
+    loadError: '文件内容未随刷新恢复，请重试。',
+    saving: false,
+    configValidation: null,
+  };
+}
+
+export function captureWorkspaceTaskSnapshot(state: WorkspaceTaskState, taskView: TaskView): WorkspaceTaskSnapshot {
+  return { taskView, state: cloneWorkspaceTaskState(state) };
+}
+
+export function restoreWorkspaceTaskState(target: WorkspaceTaskState, source: WorkspaceTaskState): void {
+  Object.assign(target, cloneWorkspaceTaskState(source));
+}
+
+function cloneWorkspaceTaskState(state: WorkspaceTaskState): WorkspaceTaskState {
+  return {
+    editorModelScope:
+      typeof state.editorModelScope === 'string' && state.editorModelScope.trim()
+        ? state.editorModelScope
+        : createEditorModelScope(),
+    workspacePresentation: state.workspacePresentation === 'fullscreen' ? 'fullscreen' : 'docked',
+    reviewSourceTaskId: state.reviewSourceTaskId,
+    reviewIntent: state.reviewIntent,
+    workspaceSearchResults: state.workspaceSearchResults.map((file) => ({
+      ...file,
+      matches: file.matches.map((match) => ({ ...match })),
+    })),
+    workspaceSearchQuery: state.workspaceSearchQuery,
+    workspaceSearchScope: state.workspaceSearchScope,
+    workspaceSearchResultScope: state.workspaceSearchResultScope,
+    workspaceSearchResultRoot: state.workspaceSearchResultRoot,
+    workspaceSearchResultsTruncated: state.workspaceSearchResultsTruncated,
+    workspaceSearchLoading: false,
+    workspaceSearchError: state.workspaceSearchError,
+    gitStatus: state.gitStatus
+      ? { ...state.gitStatus, files: state.gitStatus.files.map((file) => ({ ...file })) }
+      : null,
+    gitStatusLoading: false,
+    gitStatusError: state.gitStatusError,
+    gitDiffError: state.gitDiffError ? { ...state.gitDiffError } : null,
+    gitActionLoading: false,
+    lastCommitReceipt: state.lastCommitReceipt ? { ...state.lastCommitReceipt } : null,
+    workspaceRoot: state.workspaceRoot,
+    filesByDirectory: Object.fromEntries(
+      Object.entries(state.filesByDirectory).map(([path, entries]) => [path, entries.map((entry) => ({ ...entry }))])
+    ),
+    expandedDirectories: { ...state.expandedDirectories },
+    directoryLoading: Object.fromEntries(Object.keys(state.directoryLoading).map((path) => [path, false])),
+    directoryErrors: { ...state.directoryErrors },
+    editorTabs: state.editorTabs.map(cloneEditorTab),
+    activeEditorTabId: state.activeEditorTabId,
+    pendingEditorTabCloseId: state.pendingEditorTabCloseId,
+    fileLoadError: state.fileLoadError
+      ? { selection: { ...state.fileLoadError.selection }, message: state.fileLoadError.message }
+      : null,
+    fileConflict: state.fileConflict
+      ? {
+          ...state.fileConflict,
+          diskRevision: typeof state.fileConflict.diskRevision === 'string' ? state.fileConflict.diskRevision : null,
+        }
+      : null,
+    workspaceReplaceLoading: false,
+  };
+}
+
+function cloneEditorTab(tab: WorkspaceEditorTab): WorkspaceEditorTab {
+  if (tab.kind === 'diff') {
+    return {
+      ...tab,
+      loading: false,
+      loadError: tab.loadError ?? (tab.loading ? '差异加载已暂停，请重试。' : null),
+    };
+  }
+  return {
+    ...tab,
+    revision: typeof tab.revision === 'string' ? tab.revision : null,
+    location: tab.location ? { ...tab.location } : null,
+    loading: false,
+    loadError: tab.loadError ?? (tab.loading ? '文件加载已暂停，请重试。' : null),
+    saving: false,
+    configValidation: tab.configValidation
+      ? {
+          ...tab.configValidation,
+          issues: [...tab.configValidation.issues],
+          summary: tab.configValidation.summary ? { ...tab.configValidation.summary } : tab.configValidation.summary,
+        }
+      : null,
   };
 }
 
@@ -114,4 +382,12 @@ export function workspaceRelativePath(path: string, root: string): string {
 
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
+}
+
+let editorModelScopeSequence = 0;
+
+function createEditorModelScope(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID();
+  editorModelScopeSequence += 1;
+  return `workspace-${Date.now().toString(36)}-${editorModelScopeSequence.toString(36)}`;
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -136,3 +136,86 @@ describe('codeApi workspace code intelligence', () => {
     ]);
   });
 });
+
+describe('codeApi workspace search', () => {
+  it('encodes the optional exclusion pattern and result limit', async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ code: 200, data: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    await codeApi.searchWorkspace('/repo with spaces', 'find me', {
+      excludePattern: '.git/,node_modules/,target/',
+      maxResults: 42,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/workspace/search?rootPath=%2Frepo%20with%20spaces&query=find%20me&excludePattern=.git%2F%2Cnode_modules%2F%2Ctarget%2F&maxResults=42',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+  });
+
+  it('encodes workspace file catalog queries and result limits', async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: 200,
+            data: { workspaceRoot: '/repo with spaces', items: [], total: 0, truncated: false },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    await codeApi.workspaceFiles('/repo with spaces', 'src/app', 25);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/workspace/files?rootPath=%2Frepo%20with%20spaces&query=src%2Fapp&maxResults=25',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+  });
+});
+
+describe('codeApi workspace mutations', () => {
+  it('uses the native workspace routes and request shapes', async () => {
+    const fetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ code: 200, data: { success: true } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    await codeApi.createDirectory('/repo/new folder');
+    await codeApi.createFile('/repo/new file.ts');
+    await codeApi.writeFile('/repo/new file.ts', 'next content', { expectedRevision: 'sha256:baseline' });
+    await codeApi.renamePath('/repo/old.ts', '/repo/new.ts');
+    await codeApi.copyPath('/repo/source.ts', '/repo/copy.ts');
+    await codeApi.deletePath('/repo/obsolete.ts');
+
+    expect(
+      fetch.mock.calls.map(([path, init]) => [
+        path,
+        init?.method,
+        typeof init?.body === 'string' ? JSON.parse(init.body) : null,
+      ])
+    ).toEqual([
+      ['/api/v1/workspace/mkdir', 'POST', { path: '/repo/new folder' }],
+      ['/api/v1/workspace/create-file', 'POST', { path: '/repo/new file.ts' }],
+      [
+        '/api/v1/workspace/write',
+        'POST',
+        { path: '/repo/new file.ts', content: 'next content', expectedRevision: 'sha256:baseline' },
+      ],
+      ['/api/v1/workspace/rename', 'POST', { src: '/repo/old.ts', dest: '/repo/new.ts' }],
+      ['/api/v1/workspace/copy', 'POST', { src: '/repo/source.ts', dest: '/repo/copy.ts' }],
+      ['/api/v1/workspace/delete?path=%2Frepo%2Fobsolete.ts', 'DELETE', null],
+    ]);
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -34,6 +34,16 @@ interface ApiEnvelope<T> {
   message?: string;
 }
 
+export interface WorkspaceSearchRequestOptions {
+  excludePattern?: string;
+  maxResults?: number;
+}
+
+export interface WorkspaceWritePrecondition {
+  expectedRevision?: string;
+  expectedContent?: string;
+}
+
 export class ApiError extends Error {
   readonly status: number;
   readonly details?: unknown;
@@ -229,11 +239,11 @@ export const codeApi = {
       `/api/v1/workspace/files?rootPath=${encodeURIComponent(rootPath)}&query=${encodeURIComponent(query)}&maxResults=${maxResults}`
     ),
   readFile: (path: string) =>
-    apiRequest<{ content: string }>(`/api/v1/workspace/read?path=${encodeURIComponent(path)}`),
-  writeFile: (path: string, content: string) =>
-    apiRequest<{ success: boolean }>('/api/v1/workspace/write', {
+    apiRequest<{ content: string; revision?: string }>(`/api/v1/workspace/read?path=${encodeURIComponent(path)}`),
+  writeFile: (path: string, content: string, precondition: WorkspaceWritePrecondition = {}) =>
+    apiRequest<{ success: boolean; revision?: string }>('/api/v1/workspace/write', {
       method: 'POST',
-      ...jsonBody({ path, content }),
+      ...jsonBody({ path, content, ...precondition }),
     }),
   writeBinaryFile: (path: string, data: Uint8Array, append = false) =>
     apiRequest<{ success: boolean }>('/api/v1/workspace/write-binary', {
@@ -267,9 +277,13 @@ export const codeApi = {
       method: 'POST',
       ...jsonBody({ rootPath, message }),
     }),
-  searchWorkspace: (rootPath: string, query: string) =>
+  searchWorkspace: (
+    rootPath: string,
+    query: string,
+    { excludePattern, maxResults = 300 }: WorkspaceSearchRequestOptions = {}
+  ) =>
     apiRequest<WorkspaceSearchFile[]>(
-      `/api/v1/workspace/search?rootPath=${encodeURIComponent(rootPath)}&query=${encodeURIComponent(query)}&maxResults=300`
+      `/api/v1/workspace/search${apiQuery({ rootPath, query, excludePattern, maxResults })}`
     ),
   codeIntelligenceStatus: ({ sessionId, signal }: CodeIntelligenceRequestOptions = {}) =>
     apiRequest<CodeIntelligenceStatus>(`/api/v1/workspace/code-intelligence/status${apiQuery({ sessionId })}`, {

--- a/apps/web/src/state/app-state.ts
+++ b/apps/web/src/state/app-state.ts
@@ -14,7 +14,16 @@ import {
   taskDraftKey,
   type TaskState,
 } from '../features/tasks/task-state';
-import { createWorkspaceState, type WorkspaceState } from '../features/workspace/workspace-state';
+import { rememberTaskContextFocus, restoreTaskContextFocus } from '../features/tasks/task-context-focus';
+import {
+  captureWorkspaceTaskSnapshot,
+  createWorkspaceState,
+  createWorkspaceTaskState,
+  normalizePath,
+  persistWorkspaceTaskSnapshots,
+  restoreWorkspaceTaskState,
+  type WorkspaceState,
+} from '../features/workspace/workspace-state';
 import { createRunsState, type RunsState } from '../features/runs/runs-state';
 import { createSettingsState, type SettingsState } from '../features/settings/settings-state';
 import type { SettingsTab } from '../features/settings/settings-state';
@@ -25,10 +34,17 @@ const titleStorageKey = 'a3s-code-web.session-titles';
 const themeStorageKey = 'a3s-code-web.theme';
 let modelChangeNoticeId = 0;
 
+const initialTaskState = createTaskState();
+const initialWorkspaceState = createWorkspaceState(taskDraftKey(initialTaskState.activeSessionId));
+const initialCodeShellState = createCodeShellState();
+const initialWorkspaceSnapshot =
+  initialWorkspaceState.workspaceSnapshotsByTask[taskDraftKey(initialTaskState.activeSessionId)];
+if (initialWorkspaceSnapshot) initialCodeShellState.taskView = initialWorkspaceSnapshot.taskView;
+
 export const appState = proxy<AppState>({
-  ...createCodeShellState(),
-  ...createTaskState(),
-  ...createWorkspaceState(),
+  ...initialCodeShellState,
+  ...initialTaskState,
+  ...initialWorkspaceState,
   ...createRunsState(),
   ...createSettingsState(),
 });
@@ -60,7 +76,34 @@ export function sessionTitle(
   return titles[session.sessionId] || session.title?.trim() || '新任务';
 }
 
-export function switchActiveTask(sessionId: string | null): void {
+export interface WorkspaceContext {
+  generation: number;
+  workspaceRoot: string;
+}
+
+export function captureWorkspaceContext(): WorkspaceContext {
+  return {
+    generation: appState.workspaceGeneration,
+    workspaceRoot: appState.workspaceRoot,
+  };
+}
+
+export function isWorkspaceContextCurrent(context: WorkspaceContext): boolean {
+  return (
+    context.generation === appState.workspaceGeneration &&
+    sameWorkspaceRoot(context.workspaceRoot, appState.workspaceRoot)
+  );
+}
+
+export function switchActiveTask(sessionId: string | null, workspaceRoot?: string): boolean {
+  if (sessionId === appState.activeSessionId) {
+    const resolvedRoot = resolveWorkspaceRoot(sessionId, workspaceRoot);
+    if (resolvedRoot && !sameWorkspaceRoot(resolvedRoot, appState.workspaceRoot)) {
+      replaceActiveWorkspace(resolvedRoot);
+    }
+    return true;
+  }
+
   const currentKey = taskDraftKey(appState.activeSessionId);
   appState.draftsByTask[currentKey] = {
     content: appState.composerValue,
@@ -68,13 +111,105 @@ export function switchActiveTask(sessionId: string | null): void {
     skillNames: [...appState.composerSkills],
   };
   reportTaskPersistenceResult(persistTaskDrafts(appState.draftsByTask));
+  appState.workspaceSnapshotsByTask[currentKey] = captureWorkspaceTaskSnapshot(appState, appState.taskView);
   appState.activeSessionId = sessionId;
   reportTaskPersistenceResult(persistActiveTask(sessionId));
-  const next = appState.draftsByTask[taskDraftKey(sessionId)];
-  appState.composerValue = next?.content ?? '';
-  appState.composerContextFiles = [...(next?.contextFiles ?? [])];
-  appState.composerSkills = [...(next?.skillNames ?? [])];
+  const nextKey = taskDraftKey(sessionId);
+  const resolvedRoot = resolveWorkspaceRoot(sessionId, workspaceRoot);
+  const stored = appState.workspaceSnapshotsByTask[nextKey];
+  const nextWorkspace =
+    stored && sameWorkspaceRoot(stored.state.workspaceRoot, resolvedRoot)
+      ? stored
+      : { taskView: 'conversation' as const, state: createWorkspaceTaskState(resolvedRoot) };
+  if (stored && stored !== nextWorkspace) delete appState.workspaceSnapshotsByTask[nextKey];
+  restoreWorkspaceTaskState(appState, nextWorkspace.state);
+  appState.taskView = nextWorkspace.taskView;
+  appState.workspaceGeneration += 1;
+  appState.fileQuickOpenOpen = false;
+  appState.commandPaletteOpen = false;
+  const nextDraft = appState.draftsByTask[taskDraftKey(sessionId)];
+  appState.composerValue = nextDraft?.content ?? '';
+  appState.composerContextFiles = [...(nextDraft?.contextFiles ?? [])];
+  appState.composerSkills = [...(nextDraft?.skillNames ?? [])];
   appState.modelChangeNotice = null;
+  reportTaskPersistenceResult(persistActiveWorkspaceTask());
+  return true;
+}
+
+export function promoteActiveTask(sessionId: string, workspaceRoot: string): void {
+  if (appState.activeSessionId) {
+    switchActiveTask(sessionId, workspaceRoot);
+    return;
+  }
+  const preparedDraftKey = taskDraftKey(null);
+  appState.draftsByTask[taskDraftKey(sessionId)] = {
+    content: appState.composerValue,
+    contextFiles: [...appState.composerContextFiles],
+    skillNames: [...appState.composerSkills],
+  };
+  delete appState.draftsByTask[preparedDraftKey];
+  reportTaskPersistenceResult(persistTaskDrafts(appState.draftsByTask));
+  const rootChanged = !sameWorkspaceRoot(appState.workspaceRoot, workspaceRoot);
+  if (rootChanged) {
+    restoreWorkspaceTaskState(appState, createWorkspaceTaskState(workspaceRoot));
+    appState.taskView = 'conversation';
+    appState.workspaceGeneration += 1;
+  } else {
+    appState.workspaceRoot = workspaceRoot;
+  }
+  delete appState.workspaceSnapshotsByTask[preparedDraftKey];
+  appState.activeSessionId = sessionId;
+  reportTaskPersistenceResult(persistActiveTask(sessionId));
+  appState.modelChangeNotice = null;
+  reportTaskPersistenceResult(persistActiveWorkspaceTask());
+}
+
+export function replaceActiveWorkspace(workspaceRoot: string): void {
+  if (sameWorkspaceRoot(workspaceRoot, appState.workspaceRoot)) {
+    appState.workspaceRoot = workspaceRoot;
+    reportTaskPersistenceResult(persistActiveWorkspaceTask());
+    return;
+  }
+  const key = taskDraftKey(appState.activeSessionId);
+  delete appState.workspaceSnapshotsByTask[key];
+  restoreWorkspaceTaskState(appState, createWorkspaceTaskState(workspaceRoot));
+  appState.taskView = 'conversation';
+  appState.workspaceGeneration += 1;
+  appState.fileQuickOpenOpen = false;
+  reportTaskPersistenceResult(persistActiveWorkspaceTask());
+}
+
+export function removeWorkspaceTaskSnapshot(sessionId: string): void {
+  delete appState.workspaceSnapshotsByTask[taskDraftKey(sessionId)];
+  reportTaskPersistenceResult(persistActiveWorkspaceTask());
+}
+
+function persistActiveWorkspaceTask(): boolean {
+  return persistWorkspaceTaskSnapshots(
+    appState.workspaceSnapshotsByTask,
+    taskDraftKey(appState.activeSessionId),
+    appState,
+    appState.taskView
+  );
+}
+
+function resolveWorkspaceRoot(sessionId: string | null, explicit?: string): string {
+  const requested = explicit?.trim();
+  if (requested) return requested;
+  const sessionWorkspace = sessionId
+    ? appState.sessions.find((session) => session.sessionId === sessionId)?.workspace.trim()
+    : appState.newTaskConfig.workspace.trim() || appState.health?.workspace.trim();
+  if (sessionWorkspace) return sessionWorkspace;
+  return appState.workspaceSnapshotsByTask[taskDraftKey(sessionId)]?.state.workspaceRoot || appState.workspaceRoot;
+}
+
+function sameWorkspaceRoot(left: string, right: string): boolean {
+  const normalizedLeft = normalizePath(left).replace(/\/$/, '');
+  const normalizedRight = normalizePath(right).replace(/\/$/, '');
+  if (/^[A-Za-z]:\//.test(normalizedLeft) || /^[A-Za-z]:\//.test(normalizedRight)) {
+    return normalizedLeft.toLowerCase() === normalizedRight.toLowerCase();
+  }
+  return normalizedLeft === normalizedRight;
 }
 
 export function reportTaskPersistenceResult(persisted: boolean): void {
@@ -127,9 +262,13 @@ export function appendTaskInstruction(content: string): void {
 }
 
 export function navigateTask(view: TaskView): void {
+  const previousView = appState.taskView;
+  if (previousView === 'conversation' && view !== 'conversation') rememberTaskContextFocus(view);
   appState.settingsOpen = false;
+  if (view === 'conversation') appState.workspacePresentation = 'docked';
   appState.taskView = view;
   window.history.replaceState(null, '', `#code/${view}`);
+  if (previousView !== 'conversation' && view === 'conversation') restoreTaskContextFocus(previousView);
 }
 
 export function navigateSettings(tab: SettingsTab): void {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5,6 +5,7 @@
 @import "./styles/workspace-editor.css";
 @import "./styles/workspace-changes.css";
 @import "./styles/workspace-search.css";
+@import "./styles/workspace-quick-open.css";
 @import "./styles/settings.css";
 @import "./styles/settings-config.css";
 @import "./styles/settings-sections.css";

--- a/apps/web/src/styles/active-task-layout.css
+++ b/apps/web/src/styles/active-task-layout.css
@@ -34,6 +34,21 @@
   background: var(--a3s-panel);
 }
 
+.task-context-panel.fullscreen {
+  position: absolute;
+  z-index: 50;
+  inset: 0;
+  width: 100%;
+  min-width: 0;
+  flex-basis: auto;
+  border-left: 0;
+  box-shadow: none;
+}
+
+.task-context-panel.fullscreen .task-context-resizer {
+  display: none;
+}
+
 .task-context-resizer {
   position: absolute;
   z-index: 4;

--- a/apps/web/src/styles/workspace-editor.css
+++ b/apps/web/src/styles/workspace-editor.css
@@ -67,13 +67,36 @@
   height: 35px;
   flex: 0 1 150px;
   align-items: center;
-  gap: 6px;
-  padding: 0 6px 0 9px;
+  gap: 2px;
+  padding: 0 5px 0 0;
   border-right: 1px solid var(--a3s-line);
   background: transparent;
   color: var(--a3s-muted);
   cursor: default;
   user-select: none;
+}
+
+.workspace-editor-tab-trigger {
+  display: flex;
+  min-width: 0;
+  height: 100%;
+  flex: 1;
+  align-items: center;
+  gap: 6px;
+  padding: 0 0 0 9px;
+  border: 0;
+  border-radius: 2px;
+  outline-offset: -3px;
+  background: transparent;
+  color: inherit;
+  cursor: default;
+  font: inherit;
+  text-align: left;
+}
+
+.workspace-editor-tab.disambiguated {
+  max-width: 220px;
+  flex-basis: 180px;
 }
 
 .workspace-editor-tab::before {
@@ -100,14 +123,34 @@
   background: var(--a3s-blue);
 }
 
-.workspace-editor-tab > span:not(.workspace-tab-loading) {
+.workspace-tab-label {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: baseline;
+  gap: 5px;
+  overflow: hidden;
+}
+
+.workspace-tab-name,
+.workspace-tab-detail {
   min-width: 0;
   overflow: hidden;
-  flex: 1;
-  font-size: 11px;
-  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.workspace-tab-name {
+  flex: 0 1 auto;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.workspace-tab-detail {
+  flex: 1 1 auto;
+  color: var(--a3s-faint);
+  font-size: 9px;
+  font-weight: 450;
 }
 
 .workspace-tab-icon {
@@ -232,8 +275,29 @@
 
 .workspace-editor-actions {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   gap: 1px;
+}
+
+.workspace-editor-actions .code-navigation-trigger {
+  min-height: 25px;
+  gap: 4px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 4px;
+  color: var(--a3s-muted);
+  font-size: 10px;
+}
+
+.workspace-editor-actions .code-navigation-trigger:hover:not(:disabled),
+.workspace-editor-actions .code-navigation-trigger[aria-expanded="true"] {
+  background: var(--a3s-panel-strong);
+  color: var(--a3s-ink);
+}
+
+.workspace-editor-actions .code-navigation-trigger:disabled {
+  opacity: 0.45;
 }
 
 .workspace-editor-actions .ds-icon-button {
@@ -405,8 +469,53 @@
 
 .workspace-editor-statusbar > div {
   display: flex;
+  min-width: 0;
   align-items: center;
   gap: 12px;
+  justify-content: flex-end;
+  overflow: hidden;
+}
+
+.workspace-editor-statusbar > span,
+.workspace-editor-statusbar > div > span {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.workspace-editor-status-action {
+  height: 19px;
+  flex: 0 0 auto;
+  padding: 0 4px;
+  border: 0;
+  border-radius: 3px;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.workspace-editor-status-action:hover:not(:disabled),
+.workspace-editor-status-action:focus-visible,
+.workspace-editor-status-action[aria-expanded="true"] {
+  background: var(--a3s-panel-strong);
+  color: var(--a3s-ink);
+}
+
+.workspace-editor-status-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.line-ending-menu-check:not(.selected) {
+  opacity: 0;
+}
+
+.workspace-editor-statusbar > div > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  flex: 0 1 auto;
+  text-overflow: ellipsis;
 }
 
 .workspace-editor-empty {

--- a/apps/web/src/styles/workspace-explorer.css
+++ b/apps/web/src/styles/workspace-explorer.css
@@ -114,9 +114,14 @@
 }
 
 .explorer-row:hover,
-.explorer-row.contextual {
+.explorer-row.contextual,
+.explorer-row:focus-visible {
   background: color-mix(in srgb, var(--a3s-panel-strong) 66%, transparent);
   color: var(--a3s-ink);
+}
+
+.explorer-row:focus-visible {
+  outline-offset: -2px;
 }
 
 .explorer-row.active {
@@ -389,7 +394,7 @@
   display: grid;
   width: 100%;
   min-height: 32px;
-  grid-template-columns: 18px minmax(0, 1fr);
+  grid-template-columns: 18px minmax(0, 1fr) auto;
   align-items: center;
   gap: 7px;
   padding: 0 9px;
@@ -408,9 +413,23 @@
   stroke-width: 1.8;
 }
 
+.workspace-context-menu-item > button kbd {
+  color: var(--a3s-faint);
+  font: 9px/1.4 "SFMono-Regular", Consolas, monospace;
+  white-space: nowrap;
+}
+
 .workspace-context-menu-item > button:hover,
 .workspace-context-menu-item > button:focus-visible {
   background: var(--a3s-panel-strong);
+}
+
+.workspace-context-menu-item > button[role="menuitemradio"][aria-checked="true"] {
+  background: color-mix(in srgb, var(--a3s-blue) 8%, transparent);
+}
+
+.workspace-context-menu-item > button[role="menuitemradio"][aria-checked="true"] svg {
+  color: var(--a3s-blue);
 }
 
 .workspace-context-menu-item > button.danger,

--- a/apps/web/src/styles/workspace-quick-open.css
+++ b/apps/web/src/styles/workspace-quick-open.css
@@ -1,0 +1,132 @@
+.workspace-quick-open-overlay {
+  z-index: 140;
+}
+
+.workspace-quick-open {
+  width: min(660px, calc(100% - 40px));
+}
+
+.workspace-quick-open > label {
+  position: relative;
+}
+
+.workspace-quick-open-loader {
+  flex: 0 0 auto;
+  color: var(--a3s-blue);
+}
+
+.workspace-quick-open-results {
+  min-height: 96px;
+  max-height: min(460px, 58vh);
+}
+
+.workspace-quick-open-results > button {
+  min-height: 45px;
+  gap: 10px;
+}
+
+.workspace-quick-open-results > button.active,
+.workspace-quick-open-results > button[aria-selected="true"] {
+  background: color-mix(in srgb, var(--a3s-blue) 10%, var(--a3s-panel-soft));
+  outline: 1px solid color-mix(in srgb, var(--a3s-blue) 24%, transparent);
+}
+
+.workspace-quick-open-results > button:disabled {
+  cursor: progress;
+  opacity: 0.72;
+}
+
+.workspace-quick-open-results > button > svg {
+  flex: 0 0 auto;
+}
+
+.workspace-quick-open-results > button > span:not(.workspace-quick-open-badges) {
+  min-width: 0;
+  flex: 1;
+}
+
+.workspace-quick-open-results strong,
+.workspace-quick-open-results small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-quick-open-badges {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: row !important;
+  align-items: center;
+  gap: 5px !important;
+}
+
+.workspace-quick-open-badges em {
+  padding: 2px 5px;
+  border: 1px solid var(--a3s-line);
+  border-radius: 4px;
+  background: var(--a3s-panel);
+  color: var(--a3s-faint);
+  font-size: 9px;
+  font-style: normal;
+  white-space: nowrap;
+}
+
+.workspace-quick-open-state {
+  display: flex;
+  min-height: 90px;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 20px;
+  color: var(--a3s-muted);
+  font-size: 11px;
+  text-align: center;
+}
+
+.workspace-quick-open-state.error {
+  flex-direction: column;
+  color: var(--a3s-danger);
+}
+
+.workspace-quick-open-state button {
+  display: inline-flex;
+  min-height: 27px;
+  align-items: center;
+  gap: 5px;
+  padding: 0 9px;
+  border: 1px solid var(--a3s-line-strong);
+  border-radius: 6px;
+  background: var(--a3s-panel-soft);
+  color: var(--a3s-ink);
+  cursor: pointer;
+}
+
+.workspace-quick-open-footer {
+  display: flex;
+  min-height: 35px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.workspace-quick-open-footer > span:last-child:not(:first-child) {
+  overflow: hidden;
+  color: var(--a3s-warning);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 680px) {
+  .workspace-quick-open-overlay {
+    padding-top: 6vh;
+  }
+
+  .workspace-quick-open {
+    width: calc(100% - 20px);
+  }
+
+  .workspace-quick-open-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/apps/web/src/styles/workspace-search.css
+++ b/apps/web/src/styles/workspace-search.css
@@ -40,7 +40,7 @@
   border-bottom: 1px solid var(--a3s-line);
 }
 
-.workspace-search-form label {
+.workspace-search-input {
   display: flex;
   height: 31px;
   align-items: center;
@@ -52,11 +52,11 @@
   color: var(--a3s-muted);
 }
 
-.workspace-search-form label:focus-within {
+.workspace-search-input:focus-within {
   border-color: var(--a3s-blue);
 }
 
-.workspace-search-form input {
+.workspace-search-input input {
   min-width: 0;
   flex: 1;
   border: 0;
@@ -64,6 +64,39 @@
   background: transparent;
   color: var(--a3s-ink);
   font-size: 11px;
+}
+
+.workspace-search-scope {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  color: var(--a3s-muted);
+  cursor: pointer;
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.workspace-search-scope input {
+  width: 13px;
+  height: 13px;
+  margin: 1px 0 0;
+  accent-color: var(--a3s-blue);
+}
+
+.workspace-search-scope input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--a3s-blue) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.workspace-search-scope span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.workspace-search-scope small {
+  color: var(--a3s-faint);
+  font-size: 9px;
 }
 
 .workspace-search-form > div {
@@ -106,7 +139,7 @@
   overflow: hidden;
   font-size: 10px;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .workspace-search-match {
@@ -136,6 +169,12 @@
   font-size: 10px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.workspace-search-match mark {
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--a3s-blue) 18%, transparent);
+  color: var(--a3s-ink);
 }
 
 .workspace-search-empty {

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom/vitest';
 import { createElement, useEffect, useRef } from 'react';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
+import { clearWorkspaceEditorModels } from '../features/workspace/components/monaco-editor-model-store';
 
 const monacoMock = vi.hoisted(() => ({
   editor: {
     defineTheme: vi.fn(),
     setModelMarkers: vi.fn(),
+    EndOfLineSequence: { LF: 0, CRLF: 1 },
   },
   languages: {
     register: vi.fn(),
@@ -51,21 +53,85 @@ const monacoMock = vi.hoisted(() => ({
       TypeParameter: 25,
     },
   },
+  typescript: {
+    typescriptDefaults: {
+      modeConfiguration: { documentSymbols: true, definitions: true, references: true },
+      setModeConfiguration: vi.fn(),
+    },
+    javascriptDefaults: {
+      modeConfiguration: { documentSymbols: true, definitions: true, references: true },
+      setModeConfiguration: vi.fn(),
+    },
+  },
   MarkerSeverity: { Hint: 1, Info: 2, Warning: 4, Error: 8 },
   KeyMod: { CtrlCmd: 1, Shift: 16 },
   KeyCode: { KeyS: 2, KeyW: 3, F12: 4 },
   __actions: [] as MonacoAction[],
+  __editorActionRuns: [] as string[],
   __documentSymbolProviders: [] as MonacoDocumentSymbolRegistration[],
+  __cursorSelectionListeners: [] as Array<() => void>,
+  __modelContentListeners: [] as Array<() => void>,
+  __modelChangeListeners: [] as Array<() => void>,
+  __editorMountCount: 0,
+  __editorUnmountCount: 0,
+  __currentEditorPath: '',
+  __savedViewStates: [] as unknown[],
+  __restoredViewStates: [] as unknown[],
+  __pushEolCalls: [] as number[],
   __position: { lineNumber: 1, column: 1 },
-  __model: { uri: { toString: () => 'file:///workspace/file.ts' } },
+  __selections: [{ selectedText: '', isEmpty: () => true }] as MonacoSelection[],
+  __eol: '\n' as '\n' | '\r\n',
+  __language: 'plaintext',
+  __value: '',
+  __onChange: null as ((value: string) => void) | null,
+  __modelDisposed: false,
+  __model: {
+    uri: { toString: () => 'file:///workspace/file.ts' },
+    getLanguageId: () => monacoMock.__language,
+    getEOL: () => monacoMock.__eol,
+    getEndOfLineSequence: () => (monacoMock.__eol === '\r\n' ? 1 : 0),
+    getValueLengthInRange: (selection: MonacoSelection) => selection.selectedText.length,
+    pushEOL: (sequence: number) => {
+      monacoMock.__pushEolCalls.push(sequence);
+      const eol = sequence === monacoMock.editor.EndOfLineSequence.CRLF ? '\r\n' : '\n';
+      const value = monacoMock.__value.replace(/\r\n|\r|\n/g, eol);
+      monacoMock.__eol = eol;
+      monacoMock.__value = value;
+      monacoMock.__onChange?.(value);
+      for (const listener of monacoMock.__modelContentListeners) listener();
+    },
+    isDisposed: () => monacoMock.__modelDisposed,
+    dispose: () => {
+      monacoMock.__modelDisposed = true;
+    },
+  },
 }));
 
 vi.mock('monaco-editor', () => monacoMock);
+vi.mock('../features/workspace/components/monaco-runtime', () => ({ monaco: monacoMock }));
 
 vi.mock('@monaco-editor/react', () => {
-  const Editor = ({ value = '', onChange, onMount, beforeMount, options = {} }: MonacoEditorMockProps) => {
+  const Editor = ({
+    value = '',
+    language = 'plaintext',
+    path = '',
+    onChange,
+    onMount,
+    beforeMount,
+    options = {},
+  }: MonacoEditorMockProps) => {
     const ref = useRef<HTMLTextAreaElement>(null);
+    const mountedPathRef = useRef(path);
     useEffect(() => {
+      monacoMock.__editorMountCount += 1;
+      monacoMock.__currentEditorPath = path;
+      mountedPathRef.current = path;
+      monacoMock.__eol = value.includes('\r\n') ? '\r\n' : '\n';
+      monacoMock.__language = language;
+      monacoMock.__value = value;
+      monacoMock.__onChange = onChange ?? null;
+      monacoMock.__position = { lineNumber: 1, column: 1 };
+      monacoMock.__selections = [{ selectedText: '', isEmpty: () => true }];
       beforeMount?.(monacoMock);
       onMount?.(
         {
@@ -80,17 +146,56 @@ vi.mock('@monaco-editor/react', () => {
             };
           },
           focus: () => ref.current?.focus(),
+          saveViewState: () => {
+            const state = {
+              path: monacoMock.__currentEditorPath,
+              position: { ...monacoMock.__position },
+              selections: [...monacoMock.__selections],
+            };
+            monacoMock.__savedViewStates.push(state);
+            return state;
+          },
+          restoreViewState: (state: unknown) => {
+            monacoMock.__restoredViewStates.push(state);
+            const restored = state as { position?: { lineNumber: number; column: number } } | null;
+            if (restored?.position) monacoMock.__position = { ...restored.position };
+          },
           getModel: () => monacoMock.__model,
           getPosition: () => monacoMock.__position,
+          getSelections: () => monacoMock.__selections,
+          onDidChangeCursorSelection: (listener: () => void) =>
+            mockRegistration(monacoMock.__cursorSelectionListeners, listener),
+          onDidChangeModelContent: (listener: () => void) =>
+            mockRegistration(monacoMock.__modelContentListeners, listener),
+          onDidChangeModel: (listener: () => void) => mockRegistration(monacoMock.__modelChangeListeners, listener),
+          getAction: (id: string) => ({
+            run: async () => {
+              monacoMock.__editorActionRuns.push(id);
+            },
+          }),
           revealPositionInCenterIfOutsideViewport: vi.fn(),
           setPosition: ({ lineNumber, column }: { lineNumber: number; column: number }) => {
+            monacoMock.__position = { lineNumber, column };
+            monacoMock.__selections = [{ selectedText: '', isEmpty: () => true }];
             const offset = textOffset(value, lineNumber, column);
             ref.current?.setSelectionRange(offset, offset);
+            for (const listener of monacoMock.__cursorSelectionListeners) listener();
           },
         },
         monacoMock
       );
+      return () => {
+        monacoMock.__editorUnmountCount += 1;
+      };
     }, []);
+    useEffect(() => {
+      const pathChanged = mountedPathRef.current !== path;
+      monacoMock.__language = language;
+      if (!pathChanged) return;
+      mountedPathRef.current = path;
+      monacoMock.__currentEditorPath = path;
+      for (const listener of [...monacoMock.__modelChangeListeners]) listener();
+    }, [language, path]);
     return createElement('textarea', {
       ref,
       'aria-label': options.ariaLabel,
@@ -100,13 +205,14 @@ vi.mock('@monaco-editor/react', () => {
     });
   };
   const DiffEditor = ({ original = '', modified = '', beforeMount, onMount, options = {} }: MonacoDiffMockProps) => {
+    const ref = useRef<HTMLDivElement>(null);
     useEffect(() => {
       beforeMount?.(monacoMock);
-      onMount?.({ getModifiedEditor: () => ({ focus: vi.fn() }) }, monacoMock);
+      onMount?.({ getModifiedEditor: () => ({ focus: () => ref.current?.focus() }) }, monacoMock);
     }, []);
     return createElement(
       'div',
-      { role: 'region', 'aria-label': options.ariaLabel },
+      { ref, role: 'region', tabIndex: -1, 'aria-label': options.ariaLabel, 'data-testid': 'monaco-diff-editor' },
       createElement('pre', { 'data-side': 'original' }, original),
       createElement('pre', { 'data-side': 'modified' }, modified)
     );
@@ -121,11 +227,21 @@ vi.mock('@monaco-editor/react', () => {
 
 interface MonacoEditorMockProps {
   value?: string;
+  language?: string;
+  path?: string;
   onChange?: (value: string) => void;
   onMount?: (editor: unknown, monaco: typeof monacoMock) => void;
   beforeMount?: (monaco: typeof monacoMock) => void;
   options?: { ariaLabel?: string; readOnly?: boolean };
 }
+
+afterEach(() => {
+  clearWorkspaceEditorModels();
+  monacoMock.__modelDisposed = false;
+  monacoMock.__savedViewStates.splice(0);
+  monacoMock.__restoredViewStates.splice(0);
+  monacoMock.__currentEditorPath = '';
+});
 
 interface MonacoAction {
   id: string;
@@ -151,6 +267,11 @@ interface MonacoDocumentSymbolRegistration {
   provider: MonacoDocumentSymbolProvider;
 }
 
+interface MonacoSelection {
+  selectedText: string;
+  isEmpty: () => boolean;
+}
+
 interface MonacoDiffMockProps {
   original?: string;
   modified?: string;
@@ -164,4 +285,14 @@ function textOffset(content: string, line: number, column: number): number {
   const lineIndex = Math.min(Math.max(0, line - 1), Math.max(0, lines.length - 1));
   const lineOffset = lines.slice(0, lineIndex).reduce((total, value) => total + value.length + 1, 0);
   return lineOffset + Math.min(Math.max(0, column - 1), lines[lineIndex]?.length ?? 0);
+}
+
+function mockRegistration(listeners: Array<() => void>, listener: () => void): MonacoDisposable {
+  listeners.push(listener);
+  return {
+    dispose: () => {
+      const index = listeners.indexOf(listener);
+      if (index >= 0) listeners.splice(index, 1);
+    },
+  };
 }

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -196,8 +196,11 @@ export interface SkillCatalog {
 
 export interface WorkspaceSearchMatch {
   line: number;
+  /** One-based UTF-16 column, matching Monaco's position contract. */
   column: number;
+  /** Bounded context around this match rather than an unbounded source line. */
   text: string;
+  /** Zero-based UTF-16 offsets inside `text`. */
   matchStart: number;
   matchEnd: number;
 }


### PR DESCRIPTION
## Summary
- add durable Monaco model lifecycle, quick open, navigation history, and richer code intelligence UX
- improve explorer keyboard and context-menu workflows plus task-scoped editor persistence
- add conditional saves with conflict recovery, explicit reload, and overwrite behavior
- update Web product and component documentation

## Verification
- bun run format:check
- bun run lint:check
- bun run typecheck
- bun run test (60 files, 443 tests)
- bun run build
- browser QA covered conditional save success, HTTP 412 conflict, reload, and explicit overwrite