### PR TITLE
fix(updater): verify and atomically install releases

### DIFF
--- a/crates/updater/src/download.rs
+++ b/crates/updater/src/download.rs
@@ -2,11 +2,14 @@
 
 use anyhow::{bail, Context};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
 use std::io::Cursor;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tempfile::TempDir;
 
-const MAX_ARCHIVE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+const MAX_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_EXTRACTED_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+const MAX_EXTRACTED_ENTRIES: usize = 50_000;
 
 /// Download one release asset into memory.
 pub async fn download_asset(url: &str) -> anyhow::Result<Vec<u8>> {
@@ -15,7 +18,7 @@ pub async fn download_asset(url: &str) -> anyhow::Result<Vec<u8>> {
         .timeout(std::time::Duration::from_secs(300))
         .build()
         .context("failed to build release download client")?;
-    let response = client
+    let mut response = client
         .get(url)
         .send()
         .await
@@ -33,14 +36,23 @@ pub async fn download_asset(url: &str) -> anyhow::Result<Vec<u8>> {
     {
         bail!("release asset exceeds the {} byte limit", MAX_ARCHIVE_BYTES);
     }
-    let bytes = response
-        .bytes()
+    let initial_capacity = response
+        .content_length()
+        .unwrap_or_default()
+        .min(MAX_ARCHIVE_BYTES) as usize;
+    let mut bytes = Vec::with_capacity(initial_capacity);
+    while let Some(chunk) = response
+        .chunk()
         .await
-        .with_context(|| format!("failed to read release asset body from {url}"))?;
-    if bytes.len() as u64 > MAX_ARCHIVE_BYTES {
-        bail!("release asset exceeds the {} byte limit", MAX_ARCHIVE_BYTES);
+        .with_context(|| format!("failed to read release asset body from {url}"))?
+    {
+        let next_len = bytes.len().saturating_add(chunk.len());
+        if next_len as u64 > MAX_ARCHIVE_BYTES {
+            bail!("release asset exceeds the {} byte limit", MAX_ARCHIVE_BYTES);
+        }
+        bytes.extend_from_slice(&chunk);
     }
-    Ok(bytes.to_vec())
+    Ok(bytes)
 }
 
 /// Return a lowercase SHA-256 digest.
@@ -75,36 +87,41 @@ pub fn extract_tar_gz_archive(data: &[u8], dest_dir: &Path) -> anyhow::Result<Ve
     let gz = flate2::read::GzDecoder::new(data);
     let mut archive = tar::Archive::new(gz);
     let mut extracted = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut extracted_bytes = 0_u64;
 
-    for entry in archive.entries().context("failed to read tar entries")? {
+    for (entry_count, entry) in archive
+        .entries()
+        .context("failed to read tar entries")?
+        .enumerate()
+    {
         let mut entry = entry.context("failed to read tar entry")?;
-        let relative = entry.path().context("failed to read tar entry path")?;
-        if relative.is_absolute()
-            || relative.components().any(|component| {
-                matches!(
-                    component,
-                    std::path::Component::ParentDir | std::path::Component::RootDir
-                )
-            })
-        {
-            bail!(
-                "archive entry escapes extraction root: {}",
-                relative.display()
-            );
+        if entry_count >= MAX_EXTRACTED_ENTRIES {
+            bail!("archive exceeds the {MAX_EXTRACTED_ENTRIES} entry limit");
         }
-        let output = dest_dir.join(relative.as_ref());
-        if !output.starts_with(dest_dir) {
-            bail!(
-                "archive entry escapes extraction root: {}",
-                relative.display()
-            );
-        }
-
+        let entry_path = entry.path().context("failed to read tar entry path")?;
         let entry_type = entry.header().entry_type();
+        let Some(relative) = sanitized_relative_path(&entry_path)? else {
+            if entry_type.is_dir() {
+                // Common tar producers emit `./` as an explicit marker for the
+                // extraction root. It does not create or own a child path.
+                continue;
+            }
+            bail!("archive contains a non-directory root entry");
+        };
+        if !seen.insert(relative.clone()) {
+            bail!("archive contains duplicate entry {}", relative.display());
+        }
+        let output = dest_dir.join(&relative);
+
         if entry_type.is_dir() {
             std::fs::create_dir_all(&output)
                 .with_context(|| format!("failed to create {}", output.display()))?;
         } else if entry_type.is_file() {
+            extracted_bytes = extracted_bytes.saturating_add(entry.size());
+            if extracted_bytes > MAX_EXTRACTED_BYTES {
+                bail!("archive exceeds the {MAX_EXTRACTED_BYTES} extracted byte limit");
+            }
             if let Some(parent) = output.parent() {
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("failed to create {}", parent.display()))?;
@@ -131,7 +148,12 @@ pub fn extract_zip_archive(data: &[u8], dest_dir: &Path) -> anyhow::Result<Vec<P
     std::fs::create_dir_all(dest_dir)
         .with_context(|| format!("failed to create extraction root {}", dest_dir.display()))?;
     let mut archive = zip::ZipArchive::new(Cursor::new(data)).context("failed to read ZIP")?;
+    if archive.len() > MAX_EXTRACTED_ENTRIES {
+        bail!("ZIP exceeds the {MAX_EXTRACTED_ENTRIES} entry limit");
+    }
     let mut extracted = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut extracted_bytes = 0_u64;
 
     for index in 0..archive.len() {
         let mut entry = archive
@@ -143,18 +165,28 @@ pub fn extract_zip_archive(data: &[u8], dest_dir: &Path) -> anyhow::Result<Vec<P
                 entry.name()
             );
         }
-        let relative = entry
+        let enclosed = entry
             .enclosed_name()
             .with_context(|| format!("ZIP entry escapes extraction root: {}", entry.name()))?;
-        let output = dest_dir.join(&relative);
-        if !output.starts_with(dest_dir) {
-            bail!("ZIP entry escapes extraction root: {}", relative.display());
+        let Some(relative) = sanitized_relative_path(&enclosed)? else {
+            if entry.is_dir() {
+                continue;
+            }
+            bail!("ZIP contains a non-directory root entry");
+        };
+        if !seen.insert(relative.clone()) {
+            bail!("ZIP contains duplicate entry {}", relative.display());
         }
+        let output = dest_dir.join(&relative);
 
         if entry.is_dir() {
             std::fs::create_dir_all(&output)
                 .with_context(|| format!("failed to create {}", output.display()))?;
         } else if entry.is_file() {
+            extracted_bytes = extracted_bytes.saturating_add(entry.size());
+            if extracted_bytes > MAX_EXTRACTED_BYTES {
+                bail!("ZIP exceeds the {MAX_EXTRACTED_BYTES} extracted byte limit");
+            }
             if let Some(parent) = output.parent() {
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("failed to create {}", parent.display()))?;
@@ -169,6 +201,26 @@ pub fn extract_zip_archive(data: &[u8], dest_dir: &Path) -> anyhow::Result<Vec<P
         }
     }
     Ok(extracted)
+}
+
+fn sanitized_relative_path(path: &Path) -> anyhow::Result<Option<PathBuf>> {
+    if path.as_os_str().is_empty() {
+        bail!("archive contains an empty entry path");
+    }
+    let mut sanitized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => sanitized.push(segment),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("archive entry escapes extraction root: {}", path.display())
+            }
+        }
+    }
+    if sanitized.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(sanitized))
 }
 
 /// Extract a supported release archive according to its published file name.
@@ -186,95 +238,36 @@ pub fn extract_release_archive(
     }
 }
 
