### PR TITLE
feat(web): surface local model account status

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -74,6 +74,7 @@ Product implementation is governed by the
 - Workspace-wide Git review with complete original/modified Monaco diff tabs,
   stage, unstage, and commit.
 - A complete local configuration center for A3S OS account and endpoint,
+  runtime-detected Claude Code, Codex, and WorkBuddy account status and refresh,
   appearance, models and Providers, Agent execution and queues, session storage
   and memory policy, search and headless browsing, document/OCR parsing, MCP
   transports and OAuth, updates, service information, and searchable Help.
@@ -83,7 +84,9 @@ Product implementation is governed by the
   names and model IDs retain focus and disclosure state.
 - A source-grouped task model switcher that combines configured Provider models
   with valid local Claude Code, Codex, and WorkBuddy account models through the
-  same runtime discovery and client routing used by the TUI.
+  same runtime discovery and client routing used by the TUI. Account credentials
+  remain in the CLI, while Settings reports only connection state and available
+  model counts.
 - Browser-native command (`Cmd/Ctrl+K`) and file (`Cmd/Ctrl+P`) palettes for
   existing pages, contextual actions, and bounded workspace navigation.
 - Wide and compact desktop layouts, plus system, light, and dark themes.

--- a/apps/web/docs/FUNCTIONAL_SPEC.md
+++ b/apps/web/docs/FUNCTIONAL_SPEC.md
@@ -374,7 +374,11 @@ Git state is never labelled as selected-task provenance.
 
 - Open Settings as a global modal over the current Code surface; do not replace,
   unmount, or reset that surface.
-- Configure account and appearance.
+- Configure the optional A3S OS account and appearance.
+- Show Claude Code, Codex, and WorkBuddy local account state from qualified
+  runtime catalog sources, with model counts, truthful sign-in guidance, and one
+  in-place refresh action. Do not infer account login from a configured
+  Anthropic or OpenAI Provider.
 - Configure the default model, providers, model capabilities, runtime limits,
   and locally held credentials.
 - Configure Agent execution limits, Skill and Agent directories, automatic
@@ -401,7 +405,8 @@ or shell shortcuts; each configuration category is lazy, retryable, and saved
 independently; a failed save preserves the local draft and authoritative saved
 state; secrets are masked and are never returned to the browser; effect labels
 distinguish new-task changes from restart-required changes; Help does not teach
-slash commands as the primary Web interaction.
+slash commands as the primary Web interaction; local account refresh failure
+retains the previous catalog and stays inline in the Account section.
 
 ## Excluded from this release
 

