### PR TITLE
test(use): exercise real hot-plug and first-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ submodules, and applications live under `apps/`.
 
 The `a3s` command is the unified product entrypoint: `a3s code` launches the
 interactive coding agent, `a3s box` manages isolated runtimes, `a3s bench` runs
-reproducible evaluations, and `a3s use` exposes Browser, Office, and installed
-Use extensions. `a3s list`, `a3s install`, `a3s upgrade`, and `a3s uninstall`
-provide one typed component lifecycle. Local Code, Runtime, provider/model, and
-Bench workflows do not require an A3S OS login unless the selected remote
-capability requires one.
+reproducible evaluations, and `a3s use` exposes Browser, native Office, OCR,
+and installed Use extensions. `a3s list`, `a3s install`, `a3s upgrade`, and
+`a3s uninstall` provide one typed component lifecycle. Local Code, Runtime,
+provider/model, and Bench workflows do not require an A3S OS login unless the
+selected remote capability requires one.
 
 The stack is intentionally not a root Rust workspace and not a JavaScript UI
 runtime. Web and WebView packages are auxiliary surfaces; the core product path
@@ -37,7 +37,7 @@ is Rust.
 | Product surfaces | `crates/cli`, `crates/bench`, `apps/web`, `apps/box`, `apps/docs` | CLI, browser workspace, benchmark control component, native app, and documentation site. |
 | Agent runtime | `crates/code`, `crates/ahp`, `crates/acl`, `crates/common` | Sessions, tools, policy, protocol, config, and shared types. |
 | UI systems | `crates/tui`, `crates/gui`, `crates/webview` | Terminal UI, native RSX UI, and trusted WebView helpers. |
-| Use and retrieval | `crates/use`, `crates/search` | Browser and Office capability surfaces, external Use extensions, and search through the shared Browser runtime. |
+| Use and retrieval | `crates/use`, `crates/search` | Browser, native Office, and OCR capability surfaces, external Use extensions, and search through the shared Browser runtime. |
 | State and coordination | `crates/memory`, `crates/event`, `crates/flow`, `crates/lane` | Memory, events, workflows, and queues. |
 | Runtime safety and operations | `crates/runtime`, `crates/box`, `crates/observer`, `crates/sentry` | Provider-neutral execution, isolation, observability, and runtime control. |
 | Services | `crates/boot`, `crates/gateway`, `crates/power` | Service framework, ingress, and model serving. |
@@ -57,7 +57,7 @@ is Rust.
 | [a3s-memory](crates/memory/) | 0.1.2 | Pluggable long-term memory storage for agents. |
 | [a3s-event](crates/event/) | 0.3.0 | Event subscription, dispatch, and persistence. |
 | [a3s-lane](crates/lane/) | 0.5.0 | Rust-only priority and job queue with Redis, flows, repeat jobs, worker leases, retry, and DLQ. |
-| [a3s-use](crates/use/) | 0.1.1 | Typed Browser and Office capability layer plus native CLI, standard MCP, and Skill extension surfaces. |
+| [a3s-use](crates/use/) | 0.1.1 | Typed Browser, native Office, and OCR capability layer plus native CLI, standard MCP, and Skill extension surfaces. |
 | [a3s-search](crates/search/) | 1.4.3 | Embeddable meta-search engine using `a3s-use-browser` for headless browsing. |
 | [a3s-bench](crates/bench/) | 0.1.0 | Reproducible evaluation of coding agents, automated systems, and deterministic tools. |
 | [a3s-runtime](crates/runtime/) | 0.1.0 | Provider-neutral execution contract and Runtime client. |
@@ -88,9 +88,10 @@ a3s web
 # Inspect the trusted component catalog and local installation state.
 a3s list
 
-# Use the built-in Browser and Office domains.
+# Use the built-in Browser, native Office, and OCR domains.
 a3s use browser render https://example.com
 a3s use office doctor --json
+a3s use ocr doctor --json
 
 # Manage catalog components explicitly.
 a3s install use
@@ -107,10 +108,14 @@ Managed component installation and runtime support currently target macOS and
 Linux. Windows remains a compile/package preview on the roadmap until its
 managed lifecycle, file-locking, and persistent Browser session gates pass.
 
-Browser and Office are built-in A3S Use domains. External domains remain
-independently implementable through ACL-declared native CLI, standard MCP,
-and/or `SKILL.md` surfaces; A3S Use does not introduce a custom JSON-RPC
-extension protocol. A3S Search depends directly on the typed
+Browser, native Office, and OCR are built-in A3S Use domains. Before terminal
+takeover, `a3s code` reuses a healthy Use installation or installs its verified
+release when networking and automatic setup are allowed. `--offline`,
+`A3S_OFFLINE=1`, and `A3S_NO_AUTO_INSTALL=1` remain strict zero-network,
+zero-receipt boundaries, and setup failure never prevents Code from starting.
+External domains remain independently implementable through ACL-declared native
+CLI, standard MCP, and/or `SKILL.md` surfaces; A3S Use does not introduce a
+custom JSON-RPC extension protocol. A3S Search depends directly on the typed
 `a3s-use-browser` library rather than owning a second browser runtime.
 
 When Code delegates to the restricted `use` worker, TUI and Web project the