-/// Download a `.tar.gz` asset and extract the binary from it.
+/// Safely extract a verified release archive and resolve exactly one binary.
 ///
-/// Returns `(binary_path, temp_dir)`. The caller must keep `TempDir` alive
-/// until the extracted binary has been consumed (e.g. copied into place).
-/// Dropping `TempDir` automatically cleans up the temporary directory.
-pub async fn download_and_extract(
-    url: &str,
+/// The caller must verify the archive digest before calling this function.
+/// `TempDir` keeps every extracted file isolated until replacement completes.
+pub(crate) fn extract_release_binary(
+    data: &[u8],
+    archive_name: &str,
     binary_name: &str,
 ) -> anyhow::Result<(PathBuf, TempDir)> {
-    let client = reqwest::Client::builder()
-        .user_agent("a3s-updater/0.1")
-        .timeout(std::time::Duration::from_secs(300))
-        .build()
-        .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {}", e))?;
-
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to download asset from {}: {}", url, e))?;
-
-    if !response.status().is_success() {
-        return Err(anyhow::anyhow!(
-            "Download failed with status {} for {}",
-            response.status(),
-            url
-        ));
+    let temp_dir = TempDir::new().context("failed to create release staging directory")?;
+    let files = extract_release_archive(data, temp_dir.path(), archive_name)?;
+    let mut matches = files.into_iter().filter(|path| {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == binary_name)
+    });
+    let binary = matches
+        .next()
+        .with_context(|| format!("binary '{binary_name}' not found in release archive"))?;
+    if matches.next().is_some() {
+        bail!("release archive contains multiple binaries named '{binary_name}'");
     }
-
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to read download body: {}", e))?;
-
-    // Create a cryptographically unique temp directory (auto-cleaned on drop)
-    let temp_dir =
-        TempDir::new().map_err(|e| anyhow::anyhow!("Failed to create temp directory: {}", e))?;
-
-    // Decompress gzip and extract tar
-    extract_tar_gz(&bytes, temp_dir.path(), binary_name)?;
-
-    let binary_path = temp_dir.path().join(binary_name);
-    if !binary_path.exists() {
-        return Err(anyhow::anyhow!(
-            "Binary '{}' not found in downloaded archive",
-            binary_name
-        ));
-    }
-
-    Ok((binary_path, temp_dir))
-}
-
-/// Extract a `.tar.gz` archive, looking for the target binary.
-fn extract_tar_gz(data: &[u8], dest_dir: &Path, binary_name: &str) -> anyhow::Result<()> {
-    let gz = flate2::read::GzDecoder::new(data);
-    let mut archive = tar::Archive::new(gz);
-
-    for entry in archive
-        .entries()
-        .map_err(|e| anyhow::anyhow!("Failed to read tar entries: {}", e))?
+    #[cfg(unix)]
     {
-        let mut entry = entry.map_err(|e| anyhow::anyhow!("Failed to read tar entry: {}", e))?;
+        use std::os::unix::fs::PermissionsExt;
 
-        // Only extract regular files — reject symlinks and hardlinks to prevent
-        // path traversal via crafted archives.
-        let entry_type = entry.header().entry_type();
-        if !entry_type.is_file() {
-            continue;
-        }
-
-        let path = entry
-            .path()
-            .map_err(|e| anyhow::anyhow!("Failed to read entry path: {}", e))?;
-
-        // Extract only the target binary (may be at root or nested)
-        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-
-        if file_name == binary_name {
-            entry
-                .unpack(dest_dir.join(binary_name))
-                .map_err(|e| anyhow::anyhow!("Failed to extract '{}': {}", binary_name, e))?;
-            return Ok(());
-        }
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("failed to make {} executable", binary.display()))?;
     }
-
-    Err(anyhow::anyhow!(
-        "Binary '{}' not found in archive",
-        binary_name
-    ))
+    Ok((binary, temp_dir))
 }
 
 #[cfg(test)]