--- a/apps/web/src/features/settings/components/account-settings.test.tsx
+++ b/apps/web/src/features/settings/components/account-settings.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appState } from '../../../state/app-state';
+import type { SettingsActions } from '../settings-actions';
+import { AccountSettings } from './account-settings';
+
+describe('AccountSettings', () => {
+  const actions = {
+    refreshModelCatalog: vi.fn(async () => undefined),
+    loginWithOs: vi.fn(async () => undefined),
+    logout: vi.fn(async () => undefined),
+  } as unknown as SettingsActions;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appState.health = {
+      ok: true,
+      app: 'A3S Code',
+      version: '0.7.7',
+      configPath: '/repo/config.acl',
+      workspace: '/repo',
+    };
+    appState.osAccount = {
+      configured: false,
+      signedIn: false,
+      needsRefresh: false,
+      capabilitySkillActive: false,
+      builtinSkillActive: false,
+      runtimeToolActive: false,
+    };
+    appState.modelCatalogRefreshing = false;
+    appState.modelCatalogRefreshError = null;
+    appState.modelCatalogRefreshedAt = null;
+    appState.modelCatalog = {
+      defaultModel: 'codex/gpt-5.4',
+      warnings: [],
+      items: [
+        {
+          id: 'anthropic/claude-opus',
+          name: 'claude-opus',
+          source: 'anthropic',
+          reasoning: false,
+          toolCall: true,
+        },
+        {
+          id: 'codex/gpt-5.4',
+          name: 'gpt-5.4',
+          source: 'Codex',
+          reasoning: true,
+          toolCall: true,
+        },
+        {
+          id: 'workbuddy/auto',
+          name: 'auto',
+          source: 'WorkBuddy',
+          reasoning: true,
+          toolCall: true,
+        },
+        {
+          id: 'workbuddy/glm-5.1',
+          name: 'glm-5.1',
+          source: 'WorkBuddy',
+          reasoning: true,
+          toolCall: true,
+        },
+      ],
+    };
+  });
+
+  afterEach(() => cleanup());
+
+  it('separates configured Providers from actually signed-in local tool accounts', () => {
+    render(<AccountSettings actions={actions} />);
+
+    const claude = screen.getByRole('listitem', { name: 'Claude Code 账户状态' });
+    const codex = screen.getByRole('listitem', { name: 'Codex 账户状态' });
+    const workbuddy = screen.getByRole('listitem', { name: 'WorkBuddy 账户状态' });
+
+    expect(within(claude).getByText('未连接')).toBeInTheDocument();
+    expect(within(claude).getByText('claude auth login')).toBeInTheDocument();
+    expect(within(codex).getByText(/1 个可用模型/)).toBeInTheDocument();
+    expect(within(codex).getByText('已连接')).toBeInTheDocument();
+    expect(within(workbuddy).getByText(/2 个可用模型/)).toBeInTheDocument();
+  });
+
+  it('exposes one explicit refresh action for all local account models', () => {
+    render(<AccountSettings actions={actions} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '刷新账户模型' }));
+
+    expect(actions.refreshModelCatalog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/settings/components/account-settings.tsx
+++ b/apps/web/src/features/settings/components/account-settings.tsx
@@ -1,89 +1,12 @@
-import { Cloud, LogOut } from 'lucide-react';
-import { useState } from 'react';
-import { useSnapshot } from 'valtio';
-import { appState } from '../../../state/app-state';
 import type { SettingsActions } from '../settings-actions';
+import { A3sOsAccount } from './account/a3s-os-account';
+import { LocalModelAccounts } from './account/local-model-accounts';
 
 export function AccountSettings({ actions }: { actions: SettingsActions }) {
-  const state = useSnapshot(appState);
-  const [accountBusy, setAccountBusy] = useState(false);
-  const signedIn = state.osAccount?.signedIn;
-  const runAccountAction = async () => {
-    if (accountBusy) return;
-    setAccountBusy(true);
-    try {
-      if (signedIn) await actions.logout();
-      else await actions.loginWithOs();
-    } catch {
-      // The controller keeps the existing account state and reports the error.
-    } finally {
-      setAccountBusy(false);
-    }
-  };
   return (
-    <div className='settings-section'>
-      <div className='setting-heading'>
-        <h3>A3S OS 连接</h3>
-        <p>OAuth 凭据由本机 A3S CLI 安全持有，不会写入浏览器存储。</p>
-      </div>
-      <div className='os-account-card'>
-        <img src='/logo.png' alt='' />
-        <div>
-          <strong>{state.osAccount?.label || state.osAccount?.origin || '未配置 A3S OS'}</strong>
-          <span>
-            {signedIn
-              ? state.osAccount?.runtimeToolActive
-                ? '已授权 · Runtime 工具可用'
-                : '已授权 · Runtime 工具未启用'
-              : state.osAccount?.configured
-                ? '等待你授权连接'
-                : '请先在本机配置 A3S OS 地址'}
-          </span>
-        </div>
-        <span className={`connection-badge ${signedIn ? 'online' : ''}`}>{signedIn ? '已连接' : '未连接'}</span>
-      </div>
-      {!state.osAccount?.configured && state.health?.configPath && (
-        <p className='account-config-hint'>配置文件：{state.health.configPath}</p>
-      )}
-      <div className='account-capabilities'>
-        <div>
-          <span>内置技能</span>
-          <strong>{state.osAccount?.builtinSkillActive ? '可用' : '未启用'}</strong>
-        </div>
-        <div>
-          <span>OS 能力技能</span>
-          <strong>{state.osAccount?.capabilitySkillActive ? '可用' : '未启用'}</strong>
-        </div>
-        <div>
-          <span>Runtime 工具</span>
-          <strong>{state.osAccount?.runtimeToolActive ? '可用' : '未启用'}</strong>
-        </div>
-      </div>
-      {signedIn ? (
-        <button
-          type='button'
-          className='btn-outline danger-btn'
-          disabled={accountBusy}
-          onClick={() => {
-            void runAccountAction();
-          }}
-        >
-          <LogOut size={16} />
-          {accountBusy ? '正在退出…' : '退出 A3S OS'}
-        </button>
-      ) : (
-        <button
-          type='button'
-          className='btn'
-          disabled={!state.osAccount?.configured || accountBusy}
-          onClick={() => {
-            void runAccountAction();
-          }}
-        >
-          <Cloud size={16} />
-          {accountBusy ? '正在连接…' : '授权连接'}
-        </button>
-      )}
+    <div className='settings-config-page account-settings-page'>
+      <A3sOsAccount actions={actions} />
+      <LocalModelAccounts actions={actions} />
     </div>
   );
 }

--- a/apps/web/src/features/settings/components/account/a3s-os-account.tsx
+++ b/apps/web/src/features/settings/components/account/a3s-os-account.tsx
@@ -1,0 +1,81 @@
+import { Cloud, LogOut } from 'lucide-react';
+import { useState } from 'react';
+import { useSnapshot } from 'valtio';
+import { Button, StatusBadge } from '../../../../design-system/primitives';
+import { appState } from '../../../../state/app-state';
+import type { SettingsActions } from '../../settings-actions';
+import { SettingsSection } from '../config/settings-section';
+
+export function A3sOsAccount({ actions }: { actions: SettingsActions }) {
+  const state = useSnapshot(appState);
+  const [accountBusy, setAccountBusy] = useState(false);
+  const signedIn = Boolean(state.osAccount?.signedIn);
+
+  const runAccountAction = async () => {
+    if (accountBusy) return;
+    setAccountBusy(true);
+    try {
+      if (signedIn) await actions.logout();
+      else await actions.loginWithOs();
+    } catch {
+      // The controller keeps the current account state and reports the error.
+    } finally {
+      setAccountBusy(false);
+    }
+  };
+
+  return (
+    <SettingsSection title='A3S OS' description='连接远程 A3S 能力；OAuth 凭据只由本机 CLI 持有，不写入浏览器。'>
+      <div className='a3s-os-account-summary'>
+        <img src='/logo.png' alt='' />
+        <div className='account-provider-copy'>
+          <strong>{state.osAccount?.label || state.osAccount?.origin || '未配置 A3S OS'}</strong>
+          <span>
+            {signedIn
+              ? state.osAccount?.runtimeToolActive
+                ? '授权有效，Runtime 工具可用'
+                : '授权有效，Runtime 工具尚未启用'
+              : state.osAccount?.configured
+                ? '服务地址已配置，等待授权'
+                : '请先在本机配置 A3S OS 地址'}
+          </span>
+        </div>
+        <StatusBadge tone={signedIn ? 'success' : 'neutral'}>{signedIn ? '已连接' : '未连接'}</StatusBadge>
+      </div>
+
+      <div className='account-capability-grid'>
+        <Capability label='内置技能' active={Boolean(state.osAccount?.builtinSkillActive)} />
+        <Capability label='OS 能力技能' active={Boolean(state.osAccount?.capabilitySkillActive)} />
+        <Capability label='Runtime 工具' active={Boolean(state.osAccount?.runtimeToolActive)} />
+      </div>
+
+      <div className='account-section-actions'>
+        <span>
+          {!state.osAccount?.configured && state.health?.configPath
+            ? `配置文件：${state.health.configPath}`
+            : '授权状态由本机 A3S Code 服务校验'}
+        </span>
+        <Button
+          tone={signedIn ? 'danger' : 'primary'}
+          loading={accountBusy}
+          disabled={!signedIn && !state.osAccount?.configured}
+          onClick={() => {
+            void runAccountAction();
+          }}
+        >
+          {signedIn ? <LogOut size={15} /> : <Cloud size={15} />}
+          {signedIn ? '退出连接' : '授权连接'}
+        </Button>
+      </div>
+    </SettingsSection>
+  );
+}
+
+function Capability({ label, active }: { label: string; active: boolean }) {
+  return (
+    <div>
+      <span>{label}</span>
+      <strong className={active ? 'available' : ''}>{active ? '可用' : '未启用'}</strong>
+    </div>
+  );
+}

--- a/apps/web/src/features/settings/components/account/local-model-accounts.tsx
+++ b/apps/web/src/features/settings/components/account/local-model-accounts.tsx
@@ -1,0 +1,140 @@
+import { RefreshCw } from 'lucide-react';
+import { useSnapshot } from 'valtio';
+import { Button, StatusBadge } from '../../../../design-system/primitives';
+import { appState } from '../../../../state/app-state';
+import type { CatalogModel } from '../../../../types/api';
+import type { SettingsActions } from '../../settings-actions';
+import { SettingsSection } from '../config/settings-section';
+
+interface LocalAccountDefinition {
+  id: string;
+  label: string;
+  mark: string;
+  sources: string[];
+  loginCommand?: string;
+  loginInstruction?: string;
+}
+
+const localAccounts: LocalAccountDefinition[] = [
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    mark: 'C',
+    sources: ['Claude Code', 'claude-code'],
+    loginCommand: 'claude auth login',
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    mark: 'X',
+    sources: ['Codex'],
+    loginCommand: 'codex login',
+  },
+  {
+    id: 'workbuddy',
+    label: 'WorkBuddy',
+    mark: 'W',
+    sources: ['WorkBuddy', 'CodeBuddy'],
+    loginInstruction: '打开 WorkBuddy 完成登录',
+  },
+];
+
+export function LocalModelAccounts({ actions }: { actions: SettingsActions }) {
+  const state = useSnapshot(appState);
+  const models = state.modelCatalog?.items ?? [];
+  const catalogLoaded = state.modelCatalog !== null;
+
+  return (
+    <SettingsSection
+      title='本地开发工具账户'
+      description='复用本机已登录账户的授权模型；令牌和凭据不会返回浏览器。'
+      action={
+        <Button
+          tone='secondary'
+          loading={state.modelCatalogRefreshing}
+          onClick={() => {
+            void actions.refreshModelCatalog();
+          }}
+        >
+          <RefreshCw size={14} />
+          刷新账户模型
+        </Button>
+      }
+    >
+      {state.modelCatalogRefreshError && (
+        <p className='account-model-refresh-error' role='alert'>
+          刷新失败：{state.modelCatalogRefreshError}。已保留当前可用模型。
+        </p>
+      )}
+
+      <ul className='local-model-account-list'>
+        {localAccounts.map((account) => {
+          const accountModels = models.filter((model) => account.sources.some((source) => sameSource(model, source)));
+          return (
+            <LocalModelAccountRow
+              key={account.id}
+              account={account}
+              models={accountModels}
+              catalogLoaded={catalogLoaded}
+            />
+          );
+        })}
+      </ul>
+
+      <footer className='account-model-catalog-note'>
+        <span>模型能力由本机 CLI 检测，账号失效后不会继续出现在选择器中。</span>
+        {state.modelCatalogRefreshedAt && <strong>最近已刷新</strong>}
+      </footer>
+    </SettingsSection>
+  );
+}
+
+function LocalModelAccountRow({
+  account,
+  models,
+  catalogLoaded,
+}: {
+  account: LocalAccountDefinition;
+  models: readonly CatalogModel[];
+  catalogLoaded: boolean;
+}) {
+  const connected = models.length > 0;
+  const preview = models
+    .slice(0, 3)
+    .map((model) => model.name)
+    .join('、');
+
+  return (
+    <li aria-label={`${account.label} 账户状态`}>
+      <span className={`local-account-mark ${account.id}`} aria-hidden='true'>
+        {account.mark}
+      </span>
+      <div className='local-account-copy'>
+        <strong>{account.label}</strong>
+        {connected ? (
+          <span className='local-account-models' title={models.map((model) => model.name).join('、')}>
+            {models.length} 个可用模型 · {preview}
+            {models.length > 3 ? ` 等 ${models.length} 个` : ''}
+          </span>
+        ) : catalogLoaded ? (
+          <span className='local-account-guidance'>
+            未检测到有效登录 · {account.loginCommand ? <code>{account.loginCommand}</code> : account.loginInstruction}
+          </span>
+        ) : (
+          <span>正在读取本机模型目录…</span>
+        )}
+      </div>
+      <StatusBadge tone={connected ? 'success' : 'neutral'}>
+        {connected ? '已连接' : catalogLoaded ? '未连接' : '检测中'}
+      </StatusBadge>
+    </li>
+  );
+}
+
+function sameSource(model: Pick<CatalogModel, 'source'>, expected: string): boolean {
+  return normalizeSource(model.source) === normalizeSource(expected);
+}
+
+function normalizeSource(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}