@@ -158,6 +163,9 @@ just dev
 # Build and run the browser Code workspace.
 just web
 
+# Exercise real Use hot-plug and release-shaped Code first-use.
+just use-hotplug-e2e
+
 # Run the A3S Box desktop client.
 just box
 
@@ -197,7 +205,7 @@ git commit -m "Update <component> snapshot"
 
 Applications under `apps/` use app-local workflows. The root `justfile` only
 orchestrates common entry points such as `just code`, `just dev`, `just web`,
-and `just box-check`.
+`just use-hotplug-e2e`, and `just box-check`.
 
 ## Documentation
 

--- a/apps/docs/content/docs/en/cli/code-tui.mdx
+++ b/apps/docs/content/docs/en/cli/code-tui.mdx
@@ -83,11 +83,21 @@ Service, Knowledge service deployment, and asset activity panels.
 
 ## Use Workers
 
-When the explicitly installed Use component is ready, Code registers one
-restricted `use` worker in the live `task` and `parallel_task` agent catalogs.
-It can call only `mcp__use_*` tools: it cannot use the workspace, shell,
-unrelated MCP servers, or recursive delegation, and starting Code never
-installs Use as a side effect.
+Before terminal takeover, Code reuses a healthy A3S Use installation or installs
+its verified release when networking and automatic setup are allowed.
+`--offline`, `A3S_OFFLINE=1`, and `A3S_NO_AUTO_INSTALL=1` remain strict
+zero-network, zero-receipt boundaries. Setup failure is non-fatal and Code
+continues without application routes.
+
+When Use is ready, Code gives initial registry discovery one second and initial
+MCP projection a separate five-second budget. Ready Browser, native Office, OCR,
+and installed extension routes are advertised before the first model turn;
+slower routes continue converging in the background.
+
+Code registers one restricted `use` worker in the live `task` and
+`parallel_task` agent catalogs. It can call only `mcp__use_*` tools: it cannot
+use the workspace, shell, unrelated MCP servers, or recursive delegation. The
+primary model never receives the raw application tools.
 
 The TUI projects standard child progress into a capability-oriented lifecycle.
 For example, `mcp__use_browser__browser_open` appears as `Using Browser` while