@@ -329,6 +322,49 @@ mod tests {
             builder.finish().unwrap();
         }
         assert!(extract_tar_gz_archive(&linked_archive, temp.path()).is_err());
+    }
+
+    #[test]
+    fn tar_archive_accepts_an_explicit_current_directory_root() {
+        let mut tar_bytes = Vec::new();
+        {
+            let encoder =
+                flate2::write::GzEncoder::new(&mut tar_bytes, flate2::Compression::default());
+            let mut builder = tar::Builder::new(encoder);
+
+            let mut root = tar::Header::new_gnu();
+            root.set_path(".").unwrap();
+            root.set_entry_type(tar::EntryType::Directory);
+            root.set_size(0);
+            root.set_mode(0o755);
+            root.set_cksum();
+            builder.append(&root, std::io::empty()).unwrap();
+
+            let body = b"fixture";
+            let mut binary = tar::Header::new_gnu();
+            binary.set_path("./a3s-use").unwrap();
+            binary.set_size(body.len() as u64);
+            binary.set_mode(0o755);
+            binary.set_cksum();
+            builder.append(&binary, &body[..]).unwrap();
+            builder.finish().unwrap();
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let files = extract_tar_gz_archive(&tar_bytes, temp.path()).unwrap();
+        assert_eq!(files, [temp.path().join("a3s-use")]);
+        assert_eq!(std::fs::read(&files[0]).unwrap(), b"fixture");
+    }
+
+    #[test]
+    fn archive_path_sanitization_distinguishes_root_markers_from_empty_paths() {
+        assert_eq!(sanitized_relative_path(Path::new(".")).unwrap(), None);
+        assert_eq!(
+            sanitized_relative_path(Path::new("./package/a3s-use")).unwrap(),
+            Some(PathBuf::from("package/a3s-use"))
+        );
+        assert!(sanitized_relative_path(Path::new("")).is_err());
+        assert!(sanitized_relative_path(Path::new("../escape")).is_err());
     }
 
     #[test]

--- a/crates/updater/src/github.rs
+++ b/crates/updater/src/github.rs
@@ -112,3 +112,22 @@ pub fn find_matching_asset<'a>(
     let expected = asset_name(binary_name, &version.to_string(), os, arch);
     release.assets.iter().find(|a| a.name == expected)
 }