--- a/apps/web/src/features/settings/components/settings-dialog.test.tsx
+++ b/apps/web/src/features/settings/components/settings-dialog.test.tsx
@@ -23,6 +23,7 @@ const actions: SettingsActions = {
   saveIntegrationsSettings: vi.fn(async () => {
     throw new Error('not used in this test');
   }),
+  refreshModelCatalog: vi.fn(async () => undefined),
   loginWithOs: vi.fn(async () => undefined),
   logout: vi.fn(async () => undefined),
   checkForUpdates: vi.fn(async () => undefined),

--- a/apps/web/src/features/settings/settings-actions.ts
+++ b/apps/web/src/features/settings/settings-actions.ts
@@ -8,6 +8,7 @@ export interface SettingsActions {
   saveAgentSettings(patch: Partial<AgentSettings>): Promise<AgentSettings>;
   saveContextSettings(patch: Partial<ContextSettings>): Promise<ContextSettings>;
   saveIntegrationsSettings(patch: Partial<IntegrationsSettings>): Promise<IntegrationsSettings>;
+  refreshModelCatalog(): Promise<void>;
   loginWithOs(): Promise<void>;
   logout(): Promise<void>;
   checkForUpdates(): Promise<void>;

--- a/apps/web/src/features/settings/settings-state.ts
+++ b/apps/web/src/features/settings/settings-state.ts
@@ -39,6 +39,9 @@ export interface SettingsState {
   settingsCategorySavedAt: Record<ConfigCategory, number | null>;
   selectedModel: string;
   defaultModelSaving: boolean;
+  modelCatalogRefreshing: boolean;
+  modelCatalogRefreshError: string | null;
+  modelCatalogRefreshedAt: number | null;
   updateStatus: UpdateStatus | null;
   updateChecking: boolean;
   updateInstalling: boolean;
@@ -62,6 +65,9 @@ export function createSettingsState(): SettingsState {
     settingsCategorySavedAt: { llm: null, agent: null, context: null, integrations: null },
     selectedModel: '',
     defaultModelSaving: false,
+    modelCatalogRefreshing: false,
+    modelCatalogRefreshError: null,
+    modelCatalogRefreshedAt: null,
     updateStatus: null,
     updateChecking: false,
     updateInstalling: false,

--- a/apps/web/src/features/settings/use-settings-controller.test.ts
+++ b/apps/web/src/features/settings/use-settings-controller.test.ts
@@ -13,6 +13,9 @@ describe('settings context boundaries', () => {
     appState.settingsCategorySaving = { llm: false, agent: false, context: false, integrations: false };
     appState.settingsCategoryErrors = { llm: null, agent: null, context: null, integrations: null };
     appState.settingsCategorySavedAt = { llm: null, agent: null, context: null, integrations: null };
+    appState.modelCatalogRefreshing = false;
+    appState.modelCatalogRefreshError = null;
+    appState.modelCatalogRefreshedAt = null;
   });
 
   afterEach(() => {
@@ -58,6 +61,68 @@ describe('settings context boundaries', () => {
     expect(appState.llm.defaultModel).toBe('model-a');
     expect(appState.selectedModel).toBe('model-a');
     expect(appState.defaultModelSaving).toBe(false);
+  });
+
+  it('refreshes local account models without replacing a still-valid Composer selection', async () => {
+    appState.llm = { defaultModel: 'openai/default', providers: [] };
+    appState.selectedModel = 'codex/gpt-5.4';
+    appState.newTaskConfig.model = 'missing/model';
+    vi.spyOn(codeApi, 'refreshModelCatalog').mockResolvedValue({
+      defaultModel: 'workbuddy/auto',
+      warnings: [],
+      items: [
+        {
+          id: 'codex/gpt-5.4',
+          name: 'gpt-5.4',
+          source: 'Codex',
+          reasoning: true,
+          toolCall: true,
+        },
+        {
+          id: 'workbuddy/auto',
+          name: 'auto',
+          source: 'WorkBuddy',
+          reasoning: true,
+          toolCall: true,
+        },
+      ],
+    });
+    const hook = renderHook(() => useSettingsController());
+
+    await act(() => hook.result.current.refreshModelCatalog());
+
+    expect(appState.modelCatalog?.items).toHaveLength(2);
+    expect(appState.selectedModel).toBe('codex/gpt-5.4');
+    expect(appState.newTaskConfig.model).toBe('workbuddy/auto');
+    expect(appState.modelCatalogRefreshedAt).not.toBeNull();
+    expect(appState.modelCatalogRefreshError).toBeNull();
+    expect(appState.modelCatalogRefreshing).toBe(false);
+    hook.unmount();
+  });
+
+  it('keeps the current catalog and an inline retry state when account refresh fails', async () => {
+    appState.modelCatalog = {
+      defaultModel: 'codex/gpt-5.4',
+      warnings: [],
+      items: [
+        {
+          id: 'codex/gpt-5.4',
+          name: 'gpt-5.4',
+          source: 'Codex',
+          reasoning: true,
+          toolCall: true,
+        },
+      ],
+    };
+    vi.spyOn(codeApi, 'refreshModelCatalog').mockRejectedValue(new Error('account discovery unavailable'));
+    const hook = renderHook(() => useSettingsController());
+
+    await act(() => hook.result.current.refreshModelCatalog());
+
+    expect(appState.modelCatalog.items[0].id).toBe('codex/gpt-5.4');
+    expect(appState.modelCatalogRefreshError).toBe('account discovery unavailable');
+    expect(appState.modelCatalogRefreshing).toBe(false);
+    hook.unmount();
   });
 
   it('keeps update-check failure inline and retryable', async () => {

--- a/apps/web/src/features/settings/use-settings-controller.ts
+++ b/apps/web/src/features/settings/use-settings-controller.ts
@@ -108,6 +108,27 @@ export function useSettingsController() {
       appState.defaultModelSaving = false;
     }
   });
+  const refreshModelCatalog = useMemoizedFn(async () => {
+    if (appState.modelCatalogRefreshing) return;
+    appState.modelCatalogRefreshing = true;
+    appState.modelCatalogRefreshError = null;
+    try {
+      const catalog = await codeApi.refreshModelCatalog();
+      appState.modelCatalog = catalog;
+      const fallbackModel = catalog.defaultModel || appState.llm?.defaultModel || '';
+      if (!catalog.items.some((model) => model.id === appState.selectedModel)) {
+        appState.selectedModel = fallbackModel;
+      }
+      if (!catalog.items.some((model) => model.id === appState.newTaskConfig.model)) {
+        appState.newTaskConfig.model = fallbackModel;
+      }
+      appState.modelCatalogRefreshedAt = Date.now();
+    } catch (error) {
+      appState.modelCatalogRefreshError = formatApiError(error);
+    } finally {
+      appState.modelCatalogRefreshing = false;
+    }
+  });
   const loginWithOs = useMemoizedFn(async () => {
     try {
       appState.osAccount = await codeApi.osLogin();
@@ -174,6 +195,7 @@ export function useSettingsController() {
     saveAgentSettings,
     saveContextSettings,
     saveIntegrationsSettings,
+    refreshModelCatalog,
     loginWithOs,
     logout,
     checkForUpdates,

--- a/apps/web/src/styles/settings-sections.css
+++ b/apps/web/src/styles/settings-sections.css
@@ -118,8 +118,7 @@
   white-space: nowrap;
 }
 
-.default-model-card,
-.os-account-card {
+.default-model-card {
   display: flex;
   align-items: center;
   gap: 13px;
@@ -130,8 +129,7 @@
   background: var(--a3s-panel-soft);
 }
 
-.default-model-card > div,
-.os-account-card > div {
+.default-model-card > div {
   display: flex;
   min-width: 0;
   flex: 1;
@@ -139,16 +137,14 @@
   gap: 4px;
 }
 
-.default-model-card strong,
-.os-account-card strong {
+.default-model-card strong {
   overflow: hidden;
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.default-model-card span,
-.os-account-card span {
+.default-model-card span {
   color: var(--a3s-muted);
   font-size: 11px;
 }
@@ -202,50 +198,6 @@
   font-size: 10px;
 }
 
-.os-account-card img {
-  width: 38px;
-  height: 38px;
-  border-radius: 11px;
-}
-
-.connection-badge {
-  padding: 4px 7px;
-  border-radius: 999px;
-  background: var(--a3s-panel-strong);
-  color: var(--a3s-muted) !important;
-}
-
-.connection-badge.online {
-  background: color-mix(in srgb, var(--a3s-green) 11%, var(--a3s-panel));
-  color: var(--a3s-green) !important;
-}
-
-.account-capabilities {
-  display: grid;
-  margin: 0 0 18px;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-}
-
-.account-capabilities > div {
-  display: flex;
-  padding: 12px;
-  flex-direction: column;
-  gap: 6px;
-  border: 1px solid var(--a3s-line);
-  border-radius: 9px;
-  background: color-mix(in srgb, var(--a3s-panel-soft) 42%, var(--a3s-panel));
-}
-
-.account-capabilities span {
-  color: var(--a3s-muted);
-  font-size: 11px;
-}
-
-.account-capabilities strong {
-  font-size: 12px;
-}
-
 .settings-section > .btn,
 .settings-section > .btn-outline {
   min-height: 37px;
@@ -253,12 +205,193 @@
   font-size: 12px;
 }
 
-.settings-saving,
-.account-config-hint {
+.settings-saving {
   display: block;
   margin: -9px 0 14px;
   color: var(--a3s-muted);
   font-size: 11px;
+}
+
+.account-settings-page .config-section {
+  margin-bottom: 28px;
+}
+
+.a3s-os-account-summary {
+  display: grid;
+  min-height: 76px;
+  align-items: center;
+  gap: 13px;
+  padding: 14px 16px;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+}
+
+.a3s-os-account-summary img {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+}
+
+.account-provider-copy,
+.local-account-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.account-provider-copy strong,
+.local-account-copy > strong {
+  color: var(--a3s-ink);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.account-provider-copy > span,
+.local-account-copy > span {
+  overflow: hidden;
+  color: var(--a3s-muted);
+  font-size: 11px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-capability-grid {
+  display: grid;
+  border-top: 1px solid var(--a3s-line);
+  border-bottom: 1px solid var(--a3s-line);
+  background: color-mix(in srgb, var(--a3s-panel-soft) 52%, var(--a3s-panel));
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.account-capability-grid > div {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 14px;
+  border-right: 1px solid var(--a3s-line);
+}
+
+.account-capability-grid > div:last-child {
+  border-right: 0;
+}
+
+.account-capability-grid span {
+  color: var(--a3s-muted);
+  font-size: 11px;
+}
+
+.account-capability-grid strong {
+  color: var(--a3s-faint);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.account-capability-grid strong.available {
+  color: var(--a3s-green);
+}
+
+.account-section-actions,
+.account-model-catalog-note {
+  display: flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 10px 14px 10px 16px;
+}
+
+.account-section-actions > span,
+.account-model-catalog-note > span {
+  overflow: hidden;
+  color: var(--a3s-muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-section-actions .ds-button {
+  min-height: 32px;
+  padding-inline: 11px;
+  font-size: 11px;
+}
+
+.local-model-account-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.local-model-account-list > li {
+  display: grid;
+  min-height: 70px;
+  align-items: center;
+  gap: 13px;
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--a3s-line);
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+}
+
+.local-account-mark {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--a3s-line);
+  border-radius: 9px;
+  background: var(--a3s-panel);
+  color: var(--a3s-ink);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.local-account-mark.codex {
+  background: var(--a3s-action);
+  color: var(--a3s-action-ink);
+}
+
+.local-account-mark.workbuddy {
+  background: color-mix(in srgb, var(--a3s-green) 9%, var(--a3s-panel));
+  color: var(--a3s-green);
+}
+
+.local-account-models {
+  max-width: 560px;
+}
+
+.local-account-guidance code {
+  padding: 2px 5px;
+  border: 1px solid var(--a3s-line);
+  border-radius: 4px;
+  background: var(--a3s-panel);
+  color: var(--a3s-ink);
+  font: 10px/1.4 "SFMono-Regular", Consolas, monospace;
+}
+
+.account-model-refresh-error {
+  margin: 0;
+  padding: 9px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--a3s-red) 24%, var(--a3s-line));
+  background: color-mix(in srgb, var(--a3s-red) 5%, var(--a3s-panel));
+  color: var(--a3s-red);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.account-model-catalog-note {
+  min-height: 46px;
+  background: color-mix(in srgb, var(--a3s-panel-soft) 46%, var(--a3s-panel));
+}
+
+.account-model-catalog-note strong {
+  flex: 0 0 auto;
+  color: var(--a3s-green);
+  font-size: 10px;
+  font-weight: 600;
 }
 
 .settings-warning {


### PR DESCRIPTION
## Summary

- split the Account settings surface into focused A3S OS and local-model account sections
- report Claude Code, Codex, and WorkBuddy connection state only from qualified runtime catalog sources
- show authoritative available-model counts and truthful sign-in guidance without treating configured Anthropic/OpenAI Providers as local account login
- add an explicit account-model refresh that preserves the current catalog on failure and keeps valid Composer/model selections
- document the credential boundary: local account credentials remain in the CLI and are never returned to the browser

This is a semantic recovery onto the latest Web mainline. It intentionally excludes the older recovered editor implementation and the durable turn-queue UI, which depends on a separate CLI backend change still under validation.

## Validation

- `bun install --frozen-lockfile`
- `bun run format:check`
- `bun run lint:check`
- `bun run typecheck`
- `bun run test` — 61 files / 447 tests
- `bun run build`
- `git diff --check`
- browser smoke test against the live local A3S Code service:
  - Account modal and A3S OS state rendered correctly
  - Claude Code disconnected guidance remained distinct from configured Providers
  - Codex and WorkBuddy displayed authoritative model counts
  - manual refresh completed and preserved a clean browser console