--- a/apps/docs/content/docs/en/code/tui.mdx
+++ b/apps/docs/content/docs/en/code/tui.mdx
@@ -20,6 +20,7 @@ runner, IDE bridge, or controlled product surface.
 | --- | --- | --- |
 | `a3s-code-core` | [A3S-Lab/Code](https://github.com/A3S-Lab/Code) | Rust runtime crate for sessions, tools, memory, permissions, delegation, persistence, verification, and event replay. |
 | `a3s code` | [A3S-Lab/Cli](https://github.com/A3S-Lab/Cli) | Terminal coding-agent application that drives `a3s-code-core` sessions. |
+| A3S Use | [A3S-Lab/Use](https://github.com/A3S-Lab/Use) | Independently released Browser, native Office, OCR, and external application capabilities projected into Code through standard MCP and Skills. |
 | `a3s-tui` | [A3S-Lab/TUI](https://github.com/A3S-Lab/TUI) | Terminal UI framework used by the CLI. It is the renderer and component library, not the agent runtime. |
 | A3S Flow | [A3S-Lab/Flow](https://github.com/A3S-Lab/Flow) | Durable workflow engine used by `DynamicWorkflowRuntime` for replayable per-turn dynamic workflows. |
 | A3S monorepo | [A3S-Lab/a3s](https://github.com/A3S-Lab/a3s) | Product docs, release orchestration, submodule pins, and related crates. |
@@ -97,6 +98,7 @@ RemoteUI views, and engineered automation loops.
 | Models | `/model` switches configured ACL providers, OS gateway models, and signed-in account-backed model tabs when available. |
 | Effort | `/effort` changes thinking budget, tool-round budget, continuation count, and rigor guidance from `low` through `max` and `ultracode`. |
 | Tools and safety | File, search, shell, git, web, structured-output, MCP, PTC `program`, `task`, and `parallel_task` tools all pass through workspace boundaries, permission policy, HITL approval, timeouts, hooks, and traces. |
+| Application capabilities | A3S Use is prepared on first TUI use when policy allows, then projects Browser, native Office, OCR, and installed extension routes into a restricted `use` worker. |
 | Context and memory | The footer tracks context fill and auto-compaction. `/ctx` searches past sessions, `/ctx <n>` attaches a transcript window, `/ctx save <n>` promotes it to memory, `/sleep` consolidates the day, and `/memory` browses durable memories as an event/entity graph. |
 | Dynamic workflows | `ultracode` and `?` DeepResearch can use `DynamicWorkflowRuntime`, a local A3S Flow-backed runtime that records workflow and step history while sandboxed PTC scripts perform tool work. |
 | Parallel work | Local fan-out uses native host-side `parallel_task`. Dynamic workflows schedule a Flow step named `parallel_task` when they need local parallel subagents; QuickJS/PTC scripts do not call `parallel_task` directly. |
@@ -107,6 +109,23 @@ RemoteUI views, and engineered automation loops.
 | Knowledge | `/kb` manages a local personal knowledge vault. `/okf` manages shareable OKF knowledge-package assets and publishes them to the OS Knowledge service when signed in. |
 | Engineered loops | `/loop init`, `/loop run`, `/loop audit`, and `/loop logs` manage durable maker/checker loops under `.a3s/loops` with reports, budgets, state files, and Runtime/RemoteUI evidence when enabled. |
 | Operations | `/help` opens the command guide, `/theme` changes syntax themes, `/plugin` and `/reload` refresh skills/plugins, `/top` observes local agent process activity, `/view` reopens the latest RemoteUI ViewLink, and `/update` upgrades and restarts the CLI. |
+
+## Browser, Office, And OCR Through A3S Use
+
+A3S Use is an independently released first-use component. Before terminal
+takeover, `a3s code` reuses a healthy installation or installs the verified
+release when networking and automatic setup are allowed. `--offline`,
+`A3S_OFFLINE=1`, and `A3S_NO_AUTO_INSTALL=1` remain strict zero-network,
+zero-receipt boundaries. Setup failure is non-fatal; install the parent
+explicitly and restart Code once if first-use preparation was disabled or
+failed.
+
+When Use is ready, Code consumes its versioned registry and gives the initial
+MCP projection a separate bounded window. Browser, native Office, OCR, and
+installed extension routes are exposed only through a dedicated `use` worker.
+The primary model never sees raw `mcp__use_*` tools, and the worker cannot use
+the workspace, shell, unrelated MCP servers, or recursive delegation. Managed
+Skills provide domain guidance without widening that boundary.
 
 ## Interaction Model
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 # A3S - Justfile
 
+use_e2e_target := env_var_or_default("A3S_USE_E2E_TARGET", justfile_directory() / "target/use-hotplug-e2e")
+use_e2e_use_target := use_e2e_target / "use"
+use_e2e_code_target := use_e2e_target / "code"
+
 default:
     @just --list
 
@@ -41,6 +45,12 @@ playground:
 # Start the A3S Code TUI in the current repository
 code:
     cargo --config 'patch.crates-io.a3s-code-core.path="crates/code/core"' --config 'patch.crates-io.a3s-memory.path="crates/memory"' --config 'patch.crates-io.a3s-tui.path="crates/tui"' run --manifest-path crates/cli/Cargo.toml -- code
+
+# Test Code hot-plug and first-use startup against an independently built Use process
+use-hotplug-e2e:
+    CARGO_TARGET_DIR='{{ use_e2e_use_target }}' cargo build --manifest-path crates/use/Cargo.toml -p a3s-use -p a3s-use-browser-driver
+    CARGO_TARGET_DIR='{{ use_e2e_code_target }}' A3S_USE_E2E_BIN='{{ use_e2e_use_target }}/debug/a3s-use' cargo test --manifest-path crates/cli/Cargo.toml --lib use_registry::tests::real_use_process_converges_install_upgrade_rebuild_disable_and_enable -- --ignored --nocapture
+    CARGO_TARGET_DIR='{{ use_e2e_code_target }}' A3S_USE_E2E_BIN='{{ use_e2e_use_target }}/debug/a3s-use' A3S_USE_E2E_SOURCE_ROOT='{{ justfile_directory() }}/crates/use' cargo test --manifest-path crates/cli/Cargo.toml --test code_use_first_use code_tui_first_use_installs_a_real_use_release_before_the_first_turn -- --ignored --nocapture
 
 # Build and start the A3S Web application
 web:


### PR DESCRIPTION
## Summary

- add a root `just use-hotplug-e2e` workflow that builds A3S Use independently
- run both the real registry hot-plug lifecycle and the release-shaped Code first-use E2E
- isolate Use and Code Cargo targets so their different dependency graphs cannot contend for one build directory
- document verified first-use preparation, offline/no-auto-install boundaries, initial MCP readiness, and the restricted `use` worker

## Validation

- `just --unstable --fmt --check`
- `just --summary`
- `just --dry-run use-hotplug-e2e`
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run build` in `apps/docs` (473 static pages)

The two ignored process-bound tests are exercised by the new recipe once its
dependent component commits are present in the root checkout.

## Dependencies

- A3S-Lab/CLI#35 supplies the release-shaped first-use test and startup behavior.
- A3S-Lab/Use#2 supplies the built-in OCR release surface.

This PR intentionally does not update either submodule pointer to an unmerged
feature commit.

## Recovery scope

This is the focused root-orchestration extraction of a preserved interrupted
development session. It excludes unrelated root README restructuring,
application work, submodule pointer changes, and concurrent TUI features.