+
+/// Return a validated GitHub-provided SHA-256 digest for a release asset.
+///
+/// A missing digest is a hard failure: callers must never silently downgrade
+/// a self-update to an unverified download.
+pub fn asset_sha256(asset: &Asset) -> anyhow::Result<String> {
+    let digest = asset
+        .digest
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("release asset '{}' has no SHA-256 digest", asset.name))?;
+    let digest = digest.strip_prefix("sha256:").unwrap_or(digest);
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(anyhow::anyhow!(
+            "release asset '{}' has an invalid SHA-256 digest",
+            asset.name
+        ));
+    }
+    Ok(digest.to_ascii_lowercase())
+}

--- a/crates/updater/src/install.rs
+++ b/crates/updater/src/install.rs
@@ -1,6 +1,8 @@
 //! Binary replacement logic.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
 
 /// Replace the currently running binary with a new one.
 ///
@@ -20,47 +22,142 @@ pub fn replace_binary(new_binary_path: &Path) -> anyhow::Result<()> {
         .canonicalize()
         .map_err(|e| anyhow::anyhow!("Failed to resolve current executable path: {}", e))?;
 
-    let backup_path = current_exe.with_extension("bak");
+    replace_binary_at(new_binary_path, &current_exe)
+}
 
-    // Rename current binary to .bak
-    std::fs::rename(&current_exe, &backup_path).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to rename {} to {}: {}",
-            current_exe.display(),
-            backup_path.display(),
-            e
-        )
-    })?;
-
-    // Copy new binary into place
-    if let Err(e) = std::fs::copy(new_binary_path, &current_exe) {
-        // Attempt to restore backup on failure
-        let _ = std::fs::rename(&backup_path, &current_exe);
+fn replace_binary_at(new_binary_path: &Path, current_exe: &Path) -> anyhow::Result<()> {
+    if !new_binary_path.is_file() {
         return Err(anyhow::anyhow!(
-            "Failed to install new binary to {}: {}",
-            current_exe.display(),
-            e
+            "new binary does not exist: {}",
+            new_binary_path.display()
         ));
     }
-
-    // Set executable permissions on unix
+    let parent = current_exe
+        .parent()
+        .context("current executable has no parent directory")?;
+    let staging = tempfile::NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "failed to create update staging file in {}",
+            parent.display()
+        )
+    })?;
+    std::fs::copy(new_binary_path, staging.path()).with_context(|| {
+        format!(
+            "failed to stage new binary {} in {}",
+            new_binary_path.display(),
+            parent.display()
+        )
+    })?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&current_exe, perms).map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to set permissions on {}: {}",
-                current_exe.display(),
-                e
-            )
-        })?;
+
+        std::fs::set_permissions(staging.path(), std::fs::Permissions::from_mode(0o755))
+            .with_context(|| {
+                format!(
+                    "failed to set executable permissions on {}",
+                    staging.path().display()
+                )
+            })?;
+    }
+    staging
+        .as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync staged binary in {}", parent.display()))?;
+
+    let backup = unique_backup_path(current_exe);
+    std::fs::rename(current_exe, &backup).with_context(|| {
+        format!(
+            "failed to move current binary {} to {}",
+            current_exe.display(),
+            backup.display()
+        )
+    })?;
+    match staging.persist(current_exe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&backup);
+            sync_directory(parent)?;
+            Ok(())
+        }
+        Err(error) => {
+            let restore = std::fs::rename(&backup, current_exe);
+            if let Err(restore_error) = restore {
+                return Err(anyhow::anyhow!(
+                    "failed to activate staged binary at {}: {}; failed to restore backup {}: {}",
+                    current_exe.display(),
+                    error.error,
+                    backup.display(),
+                    restore_error
+                ));
+            }
+            Err(error.error).with_context(|| {
+                format!(
+                    "failed to atomically activate staged binary at {}",
+                    current_exe.display()
+                )
+            })
+        }
+    }
+}
+
+fn unique_backup_path(current_exe: &Path) -> PathBuf {
+    let parent = current_exe.parent().unwrap_or_else(|| Path::new("."));
+    let name = current_exe
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("binary");
+    for suffix in 0..u32::MAX {
+        let candidate = parent.join(format!(".{name}.a3s-backup-{suffix}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    parent.join(format!(".{name}.a3s-backup"))
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> anyhow::Result<()> {
+    std::fs::File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("failed to sync update directory {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_replacement_preserves_the_old_binary_until_staging_succeeds() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("a3s");
+        let replacement = temp.path().join("replacement");
+        std::fs::write(&current, b"old").unwrap();
+        std::fs::write(&replacement, b"new").unwrap();
+
+        replace_binary_at(&replacement, &current).unwrap();
+
+        assert_eq!(std::fs::read(&current).unwrap(), b"new");
+        assert!(!temp
+            .path()
+            .read_dir()
+            .unwrap()
+            .flatten()
+            .any(|entry| entry.file_name().to_string_lossy().contains("a3s-backup")));
     }
 
-    // Clean up backup
-    let _ = std::fs::remove_file(&backup_path);
+    #[test]
+    fn missing_replacement_leaves_the_current_binary_unchanged() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("a3s");
+        std::fs::write(&current, b"old").unwrap();
 
-    // Temp directory cleanup is handled by the caller (TempDir drop).
+        assert!(replace_binary_at(&temp.path().join("missing"), &current).is_err());
 
-    Ok(())
+        assert_eq!(std::fs::read(&current).unwrap(), b"old");
+    }
 }

--- a/crates/updater/src/lib.rs
+++ b/crates/updater/src/lib.rs
@@ -19,7 +19,8 @@ pub use download::{
     sha256_hex, verify_sha256,
 };
 pub use github::{
-    fetch_latest_release, fetch_release, find_matching_asset, parse_version, Asset, Release,
+    asset_sha256, fetch_latest_release, fetch_release, find_matching_asset, parse_version, Asset,
+    Release,
 };
 
 /// Configuration for the update check — each binary provides its own.
@@ -73,8 +74,12 @@ pub async fn run_update(config: &UpdateConfig) -> anyhow::Result<()> {
         config.binary_name, latest_version, os, arch
     );
 
+    let checksum = github::asset_sha256(asset)?;
+    let archive = download::download_asset(&asset.browser_download_url).await?;
+    download::verify_sha256(&archive, &checksum)?;
     let (new_binary, _temp_dir) =
-        download::download_and_extract(&asset.browser_download_url, config.binary_name).await?;
+        download::extract_release_binary(&archive, &asset.name, config.binary_name)?;
+    verify_downloaded_version(&new_binary, &latest_version)?;
     install::replace_binary(&new_binary)?;
     // _temp_dir is dropped here, automatically cleaning up the temp directory
 
@@ -83,6 +88,57 @@ pub async fn run_update(config: &UpdateConfig) -> anyhow::Result<()> {
         config.binary_name, current_version, latest_version
     );
 
+    Ok(())
+}
+
+fn verify_downloaded_version(
+    binary: &std::path::Path,
+    expected: &semver::Version,
+) -> anyhow::Result<()> {
+    let output = std::process::Command::new(binary)
+        .arg("--version")
+        .output()
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "failed to probe downloaded binary '{}': {error}",
+                binary.display()
+            )
+        })?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "downloaded binary '{}' failed its version probe",
+            binary.display()
+        ));
+    }
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    let actual = text
+        .split(|character: char| {
+            !(character.is_ascii_alphanumeric()
+                || character == '.'
+                || character == '-'
+                || character == '+'
+                || character == 'v')
+        })
+        .filter_map(|token| {
+            let token = token.trim_start_matches('v');
+            semver::Version::parse(token).ok()
+        })
+        .next()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "downloaded binary '{}' did not report a semantic version",
+                binary.display()
+            )
+        })?;
+    if &actual != expected {
+        return Err(anyhow::anyhow!(
+            "downloaded binary '{}' reported version {}, expected {}",
+            binary.display(),
+            actual,
+            expected
+        ));
+    }
     Ok(())
 }
 
@@ -204,5 +260,36 @@ mod tests {
 
         let v2 = github::parse_version("0.2.0").unwrap();
         assert_eq!(v2, semver::Version::parse("0.2.0").unwrap());
+    }
+
+    #[test]
+    fn release_asset_requires_a_valid_sha256_digest() {
+        let mut asset = Asset {
+            name: "a3s-search-1.0.0-linux-x86_64.tar.gz".to_string(),
+            browser_download_url: "https://example.invalid/release.tar.gz".to_string(),
+            digest: Some(format!("sha256:{}", "a".repeat(64))),
+        };
+        assert_eq!(asset_sha256(&asset).unwrap(), "a".repeat(64));
+
+        asset.digest = None;
+        assert!(asset_sha256(&asset).is_err());
+        asset.digest = Some("sha256:not-a-digest".to_string());
+        assert!(asset_sha256(&asset).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn downloaded_binary_version_must_match_the_release() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let binary = temp.path().join("a3s-test");
+        std::fs::write(&binary, "#!/bin/sh\nprintf 'a3s-test 1.2.3\\n'\n").unwrap();
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        verify_downloaded_version(&binary, &semver::Version::parse("1.2.3").unwrap()).unwrap();
+        assert!(
+            verify_downloaded_version(&binary, &semver::Version::parse("1.2.4").unwrap()).is_err()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- require a valid GitHub-provided SHA-256 digest before installing a release asset
- verify the downloaded archive before extraction and verify the selected binary reports the expected release version
- safely extract complete tar/zip archives with bounded entry/byte counts, sanitized paths, duplicate rejection, and no links or special files
- select one unambiguous platform binary while retaining companion files from the release archive
- stage and sync replacements in the executable directory, activate them atomically, and restore the previous binary if activation fails

## Security behavior

- missing or malformed release digests fail closed instead of downgrading to an unverified update
- path traversal, absolute paths, symlinks, hardlinks, special tar entries, duplicate archive paths, oversized archives, ambiguous binaries, and mismatched binary versions are rejected
- the current executable remains intact until the replacement has been fully staged and synchronized

## Validation

Run from `crates/updater`:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 24 tests passed
- `git diff --check`
