### PR TITLE
feat(web): refine Markdown, tools, and editor menus

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -38,9 +38,12 @@ Product implementation is governed by the
 - A calm turn-based execution document with restored Skill/file context,
   stable Code response headers, local copy and continue-edit actions,
   lifecycle-aware Markdown reasoning, reader-controlled stream following, and
-  Streamdown/Shiki rendering for prose, code, and tables. Its semantic tool
-  timeline merges live events, output, HITL decisions, and recovery into one
-  execution block.
+  typographically tuned Streamdown/Shiki rendering for headings, lists, task
+  lists, quotations, tables, links, images, footnotes, inline code, and
+  line-numbered code blocks. Its semantic tool timeline merges live events,
+  output, HITL decisions, and recovery into one execution block, with
+  syntax-highlighted commands and arguments, working-directory context, live
+  output metrics, copy actions, and a compact tail preview after completion.
 - Visible task execution mode with a mode-specific icon, provider-tabbed model
   selection, an independent Effort slider with English values and Chinese
   guidance, task goal timing, context usage, manual context compaction, and an
@@ -62,6 +65,9 @@ Product implementation is governed by the
   lazy-loaded Monaco editing, independent dirty file tabs with shortest-unique
   parent labels for same-named files, a semantic roving tab strip with
   post-close focus recovery and editor-to-editor `Ctrl+Tab` focus handoff,
+  Simplified Chinese Monaco and code-navigation menus, pointer and keyboard
+  tab context menus for guarded close-one/other/right/all operations and path
+  copying,
   keyboard save/close/tab switching scoped to workspace focus, an editor-safe
   `Cmd/Ctrl+B` task-sidebar toggle, bounded
   back/forward location history,
@@ -105,7 +111,9 @@ Monaco shares the workspace-scoped native Code Intelligence runtime owned by
 the CLI backend. The file toolbar exposes definition, declaration, references,
 implementations, and Go to Symbol in Editor together with their keyboard
 shortcuts. The same navigation commands remain available from Monaco's context
-menu; diagnostics appear as Monaco markers. The editor toolbar keeps a bounded,
+menu, whose native actions and A3S additions use the same Simplified Chinese
+catalog as the surrounding Web IDE; diagnostics appear as Monaco markers. The
+editor toolbar keeps a bounded,
 workspace-scoped location history: `Ctrl+-` returns to the previous file and
 caret, while `Ctrl+Shift+-` moves forward. Open drafts are reused rather than
 reread, a new navigation clears the forward branch, and file rename/delete

--- a/apps/web/docs/COMPONENT_SPEC.md
+++ b/apps/web/docs/COMPONENT_SPEC.md
@@ -204,7 +204,10 @@ entries.
 **Contracts:**
 
 - assistant Markdown uses Streamdown streaming mode while pending and static
-  mode after completion, with Shiki code highlighting and Chinese control text;
+  mode after completion, with Chinese control text, light/dark Shiki themes,
+  line-numbered code blocks, normalized embedded-HTML indentation, and
+  document typography for headings, paragraphs, nested lists, task lists,
+  quotations, tables, links, images, footnotes, and inline code;
 - `InstructionMessage` removes transport wrappers while retaining selected
   Skills and workspace files as typed resource chips; its Continue editing
   action restores both content and resources to the current draft;
@@ -243,6 +246,17 @@ calls remain open. Full output stays available in a scrollable disclosure and
 is never permanently sliced. File-editing calls hand off to the Monaco review
 surface, with raw tool output remaining available as a secondary disclosure.
 Running output follows its own bottom only until the reader scrolls away.
+Shell calls expose the exact command, syntax-highlighted program, flags,
+strings, paths, operators, redirections, and variables, plus the working
+directory when supplied. Detection accepts both plain and provider-qualified
+tool names such as `bash`, `shell_command`, and
+`functions.shell_command`. Other tools use a compact highlighted
+`tool(key=value)` presentation with the highest-signal arguments first.
+Preparing and running calls publish a live state; output reports its line count,
+offers copying, and follows the tail until the reader scrolls away. A collapsed
+completed call retains the final two output lines with explicit omission and
+truncation labels instead of hiding all execution evidence.
+
 Output copy, permission outcomes, and safe recovery belong to the same tool
 block. A global recovery card is omitted only when its normalized error message
 explicitly repeats failed-tool output or typed error evidence, or is the exact
@@ -699,8 +713,9 @@ known binary extensions directly and content-sample unfamiliar extensions.
 **Role:** keep file and diff documents in one ordered, horizontally scrollable
 tab model.
 
-**Actions:** activate, close, middle-click close, keyboard traversal, and expose
-per-file loading and dirty state.
+**Actions:** activate, close, middle-click close, keyboard traversal, expose
+per-file loading and dirty state, and open a tab context menu by pointer or
+`Shift+F10`.
 
 **Contract:** opening another file never discards a draft. A dirty close offers
 Save and Close, Don't Save, and Cancel. `Cmd/Ctrl+W` follows the same guard.
@@ -714,6 +729,12 @@ the same guarded close path. If removal disconnects the current focus, focus
 moves to the surviving active tab or the empty editor's Quick Open action; a
 still-connected control elsewhere keeps focus. Any active-tab change that
 disconnects its invoking control falls back to the newly active tab.
+The viewport-bounded Chinese context menu closes the selected tab, all other
+tabs, tabs to its right, or all tabs, and copies either the absolute or
+workspace-relative path. Multi-tab close processes dirty documents in tab
+order through the existing Save/Don't Save/Cancel guard. Cancelling stops the
+remaining close queue, and a workspace-generation change invalidates it so an
+old task cannot close tabs in the newly selected workspace.
 
 ### `MonacoFileEditor`
 
@@ -726,15 +747,18 @@ references, implementations, and file outline. Monaco shortcuts and its editor
 context menu invoke the same navigation boundary.
 
 **Contract:** Monaco and its language workers are bundled locally and loaded on
-demand. The shared editor/diff runtime keeps Monaco's complete standalone
-contribution surface, four worker-backed language-service families (JSON, CSS,
-HTML, and TypeScript/JavaScript), and only the tokenizers needed by the
-product's ACL/HCL, shell, C/C++, JavaScript/TypeScript, CSS, Go, HTML, JSON,
-Markdown, Python, Rust, SQL, INI/TOML, XML, and YAML mappings. It starts from
-the scoped editor API rather than the package-wide entry, so unsupported
-language tokenizers and unused protocol code are not part of editor activation.
-Semantic targets reuse normal workspace file selection; dirty buffers remain
-local and navigation labels results that come from the saved document.
+demand. The Simplified Chinese NLS catalog loads before any editor module, so
+Monaco's native context menu, command palette, and built-in editing actions
+match the Chinese A3S navigation commands. The shared editor/diff runtime keeps
+Monaco's complete standalone contribution surface, four worker-backed
+language-service families (JSON, CSS, HTML, and TypeScript/JavaScript), and
+only the tokenizers needed by the product's ACL/HCL, shell, C/C++,
+JavaScript/TypeScript, CSS, Go, HTML, JSON, Markdown, Python, Rust, SQL,
+INI/TOML, XML, and YAML mappings. It starts from the scoped editor API rather
+than the package-wide entry, so unsupported language tokenizers and unused
+protocol code are not part of editor activation. Semantic targets reuse normal
+workspace file selection; dirty buffers remain local and navigation labels
+results that come from the saved document.
 One mounted editor switches between models whose virtual URI combines task
 scope and the normalized path first assigned to the document. A referenced
 model owns its live undo/redo stack, cursor and selections, folding, scroll,

--- a/apps/web/src/features/tasks/components/execution-stream.test.tsx
+++ b/apps/web/src/features/tasks/components/execution-stream.test.tsx
@@ -263,7 +263,7 @@ describe('ExecutionStream permission decisions', () => {
     fireEvent.click(argumentsDisclosure);
     expect(argumentsDisclosure).toHaveAttribute('aria-expanded', 'true');
     expect(rawArguments).toBeVisible();
-    expect(screen.getAllByText(/cargo test/)).toHaveLength(3);
+    expect(screen.getByRole('region', { name: '命令预览' })).toHaveTextContent('cargo test');
     fireEvent.click(screen.getByRole('button', { name: '允许一次' }));
     expect(confirmToolUse).toHaveBeenCalledWith('session-approval', 'tool-7', true);
   });
@@ -527,12 +527,60 @@ describe('ExecutionStream permission decisions', () => {
     const details = container.querySelector('.tool-call-item');
     const disclosure = details?.querySelector('button[aria-expanded]');
     expect(disclosure).toHaveAttribute('aria-expanded', 'false');
-    expect(container.querySelector('.tool-call-output')).toHaveTextContent('final line must remain visible');
-    expect(container.querySelector('.tool-call-output')?.textContent).toBe(completeOutput);
+    expect(screen.getByLabelText('输出预览')).toHaveTextContent('final line must remain visible');
+    expect(container.querySelector('.tool-call-output')).not.toBeInTheDocument();
     fireEvent.click(disclosure!);
     expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+    expect(container.querySelector('.tool-call-output')?.textContent).toBe(completeOutput);
     expect(screen.getByRole('region', { name: '执行过程' })).toHaveTextContent('1 项操作已完成');
     expect(screen.getByLabelText('执行信息')).toHaveTextContent('bash');
+  });
+
+  it('renders the shell command, parameters, cwd, and incremental output as the primary execution preview', () => {
+    appState.activeSessionId = 'session-command-preview';
+    appState.messagesBySession['session-command-preview'] = [
+      {
+        id: 'assistant-command-preview',
+        sessionId: 'session-command-preview',
+        role: 'assistant',
+        content: '',
+        createdAt: new Date().toISOString(),
+        pending: true,
+        events: [
+          {
+            type: 'tool_execution_start',
+            tool_id: 'tool-command-preview',
+            tool_name: 'bash',
+            args: {
+              command: 'cargo test -p a3s-cli --test web_cli',
+              cwd: '/repo/crates/cli',
+            },
+          },
+          {
+            type: 'tool_output_delta',
+            tool_id: 'tool-command-preview',
+            tool_name: 'bash',
+            delta: 'running 13 tests\n',
+          },
+          {
+            type: 'tool_output_delta',
+            tool_id: 'tool-command-preview',
+            tool_name: 'bash',
+            delta: 'test result: ok\n',
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(<ExecutionStream actions={{} as TaskActions} />);
+
+    const command = screen.getByRole('region', { name: '命令预览' });
+    expect(command).toHaveTextContent('cargo test -p a3s-cli --test web_cli');
+    expect(command).toHaveTextContent('/repo/crates/cli');
+    expect(command.querySelector('[data-syntax-role="program"]')).toHaveTextContent('cargo');
+    expect(command.querySelectorAll('[data-syntax-role="flag"]')).toHaveLength(2);
+    expect(screen.getByRole('log', { name: '实时工具输出' })).toHaveTextContent('test result: ok');
+    expect(container.querySelector('.tool-call-result')).toHaveTextContent('实时输出 · 2 行');
   });
 
   it('compacts older successful tool calls without hiding active evidence', () => {
@@ -644,10 +692,49 @@ describe('ExecutionStream permission decisions', () => {
 
     const { container } = render(<ExecutionStream actions={{} as TaskActions} />);
     expect(await screen.findByRole('heading', { name: '构建结果' }, { timeout: 10_000 })).toBeInTheDocument();
-    expect(container.querySelector('.streaming-markdown')).toBeInTheDocument();
+    expect(container.querySelector('.streaming-markdown')).toHaveClass('a3s-document-markdown');
     await waitFor(() => expect(container.querySelector('pre code span')).toBeInTheDocument());
+    expect(container.querySelector('pre code')?.className).toContain('counter-reset');
     expect(screen.getByRole('button', { name: '复制代码' })).toBeInTheDocument();
   }, 20_000);
+
+  it('renders refined GFM document elements with accessible semantics', async () => {
+    appState.activeSessionId = 'session-refined-markdown';
+    appState.messagesBySession['session-refined-markdown'] = [
+      {
+        id: 'assistant-refined-markdown',
+        sessionId: 'session-refined-markdown',
+        role: 'assistant',
+        content: [
+          '## 发布检查',
+          '',
+          '> 请先完成验证。',
+          '',
+          '- [x] 类型检查',
+          '- [ ] 浏览器验收',
+          '',
+          '| 项目 | 状态 |',
+          '| --- | --- |',
+          '| 构建 | 通过 |',
+          '',
+          '---',
+          '',
+          '[查看文档](https://example.com/docs)',
+        ].join('\n'),
+        createdAt: new Date().toISOString(),
+      },
+    ];
+
+    const { container } = render(<ExecutionStream actions={{} as TaskActions} />);
+
+    expect(await screen.findByRole('heading', { name: '发布检查' })).toBeInTheDocument();
+    expect(container.querySelector('.streaming-markdown')).toHaveClass('a3s-document-markdown');
+    expect(container.querySelector('blockquote')).toHaveTextContent('请先完成验证');
+    expect(container.querySelectorAll('input[type="checkbox"]')).toHaveLength(2);
+    expect(screen.getByRole('table')).toHaveTextContent('构建');
+    expect(container.querySelector('hr')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '查看文档' })).toHaveAttribute('data-streamdown', 'link');
+  });
 
   it('renders completed reasoning as collapsed Markdown instead of plain preformatted text', async () => {
     appState.activeSessionId = 'session-reasoning-markdown';

--- a/apps/web/src/features/tasks/components/streaming-markdown.tsx
+++ b/apps/web/src/features/tasks/components/streaming-markdown.tsx
@@ -36,19 +36,20 @@ const translations: StreamdownTranslations = {
 export default function StreamingMarkdown({ content, streaming }: { content: string; streaming: boolean }) {
   return (
     <Streamdown
-      className={`streaming-markdown${streaming ? ' is-streaming' : ''}`}
+      className={`streaming-markdown a3s-document-markdown${streaming ? ' is-streaming' : ''}`}
       dir='auto'
       aria-busy={streaming || undefined}
       mode={streaming ? 'streaming' : 'static'}
       isAnimating={streaming}
       parseIncompleteMarkdown
+      normalizeHtmlIndentation
       plugins={{ code }}
       shikiTheme={['github-light', 'github-dark']}
       controls={{
         code: { copy: true, download: false },
         table: { copy: true, download: false, fullscreen: true },
       }}
-      lineNumbers={false}
+      lineNumbers
       translations={translations}
     >
       {content}

--- a/apps/web/src/features/tasks/components/tool-call-syntax.test.ts
+++ b/apps/web/src/features/tasks/components/tool-call-syntax.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { shellSyntaxTokens, toolInvocationPresentation, toolOutputExcerpt } from './tool-call-syntax';
+
+describe('tool call syntax presentation', () => {
+  it('preserves a shell command while assigning TUI-compatible syntax roles', () => {
+    const command = `cd '../work tree'&&cargo test -p a3s|rg "tool call"`;
+    const tokens = shellSyntaxTokens(command);
+
+    expect(tokens.map((token) => token.text).join('')).toBe(command);
+    expect(tokens).toEqual(
+      expect.arrayContaining([
+        { text: 'cd', role: 'program' },
+        { text: "'../work tree'", role: 'string' },
+        { text: '&&', role: 'operator' },
+        { text: 'cargo', role: 'program' },
+        { text: '-p', role: 'flag' },
+        { text: '|', role: 'operator' },
+        { text: '"tool call"', role: 'string' },
+      ])
+    );
+  });
+
+  it('builds a readable generic invocation instead of exposing only raw JSON', () => {
+    const presentation = toolInvocationPresentation({
+      name: 'read',
+      args: { path: 'src/app.ts', line: 12, optional: true },
+      inputText: '',
+    });
+
+    expect(presentation).toMatchObject({
+      kind: 'tool',
+      text: 'read(path=src/app.ts, line=12, optional=true)',
+    });
+    expect(presentation?.tokens).toEqual(
+      expect.arrayContaining([
+        { text: 'read', role: 'program' },
+        { text: 'path', role: 'key' },
+        { text: 'src/app.ts', role: 'path' },
+        { text: '12', role: 'number' },
+        { text: 'true', role: 'keyword' },
+      ])
+    );
+  });
+
+  it('previews a command while its streamed JSON argument is still incomplete', () => {
+    const presentation = toolInvocationPresentation({
+      name: 'bash',
+      inputText: '{"command":"cargo test --workspace',
+    });
+
+    expect(presentation).toMatchObject({
+      kind: 'shell',
+      text: 'cargo test --workspace',
+    });
+  });
+
+  it('recognizes namespaced command tools used by other agent providers', () => {
+    const presentation = toolInvocationPresentation({
+      name: 'functions.shell_command',
+      args: { command: 'rg --files', workdir: '/repo' },
+      inputText: '',
+    });
+
+    expect(presentation).toMatchObject({
+      kind: 'shell',
+      text: 'rg --files',
+      cwd: '/repo',
+    });
+  });
+
+  it('keeps the latest output lines and reports how much earlier evidence was folded', () => {
+    expect(toolOutputExcerpt('one\ntwo\nthree\nfour\n', 2)).toEqual({
+      lines: ['three', 'four'],
+      omittedLines: 2,
+      truncated: false,
+    });
+  });
+});

--- a/apps/web/src/features/tasks/components/tool-call-syntax.ts
+++ b/apps/web/src/features/tasks/components/tool-call-syntax.ts
@@ -1,0 +1,419 @@
+import type { ToolCallProjection } from './tool-call-projection';
+
+export type ToolSyntaxRole =
+  | 'plain'
+  | 'program'
+  | 'argument'
+  | 'flag'
+  | 'string'
+  | 'path'
+  | 'keyword'
+  | 'operator'
+  | 'redirection'
+  | 'variable'
+  | 'number'
+  | 'comment'
+  | 'key';
+
+export interface ToolSyntaxToken {
+  text: string;
+  role: ToolSyntaxRole;
+}
+
+export interface ToolInvocationPresentation {
+  kind: 'shell' | 'tool';
+  text: string;
+  tokens: ToolSyntaxToken[];
+  cwd?: string;
+}
+
+export interface ToolOutputExcerpt {
+  lines: string[];
+  omittedLines: number;
+  truncated: boolean;
+}
+
+type InvocationSource = Pick<ToolCallProjection, 'name' | 'args' | 'inputText'>;
+type ShellTokenKind = 'whitespace' | 'word' | 'quoted' | 'operator' | 'comment';
+
+interface ShellToken {
+  kind: ShellTokenKind;
+  text: string;
+}
+
+const shellToolNames = new Set([
+  'bash',
+  'exec',
+  'execute',
+  'execute_command',
+  'git',
+  'run',
+  'run_command',
+  'shell',
+  'shell_command',
+  'terminal',
+]);
+const shellKeywords = new Set([
+  '!',
+  'case',
+  'do',
+  'done',
+  'elif',
+  'else',
+  'esac',
+  'fi',
+  'for',
+  'function',
+  'if',
+  'in',
+  'select',
+  'then',
+  'time',
+  'until',
+  'while',
+]);
+const commandKeywords = new Set(['!', 'do', 'elif', 'else', 'if', 'then', 'time', 'until', 'while']);
+const commandSeparators = new Set(['|', '||', '|&', '&&', ';', ';;', ';&', ';;&', '&']);
+const testPunctuation = new Set(['[', ']', '[[', ']]', '{', '}']);
+const operators = [';;&', '&&', '||', '|&', '>>', '<<', '<&', '>&', '<>', '>|', ';;', ';&'];
+const argumentPriority = [
+  'command',
+  'file_path',
+  'path',
+  'pattern',
+  'query',
+  'url',
+  'description',
+  'prompt',
+  'skill_name',
+];
+
+export function toolInvocationPresentation(source: InvocationSource): ToolInvocationPresentation | null {
+  const name = source.name.trim() || 'tool';
+  const normalizedName = name.toLowerCase();
+  const unqualifiedName = normalizedName.split(/[.:/]/).at(-1) ?? normalizedName;
+  if (shellToolNames.has(unqualifiedName)) {
+    const rawCommand =
+      stringArgument(source.args, ['command', 'cmd']) ?? extractPartialJsonString(source.inputText, 'command');
+    if (!rawCommand?.trim()) return null;
+    const command =
+      unqualifiedName === 'git' && !rawCommand.trimStart().startsWith('git ') ? `git ${rawCommand}` : rawCommand;
+    return {
+      kind: 'shell',
+      text: command,
+      tokens: shellSyntaxTokens(command),
+      cwd: stringArgument(source.args, ['cwd', 'workdir', 'work_dir']),
+    };
+  }
+
+  const args = source.args;
+  if (!args || Object.keys(args).length === 0) {
+    const input = source.inputText.trim();
+    const tokens: ToolSyntaxToken[] = [{ text: name, role: 'program' }];
+    if (input) {
+      tokens.push(
+        { text: '(', role: 'operator' },
+        { text: truncate(input.replace(/\s+/g, ' '), 160), role: 'argument' },
+        { text: ')', role: 'operator' }
+      );
+    }
+    return { kind: 'tool', text: tokens.map((token) => token.text).join(''), tokens };
+  }
+
+  const orderedKeys = [
+    ...argumentPriority.filter((key) => Object.hasOwn(args, key)),
+    ...Object.keys(args).filter((key) => !argumentPriority.includes(key)),
+  ];
+  const visibleKeys = orderedKeys.slice(0, 4);
+  const tokens: ToolSyntaxToken[] = [
+    { text: name, role: 'program' },
+    { text: '(', role: 'operator' },
+  ];
+  visibleKeys.forEach((key, index) => {
+    if (index > 0) tokens.push({ text: ', ', role: 'plain' });
+    tokens.push({ text: key, role: 'key' }, { text: '=', role: 'operator' }, ...genericValueTokens(args[key]));
+  });
+  const omitted = orderedKeys.length - visibleKeys.length;
+  if (omitted > 0) {
+    if (visibleKeys.length > 0) tokens.push({ text: ', ', role: 'plain' });
+    tokens.push({ text: `…+${omitted}`, role: 'comment' });
+  }
+  tokens.push({ text: ')', role: 'operator' });
+  return { kind: 'tool', text: tokens.map((token) => token.text).join(''), tokens };
+}
+
+export function shellSyntaxTokens(command: string): ToolSyntaxToken[] {
+  const spans: ToolSyntaxToken[] = [];
+  let commandPosition = true;
+  let redirectionTarget = false;
+
+  for (const token of shellTokens(command)) {
+    if (token.kind === 'whitespace') {
+      spans.push({ text: token.text, role: 'plain' });
+      if (token.text.includes('\n')) {
+        commandPosition = true;
+        redirectionTarget = false;
+      }
+      continue;
+    }
+    if (token.kind === 'comment') {
+      spans.push({ text: token.text, role: 'comment' });
+      continue;
+    }
+    if (token.kind === 'operator') {
+      const redirection = token.text.includes('<') || token.text.includes('>');
+      spans.push({ text: token.text, role: redirection ? 'redirection' : 'operator' });
+      if (redirection) redirectionTarget = true;
+      else if (commandSeparators.has(token.text) || token.text === '(') commandPosition = true;
+      continue;
+    }
+    if (token.kind === 'quoted') {
+      spans.push({ text: token.text, role: 'string' });
+      if (redirectionTarget) redirectionTarget = false;
+      else commandPosition = false;
+      continue;
+    }
+    if (redirectionTarget) {
+      pushShellValueTokens(spans, token.text);
+      redirectionTarget = false;
+      continue;
+    }
+    if (shellKeywords.has(token.text)) {
+      spans.push({ text: token.text, role: 'keyword' });
+      commandPosition = commandKeywords.has(token.text);
+      continue;
+    }
+    if (testPunctuation.has(token.text)) {
+      spans.push({ text: token.text, role: 'operator' });
+      if (commandPosition && (token.text === '[' || token.text === '[[')) commandPosition = false;
+      continue;
+    }
+    if (commandPosition && isAssignment(token.text)) {
+      pushAssignmentTokens(spans, token.text);
+      continue;
+    }
+    if (commandPosition) {
+      spans.push({
+        text: token.text,
+        role: token.text === 'true' || token.text === 'false' ? 'string' : 'program',
+      });
+      commandPosition = false;
+      continue;
+    }
+    pushShellValueTokens(spans, token.text);
+  }
+
+  return spans;
+}
+
+export function toolOutputExcerpt(output: string, maxLines = 2, maxCharacters = 320): ToolOutputExcerpt {
+  const allLines = output.replace(/\r\n?/g, '\n').split('\n');
+  while (allLines.at(-1) === '') allLines.pop();
+  const lineLimit = Math.max(1, maxLines);
+  const selected = allLines.slice(-lineLimit);
+  let omittedLines = Math.max(0, allLines.length - selected.length);
+  let truncated = false;
+  const characterLimit = Math.max(40, maxCharacters);
+  let visible = selected.join('\n');
+  if (visible.length > characterLimit) {
+    visible = visible.slice(-characterLimit);
+    const firstLineBreak = visible.indexOf('\n');
+    if (firstLineBreak >= 0) {
+      visible = visible.slice(firstLineBreak + 1);
+      omittedLines += 1;
+    } else {
+      visible = `…${visible.slice(1)}`;
+    }
+    truncated = true;
+  }
+  return {
+    lines: visible ? visible.split('\n') : [],
+    omittedLines,
+    truncated,
+  };
+}
+
+function shellTokens(command: string): ShellToken[] {
+  const tokens: ShellToken[] = [];
+  let cursor = 0;
+
+  while (cursor < command.length) {
+    const start = cursor;
+    const character = nextCharacter(command, cursor);
+    if (/\s/u.test(character)) {
+      cursor += character.length;
+      while (cursor < command.length && /\s/u.test(nextCharacter(command, cursor))) {
+        cursor += nextCharacter(command, cursor).length;
+      }
+      tokens.push({ kind: 'whitespace', text: command.slice(start, cursor) });
+      continue;
+    }
+    if (character === '#') {
+      cursor += character.length;
+      while (cursor < command.length && nextCharacter(command, cursor) !== '\n') {
+        cursor += nextCharacter(command, cursor).length;
+      }
+      tokens.push({ kind: 'comment', text: command.slice(start, cursor) });
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      cursor = quotedTokenEnd(command, cursor, character);
+      tokens.push({ kind: 'quoted', text: command.slice(start, cursor) });
+      continue;
+    }
+    const operator = operatorAt(command, cursor);
+    if (operator) {
+      cursor += operator.length;
+      tokens.push({ kind: 'operator', text: command.slice(start, cursor) });
+      continue;
+    }
+
+    while (cursor < command.length) {
+      const next = nextCharacter(command, cursor);
+      if (/\s/u.test(next) || next === "'" || next === '"' || operatorAt(command, cursor)) break;
+      cursor += next.length;
+      if (next === '\\' && cursor < command.length) cursor += nextCharacter(command, cursor).length;
+    }
+    tokens.push({ kind: 'word', text: command.slice(start, cursor) });
+  }
+
+  return tokens;
+}
+
+function quotedTokenEnd(command: string, start: number, quote: string): number {
+  let cursor = start + quote.length;
+  while (cursor < command.length) {
+    const character = nextCharacter(command, cursor);
+    cursor += character.length;
+    if (character === quote) break;
+    if (character === '\\' && quote === '"' && cursor < command.length) {
+      cursor += nextCharacter(command, cursor).length;
+    }
+  }
+  return cursor;
+}
+
+function operatorAt(value: string, cursor: number): string | undefined {
+  const remaining = value.slice(cursor);
+  const operator = operators.find((candidate) => remaining.startsWith(candidate));
+  if (operator) return operator;
+  const character = nextCharacter(value, cursor);
+  return '|&;<>()'.includes(character) ? character : undefined;
+}
+
+function pushShellValueTokens(tokens: ToolSyntaxToken[], value: string): void {
+  if (value.startsWith('-')) {
+    const separator = value.indexOf('=');
+    if (separator > 0) {
+      const flag = value.slice(0, separator);
+      const argument = value.slice(separator + 1);
+      tokens.push(
+        { text: flag, role: 'flag' },
+        { text: '=', role: 'operator' },
+        { text: argument, role: shellValueRole(argument) }
+      );
+    } else {
+      tokens.push({ text: value, role: 'flag' });
+    }
+  } else if (isAssignment(value)) {
+    pushAssignmentTokens(tokens, value);
+  } else {
+    tokens.push({ text: value, role: shellValueRole(value) });
+  }
+}
+
+function pushAssignmentTokens(tokens: ToolSyntaxToken[], value: string): void {
+  const separator = value.indexOf('=');
+  if (separator < 1) {
+    tokens.push({ text: value, role: 'argument' });
+    return;
+  }
+  const name = value.slice(0, separator);
+  const argument = value.slice(separator + 1);
+  tokens.push(
+    { text: name, role: 'variable' },
+    { text: '=', role: 'operator' },
+    { text: argument, role: shellValueRole(argument) }
+  );
+}
+
+function genericValueTokens(value: unknown): ToolSyntaxToken[] {
+  if (typeof value === 'string') {
+    const safe = value.length > 0 && !/[\s,()='"\\]/u.test(value);
+    const text = safe ? value : JSON.stringify(value);
+    return [{ text: truncate(text, 120), role: safe ? shellValueRole(value) : 'string' }];
+  }
+  if (typeof value === 'number') return [{ text: String(value), role: 'number' }];
+  if (typeof value === 'boolean' || value === null) {
+    return [{ text: String(value), role: 'keyword' }];
+  }
+  return [{ text: truncate(JSON.stringify(value) ?? 'null', 120), role: 'argument' }];
+}
+
+function shellValueRole(value: string): ToolSyntaxRole {
+  if (looksLikePath(value)) return 'path';
+  if (value.startsWith('$') || value.includes('${')) return 'variable';
+  if (value.trim() && Number.isFinite(Number(value))) return 'number';
+  if (value === 'true' || value === 'false' || value === 'null') return 'keyword';
+  return 'argument';
+}
+
+function looksLikePath(value: string): boolean {
+  const normalized = value.replace(/^["']|["',)\]}]+$/g, '');
+  return (
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.includes('://') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('./') ||
+    normalized.startsWith('../') ||
+    normalized.startsWith('~/') ||
+    normalized.includes('/') ||
+    /\.[a-z0-9]{1,8}$/i.test(normalized)
+  );
+}
+
+function isAssignment(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/u.test(value);
+}
+
+function stringArgument(args: Record<string, unknown> | undefined, keys: string[]): string | undefined {
+  return keys
+    .map((key) => args?.[key])
+    .find((value): value is string => typeof value === 'string' && Boolean(value.trim()));
+}
+
+function extractPartialJsonString(value: string, key: string): string | undefined {
+  const match = new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*"`).exec(value);
+  if (!match) return undefined;
+  let cursor = match.index + match[0].length;
+  let encoded = '';
+  let escaped = false;
+  while (cursor < value.length) {
+    const character = nextCharacter(value, cursor);
+    cursor += character.length;
+    if (character === '"' && !escaped) break;
+    encoded += character;
+    if (character === '\\' && !escaped) escaped = true;
+    else escaped = false;
+  }
+  if (encoded.endsWith('\\')) encoded = encoded.slice(0, -1);
+  try {
+    return JSON.parse(`"${encoded}"`) as string;
+  } catch {
+    return encoded.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+}
+
+function nextCharacter(value: string, cursor: number): string {
+  const point = value.codePointAt(cursor);
+  return point === undefined ? '' : String.fromCodePoint(point);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function truncate(value: string, length: number): string {
+  return value.length > length ? `${value.slice(0, length - 1)}…` : value;
+}

--- a/apps/web/src/features/tasks/components/tool-call-timeline.tsx
+++ b/apps/web/src/features/tasks/components/tool-call-timeline.tsx
@@ -28,6 +28,12 @@ import type { TaskActions } from '../task-actions';
 import { CopyButton } from './conversation-message-actions';
 import { PermissionDecision, type ToolDecisionState } from './permission-decision';
 import {
+  outputLineCount,
+  ToolCollapsedOutputPreview,
+  ToolCommandPreview,
+  ToolInvocationInline,
+} from './tool-command-preview';
+import {
   isFileEditCall,
   selectToolCallsForDisplay,
   summarizeToolCalls,
@@ -143,7 +149,11 @@ function ToolCallItem({
         </span>
         <span className='tool-call-title'>
           <strong>{toolActionLabel(call)}</strong>
-          {target && <small>{target}</small>}
+          {target && (
+            <small>
+              <ToolInvocationInline call={call} fallback={target} />
+            </small>
+          )}
         </span>
         <span className='tool-call-state'>
           <StateIcon state={call.state} />
@@ -153,53 +163,61 @@ function ToolCallItem({
         </span>
         <ChevronDown className='tool-call-chevron' size={14} />
       </button>
+      {!open && call.output && <ToolCollapsedOutputPreview output={call.output} />}
       <div className='tool-call-body' id={bodyId} hidden={!open}>
-        {call.state === 'awaiting' && (
-          <PermissionDecision
-            call={call}
-            sessionId={sessionId}
-            decision={decision}
-            error={decisionError}
-            actions={actions}
-          />
+        {open && (
+          <>
+            {call.state === 'awaiting' && (
+              <PermissionDecision
+                call={call}
+                sessionId={sessionId}
+                decision={decision}
+                error={decisionError}
+                actions={actions}
+              />
+            )}
+            {call.state === 'denied' && call.reason && <p className='tool-call-message denied'>{call.reason}</p>}
+            {call.state === 'timed-out' && call.reason && <p className='tool-call-message timed-out'>{call.reason}</p>}
+            {call.state === 'interrupted' && call.reason && (
+              <p className='tool-call-message interrupted'>{call.reason}</p>
+            )}
+            <ToolCommandPreview call={call} />
+            <ToolExecutionMeta call={call} />
+            {argumentsText && (
+              <ToolInlineDisclosure className='tool-call-arguments' label='调用参数' icon={<Braces size={12} />}>
+                <pre>{argumentsText}</pre>
+              </ToolInlineDisclosure>
+            )}
+            {reviewAvailable ? (
+              <div className='tool-call-review'>
+                <span>
+                  <FileDiff size={15} />
+                  <span>
+                    <strong>{filePath || '工作区文件已变更'}</strong>
+                    <small>在工作区中查看完整 Diff，并决定是否保留变更。</small>
+                  </span>
+                </span>
+                <Button tone='secondary' onClick={openReview}>
+                  审阅变更
+                </Button>
+              </div>
+            ) : (
+              call.output && <ToolCallResult call={call} />
+            )}
+            {reviewAvailable && call.output && (
+              <ToolInlineDisclosure className='tool-call-raw-output' label='查看原始工具输出'>
+                <pre>{call.output}</pre>
+              </ToolInlineDisclosure>
+            )}
+            {!call.output && call.state === 'running' && (
+              <p className='tool-call-message running'>工具正在执行，输出会在这里持续更新。</p>
+            )}
+            {call.state === 'failed' && !call.output && (
+              <p className='tool-call-message failed'>{call.reason || call.errorKind || '工具没有返回可用结果。'}</p>
+            )}
+            {['failed', 'denied', 'timed-out'].includes(call.state) && <ToolCallRecovery call={call} />}
+          </>
         )}
-        {call.state === 'denied' && call.reason && <p className='tool-call-message denied'>{call.reason}</p>}
-        {call.state === 'timed-out' && call.reason && <p className='tool-call-message timed-out'>{call.reason}</p>}
-        {call.state === 'interrupted' && call.reason && <p className='tool-call-message interrupted'>{call.reason}</p>}
-        <ToolExecutionMeta call={call} />
-        {argumentsText && (
-          <ToolInlineDisclosure className='tool-call-arguments' label='调用参数' icon={<Braces size={12} />}>
-            <pre>{argumentsText}</pre>
-          </ToolInlineDisclosure>
-        )}
-        {reviewAvailable ? (
-          <div className='tool-call-review'>
-            <span>
-              <FileDiff size={15} />
-              <span>
-                <strong>{filePath || '工作区文件已变更'}</strong>
-                <small>在工作区中查看完整 Diff，并决定是否保留变更。</small>
-              </span>
-            </span>
-            <Button tone='secondary' onClick={openReview}>
-              审阅变更
-            </Button>
-          </div>
-        ) : (
-          call.output && <ToolCallResult call={call} />
-        )}
-        {reviewAvailable && call.output && (
-          <ToolInlineDisclosure className='tool-call-raw-output' label='查看原始工具输出'>
-            <pre>{call.output}</pre>
-          </ToolInlineDisclosure>
-        )}
-        {!call.output && call.state === 'running' && (
-          <p className='tool-call-message running'>工具正在执行，输出会在这里持续更新。</p>
-        )}
-        {call.state === 'failed' && !call.output && (
-          <p className='tool-call-message failed'>{call.reason || call.errorKind || '工具没有返回可用结果。'}</p>
-        )}
-        {['failed', 'denied', 'timed-out'].includes(call.state) && <ToolCallRecovery call={call} />}
       </div>
     </section>
   );
@@ -268,6 +286,7 @@ function ToolCallResult({ call }: { call: ToolCallProjection }) {
   const outputRef = useRef<HTMLPreElement>(null);
   const [following, setFollowing] = useState(true);
   const running = call.state === 'running' || call.state === 'preparing';
+  const lines = outputLineCount(call.output);
 
   useEffect(() => {
     const output = outputRef.current;
@@ -277,7 +296,9 @@ function ToolCallResult({ call }: { call: ToolCallProjection }) {
   return (
     <section className='tool-call-result' aria-label='工具输出'>
       <header>
-        <span>{running ? '实时输出' : '输出'}</span>
+        <span>
+          {running ? '实时输出' : '输出'} · {lines} 行
+        </span>
         <span className='tool-call-result-actions'>
           {running && !following && (
             <button
@@ -295,17 +316,19 @@ function ToolCallResult({ call }: { call: ToolCallProjection }) {
           <CopyButton content={call.output} label='复制工具输出' />
         </span>
       </header>
-      <pre
-        ref={outputRef}
-        className={`tool-call-output ${call.state === 'failed' ? 'error' : ''}`}
-        onScroll={(event) => {
-          if (!running) return;
-          const output = event.currentTarget;
-          setFollowing(output.scrollHeight - output.scrollTop - output.clientHeight < 24);
-        }}
-      >
-        {call.output}
-      </pre>
+      <div role='log' aria-label={running ? '实时工具输出' : '工具输出记录'} aria-live={running ? 'polite' : 'off'}>
+        <pre
+          ref={outputRef}
+          className={`tool-call-output ${call.state === 'failed' ? 'error' : ''}`}
+          onScroll={(event) => {
+            if (!running) return;
+            const output = event.currentTarget;
+            setFollowing(output.scrollHeight - output.scrollTop - output.clientHeight < 24);
+          }}
+        >
+          {call.output}
+        </pre>
+      </div>
     </section>
   );
 }
@@ -340,11 +363,17 @@ function truncateEvidence(value: string): string {
 }
 
 function ToolIcon({ name }: { name: string }) {
-  switch (name.trim().toLowerCase()) {
+  const normalized = name.trim().toLowerCase().split(/[.:/]/).at(-1);
+  switch (normalized) {
     case 'bash':
+    case 'execute':
+    case 'execute_command':
+    case 'run_command':
     case 'shell':
+    case 'shell_command':
     case 'run':
     case 'exec':
+    case 'terminal':
       return <SquareTerminal size={15} />;
     case 'read':
     case 'cat':

--- a/apps/web/src/features/tasks/components/tool-command-preview.tsx
+++ b/apps/web/src/features/tasks/components/tool-command-preview.tsx
@@ -1,0 +1,99 @@
+import { FolderOpen, LoaderCircle, SquareTerminal, Wrench } from 'lucide-react';
+import type { ToolCallProjection } from './tool-call-projection';
+import {
+  type ToolInvocationPresentation,
+  type ToolSyntaxToken,
+  toolInvocationPresentation,
+  toolOutputExcerpt,
+} from './tool-call-syntax';
+import { CopyButton } from './conversation-message-actions';
+
+export function ToolInvocationInline({ call, fallback }: { call: ToolCallProjection; fallback?: string }) {
+  const presentation = toolInvocationPresentation(call);
+  if (!presentation) return fallback ?? null;
+  return (
+    <span className='tool-invocation-inline' title={presentation.text}>
+      <SyntaxTokens tokens={presentation.tokens} />
+    </span>
+  );
+}
+
+export function ToolCommandPreview({ call }: { call: ToolCallProjection }) {
+  const presentation = toolInvocationPresentation(call);
+  if (!presentation) return null;
+  const running = call.state === 'preparing' || call.state === 'running';
+  const shell = presentation.kind === 'shell';
+  return (
+    <section
+      className={`tool-command-preview ${presentation.kind} ${running ? 'running' : ''}`}
+      aria-label={shell ? '命令预览' : '工具调用预览'}
+    >
+      <header>
+        <span>
+          {shell ? <SquareTerminal size={13} /> : <Wrench size={13} />}
+          <strong>{shell ? '命令' : '调用'}</strong>
+        </span>
+        <span className='tool-command-preview-actions'>
+          {running && (
+            <output aria-live='polite'>
+              <LoaderCircle className='spin' size={11} />
+              {call.state === 'preparing' ? '正在准备' : '正在执行'}
+            </output>
+          )}
+          <CopyButton content={presentation.text} label={shell ? '复制命令' : '复制工具调用'} />
+        </span>
+      </header>
+      <div className='tool-command-line'>
+        <span className='tool-command-prompt' aria-hidden='true'>
+          {shell ? '$' : '›'}
+        </span>
+        <code>
+          <SyntaxTokens tokens={presentation.tokens} />
+        </code>
+      </div>
+      {presentation.cwd && <WorkingDirectory presentation={presentation} />}
+    </section>
+  );
+}
+
+export function ToolCollapsedOutputPreview({ output }: { output: string }) {
+  const excerpt = toolOutputExcerpt(output);
+  if (!excerpt.lines.length) return null;
+  return (
+    <section className='tool-call-collapsed-preview' aria-label='输出预览'>
+      <span className='tool-output-connector' aria-hidden='true'>
+        ⎿
+      </span>
+      <code>
+        {excerpt.omittedLines > 0 && <span className='tool-output-omitted'>… 前 {excerpt.omittedLines} 行已折叠</span>}
+        {excerpt.lines.map((line, index) => (
+          <span key={`${index}:${line}`}>{line || '\u00a0'}</span>
+        ))}
+        {excerpt.truncated && <span className='tool-output-omitted'>输出预览已截断</span>}
+      </code>
+    </section>
+  );
+}
+
+export function outputLineCount(output: string): number {
+  const normalized = output.replace(/\r\n?/g, '\n').replace(/\n+$/, '');
+  return normalized ? normalized.split('\n').length : 0;
+}
+
+function SyntaxTokens({ tokens }: { tokens: readonly ToolSyntaxToken[] }) {
+  return tokens.map((token, index) => (
+    <span data-syntax-role={token.role} key={`${index}:${token.role}:${token.text}`}>
+      {token.text}
+    </span>
+  ));
+}
+
+function WorkingDirectory({ presentation }: { presentation: ToolInvocationPresentation }) {
+  return (
+    <footer>
+      <FolderOpen size={11} />
+      <span>运行目录</span>
+      <code>{presentation.cwd}</code>
+    </footer>
+  );
+}

--- a/apps/web/src/features/workspace/components/monaco-code-editor.test.tsx
+++ b/apps/web/src/features/workspace/components/monaco-code-editor.test.tsx
@@ -8,7 +8,7 @@ import { workspaceEditorModelPath } from './monaco-editor-model-store';
 import { MonacoCodeEditor, type MonacoCodeEditorHandle } from './monaco-code-editor';
 
 const testMonaco = monaco as unknown as {
-  __actions: Array<{ id: string; run: () => void | Promise<void> }>;
+  __actions: Array<{ id: string; label?: string; run: () => void | Promise<void> }>;
   __editorActionRuns: string[];
   __documentSymbolProviders: Array<{
     languageSelector: string;
@@ -83,6 +83,18 @@ describe('Monaco code-intelligence bridge', () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it('registers Chinese labels for A3S actions in the editor context menu', async () => {
+    renderEditor();
+
+    await waitFor(() => expect(testMonaco.__actions).toHaveLength(4));
+    expect(testMonaco.__actions.map(({ id, label }) => [id, label])).toEqual([
+      ['a3s.code-navigation.definition', '转到定义'],
+      ['a3s.code-navigation.declaration', '转到声明'],
+      ['a3s.code-navigation.references', '查找所有引用'],
+      ['a3s.code-navigation.implementations', '转到实现'],
+    ]);
   });
 
   it('reports live cursor, selection, and line-ending state from the Monaco model', async () => {

--- a/apps/web/src/features/workspace/components/monaco-code-editor.tsx
+++ b/apps/web/src/features/workspace/components/monaco-code-editor.tsx
@@ -455,6 +455,7 @@ export const MonacoCodeEditor = forwardRef<
           ariaLabel: `编辑 ${basename(path)}`,
           automaticLayout: true,
           bracketPairColorization: { enabled: true },
+          contextmenu: true,
           cursorBlinking: 'smooth',
           cursorSmoothCaretAnimation: 'on',
           detectIndentation: true,
@@ -496,7 +497,7 @@ function navigationActions(
   return [
     editor.addAction({
       id: 'a3s.code-navigation.definition',
-      label: 'Go to Definition',
+      label: '转到定义',
       keybindings: [monaco.KeyCode.F12],
       contextMenuGroupId: 'navigation',
       contextMenuOrder: 1,
@@ -504,14 +505,14 @@ function navigationActions(
     }),
     editor.addAction({
       id: 'a3s.code-navigation.declaration',
-      label: 'Go to Declaration',
+      label: '转到声明',
       contextMenuGroupId: 'navigation',
       contextMenuOrder: 2,
       run: () => navigate('declaration'),
     }),
     editor.addAction({
       id: 'a3s.code-navigation.references',
-      label: 'Go to References',
+      label: '查找所有引用',
       keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.F12],
       contextMenuGroupId: 'navigation',
       contextMenuOrder: 3,
@@ -519,7 +520,7 @@ function navigationActions(
     }),
     editor.addAction({
       id: 'a3s.code-navigation.implementations',
-      label: 'Go to Implementations',
+      label: '转到实现',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.F12],
       contextMenuGroupId: 'navigation',
       contextMenuOrder: 4,

--- a/apps/web/src/features/workspace/components/monaco-runtime.test.ts
+++ b/apps/web/src/features/workspace/components/monaco-runtime.test.ts
@@ -22,6 +22,15 @@ const expectedBasicLanguages = [
 const expectedLanguageServices = ['css', 'html', 'json', 'typescript'].sort();
 
 describe('Monaco runtime import graph', () => {
+  it('loads Simplified Chinese messages before Monaco evaluates editor actions', () => {
+    const source = runtimeSource();
+    const locale = source.indexOf('monaco-editor/esm/nls.messages.zh-cn.js');
+    const editor = source.indexOf('monaco-editor/esm/vs/editor/editor.api.js');
+
+    expect(locale).toBeGreaterThanOrEqual(0);
+    expect(locale).toBeLessThan(editor);
+  });
+
   it('starts from the editor API without importing the broad package entry', () => {
     const source = runtimeSource();
 

--- a/apps/web/src/features/workspace/components/monaco-runtime.ts
+++ b/apps/web/src/features/workspace/components/monaco-runtime.ts
@@ -1,3 +1,6 @@
+// Monaco reads its NLS table while editor modules are evaluated, so the
+// Simplified Chinese catalog must be the first runtime dependency.
+import 'monaco-editor/esm/nls.messages.zh-cn.js';
 import type * as MonacoNamespace from 'monaco-editor';
 import * as editorApi from 'monaco-editor/esm/vs/editor/editor.api.js';
 import * as css from 'monaco-editor/esm/vs/language/css/monaco.contribution.js';

--- a/apps/web/src/features/workspace/components/workspace-context-menu.tsx
+++ b/apps/web/src/features/workspace/components/workspace-context-menu.tsx
@@ -132,6 +132,7 @@ export function WorkspaceContextMenu({
           <WorkspaceContextMenuButton
             item={item}
             onSelect={() => {
+              restoreFocusRef.current?.focus();
               onClose();
               item.onSelect();
             }}

--- a/apps/web/src/features/workspace/components/workspace-editor-tabs.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-editor-tabs.test.tsx
@@ -59,6 +59,55 @@ describe('Workspace editor tabs', () => {
     expect(close.closest('[role="tab"]')).toBeNull();
   });
 
+  it('offers Chinese tab operations and closes tabs to the right as one safe request', () => {
+    const closeEditorTabs = vi.fn();
+    const actions = {
+      activateEditorTab: vi.fn(),
+      closeEditorTab: vi.fn(),
+      closeEditorTabs,
+    } as unknown as WorkspaceActions;
+    render(<WorkspaceEditorTabs actions={actions} />);
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: 'lib.rs，code/src' }), {
+      clientX: 120,
+      clientY: 32,
+    });
+
+    const menu = screen.getByRole('menu', { name: 'lib.rs，code/src 标签页操作' });
+    expect(menu).toHaveTextContent('关闭');
+    expect(menu).toHaveTextContent('关闭其他标签页');
+    expect(menu).toHaveTextContent('关闭右侧标签页');
+    expect(menu).toHaveTextContent('关闭全部标签页');
+    expect(menu).toHaveTextContent('复制相对路径');
+    fireEvent.click(within(menu).getByRole('menuitem', { name: '关闭右侧标签页' }));
+
+    expect(closeEditorTabs).toHaveBeenCalledWith([fileEditorTabId('/repo/README.md')]);
+  });
+
+  it('copies a relative path and supports keyboard dismissal with focus restoration', async () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    const actions = {
+      activateEditorTab: vi.fn(),
+      closeEditorTab: vi.fn(),
+      closeEditorTabs: vi.fn(),
+    } as unknown as WorkspaceActions;
+    render(<WorkspaceEditorTabs actions={actions} />);
+    const tab = screen.getByRole('tab', { name: 'README.md' });
+    tab.focus();
+    fireEvent.keyDown(tab, { key: 'F10', shiftKey: true });
+
+    expect(screen.getByRole('menuitem', { name: '关闭' })).toHaveFocus();
+    fireEvent.click(screen.getByRole('menuitem', { name: '复制相对路径' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('README.md'));
+    expect(tab).toHaveFocus();
+
+    fireEvent.keyDown(tab, { key: 'F10', shiftKey: true });
+    const menu = screen.getByRole('menu', { name: 'README.md 标签页操作' });
+    fireEvent.keyDown(menu, { key: 'Escape' });
+    expect(tab).toHaveFocus();
+  });
+
   it('supports automatic arrow, Home, End, and Delete navigation', async () => {
     const activateEditorTab = vi.fn((tabId: string) => {
       appState.activeEditorTabId = tabId;

--- a/apps/web/src/features/workspace/components/workspace-editor-tabs.tsx
+++ b/apps/web/src/features/workspace/components/workspace-editor-tabs.tsx
@@ -1,17 +1,26 @@
-import { FileDiff, LoaderCircle, X } from 'lucide-react';
-import { useLayoutEffect, useRef } from 'react';
+import { Copy, FileDiff, Files, LoaderCircle, PanelRightClose, X, XCircle } from 'lucide-react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { useSnapshot } from 'valtio';
-import { appState } from '../../../state/app-state';
+import { appState, showToast } from '../../../state/app-state';
 import type { WorkspaceActions } from '../workspace-actions';
-import { isFileEditorTabDirty } from '../workspace-state';
+import { isFileEditorTabDirty, type WorkspaceEditorTab, workspaceRelativePath } from '../workspace-state';
+import { WorkspaceContextMenu, type WorkspaceContextMenuItem } from './workspace-context-menu';
 import { workspaceEditorTabLabels } from './workspace-editor-tab-label';
 import { WorkspaceFileIcon } from './workspace-file-icon';
+
+interface TabContextMenuState {
+  tabId: string;
+  x: number;
+  y: number;
+}
 
 export function WorkspaceEditorTabs({ actions }: { actions: WorkspaceActions }) {
   const state = useSnapshot(appState);
   const activeRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef(new Map<string, HTMLButtonElement>());
   const requestedFocusIdRef = useRef<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<TabContextMenuState | null>(null);
+
   useLayoutEffect(() => {
     activeRef.current?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
     const requestedFocusId = requestedFocusIdRef.current;
@@ -21,8 +30,11 @@ export function WorkspaceEditorTabs({ actions }: { actions: WorkspaceActions }) 
     requestedFocusIdRef.current = null;
     target.focus({ preventScroll: true });
   }, [state.activeEditorTabId]);
+
   if (!state.editorTabs.length) return null;
   const labels = workspaceEditorTabLabels(state.editorTabs, state.workspaceRoot);
+  const contextualTab = contextMenu ? state.editorTabs.find((tab) => tab.id === contextMenu.tabId) : undefined;
+  const contextualLabel = contextualTab ? labels.get(contextualTab.id) : undefined;
 
   const activateFromKeyboard = (tabId: string) => {
     requestedFocusIdRef.current = tabId;
@@ -33,81 +45,188 @@ export function WorkspaceEditorTabs({ actions }: { actions: WorkspaceActions }) 
     target.focus({ preventScroll: true });
   };
 
+  const openContextMenu = (tabId: string, x: number, y: number) => {
+    tabRefs.current.get(tabId)?.focus({ preventScroll: true });
+    setContextMenu({ tabId, x, y });
+  };
+
   return (
-    <div className='workspace-editor-tabs' role='tablist' aria-label='已打开的编辑器' aria-orientation='horizontal'>
-      {state.editorTabs.map((tab, index) => {
-        const active = tab.id === state.activeEditorTabId;
-        const dirty = tab.kind === 'file' && isFileEditorTabDirty(tab);
-        const display = labels.get(tab.id);
-        if (!display) return null;
-        return (
-          <div
-            ref={active ? activeRef : undefined}
-            className={`workspace-editor-tab ${active ? 'active' : ''} ${dirty ? 'dirty' : ''} ${display.detail ? 'disambiguated' : ''}`}
-            key={tab.id}
-          >
-            <button
-              ref={(element) => {
-                if (element) tabRefs.current.set(tab.id, element);
-                else tabRefs.current.delete(tab.id);
-              }}
-              type='button'
-              className='workspace-editor-tab-trigger'
-              role='tab'
-              aria-label={`${display.ariaLabel}${dirty ? '，未保存' : ''}`}
-              aria-selected={active}
-              aria-controls='workspace-editor-active-panel'
-              tabIndex={active ? 0 : -1}
-              title={display.title}
-              onClick={() => actions.activateEditorTab(tab.id)}
-              onAuxClick={(event) => {
-                if (event.button === 1) actions.closeEditorTab(tab.id);
-              }}
-              onKeyDown={(event) => {
-                let targetIndex: number | null = null;
-                if (event.key === 'ArrowLeft') targetIndex = index - 1;
-                if (event.key === 'ArrowRight') targetIndex = index + 1;
-                if (event.key === 'Home') targetIndex = 0;
-                if (event.key === 'End') targetIndex = state.editorTabs.length - 1;
-                if (targetIndex !== null) {
-                  event.preventDefault();
-                  const next = state.editorTabs[(targetIndex + state.editorTabs.length) % state.editorTabs.length];
-                  activateFromKeyboard(next.id);
-                  return;
-                }
-                if (event.key === 'Delete') {
-                  event.preventDefault();
-                  actions.closeEditorTab(tab.id);
-                }
-              }}
+    <>
+      <div className='workspace-editor-tabs' role='tablist' aria-label='已打开的编辑器' aria-orientation='horizontal'>
+        {state.editorTabs.map((tab, index) => {
+          const active = tab.id === state.activeEditorTabId;
+          const dirty = tab.kind === 'file' && isFileEditorTabDirty(tab);
+          const display = labels.get(tab.id);
+          if (!display) return null;
+          return (
+            <div
+              ref={active ? activeRef : undefined}
+              className={`workspace-editor-tab ${active ? 'active' : ''} ${dirty ? 'dirty' : ''} ${
+                display.detail ? 'disambiguated' : ''
+              } ${contextMenu?.tabId === tab.id ? 'contextual' : ''}`}
+              key={tab.id}
             >
-              {tab.kind === 'diff' ? (
-                <FileDiff className={`workspace-tab-icon ${tab.staged ? 'staged' : 'working'}`} size={14} />
-              ) : (
-                <WorkspaceFileIcon path={tab.path} size={14} />
-              )}
-              <span className='workspace-tab-label'>
-                <span className='workspace-tab-name'>{display.name}</span>
-                {display.detail && <small className='workspace-tab-detail'>{display.detail}</small>}
-              </span>
-            </button>
-            {tab.loading ? (
-              <LoaderCircle className='workspace-tab-loading spin' size={12} />
-            ) : (
               <button
+                ref={(element) => {
+                  if (element) tabRefs.current.set(tab.id, element);
+                  else tabRefs.current.delete(tab.id);
+                }}
                 type='button'
-                className='workspace-tab-close'
-                aria-label={`关闭 ${display.ariaLabel}${dirty ? '，未保存' : ''}`}
+                className='workspace-editor-tab-trigger'
+                role='tab'
+                aria-label={`${display.ariaLabel}${dirty ? '，未保存' : ''}`}
+                aria-selected={active}
+                aria-controls='workspace-editor-active-panel'
+                aria-haspopup='menu'
                 tabIndex={active ? 0 : -1}
-                onClick={() => actions.closeEditorTab(tab.id)}
+                title={display.title}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  openContextMenu(tab.id, event.clientX, event.clientY);
+                }}
+                onClick={() => actions.activateEditorTab(tab.id)}
+                onAuxClick={(event) => {
+                  if (event.button === 1) actions.closeEditorTab(tab.id);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
+                    event.preventDefault();
+                    const bounds = event.currentTarget.getBoundingClientRect();
+                    openContextMenu(tab.id, bounds.left + Math.min(bounds.width, 160), bounds.bottom);
+                    return;
+                  }
+                  let targetIndex: number | null = null;
+                  if (event.key === 'ArrowLeft') targetIndex = index - 1;
+                  if (event.key === 'ArrowRight') targetIndex = index + 1;
+                  if (event.key === 'Home') targetIndex = 0;
+                  if (event.key === 'End') targetIndex = state.editorTabs.length - 1;
+                  if (targetIndex !== null) {
+                    event.preventDefault();
+                    const next = state.editorTabs[(targetIndex + state.editorTabs.length) % state.editorTabs.length];
+                    activateFromKeyboard(next.id);
+                    return;
+                  }
+                  if (event.key === 'Delete') {
+                    event.preventDefault();
+                    actions.closeEditorTab(tab.id);
+                  }
+                }}
               >
-                <span className='workspace-tab-dirty-dot' aria-hidden='true' />
-                <X className='workspace-tab-close-icon' size={12} />
+                {tab.kind === 'diff' ? (
+                  <FileDiff className={`workspace-tab-icon ${tab.staged ? 'staged' : 'working'}`} size={14} />
+                ) : (
+                  <WorkspaceFileIcon path={tab.path} size={14} />
+                )}
+                <span className='workspace-tab-label'>
+                  <span className='workspace-tab-name'>{display.name}</span>
+                  {display.detail && <small className='workspace-tab-detail'>{display.detail}</small>}
+                </span>
               </button>
-            )}
-          </div>
-        );
-      })}
-    </div>
+              {tab.loading ? (
+                <LoaderCircle className='workspace-tab-loading spin' size={12} />
+              ) : (
+                <button
+                  type='button'
+                  className='workspace-tab-close'
+                  aria-label={`关闭 ${display.ariaLabel}${dirty ? '，未保存' : ''}`}
+                  tabIndex={active ? 0 : -1}
+                  onClick={() => actions.closeEditorTab(tab.id)}
+                >
+                  <span className='workspace-tab-dirty-dot' aria-hidden='true' />
+                  <X className='workspace-tab-close-icon' size={12} />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {contextMenu && contextualTab && (
+        <WorkspaceContextMenu
+          label={`${contextualLabel?.ariaLabel ?? basename(contextualTab.path)} 标签页操作`}
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={tabContextMenuItems(
+            contextualTab as WorkspaceEditorTab,
+            state.editorTabs as readonly WorkspaceEditorTab[],
+            state.workspaceRoot,
+            actions
+          )}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+    </>
   );
+}
+
+function tabContextMenuItems(
+  tab: WorkspaceEditorTab,
+  tabs: readonly WorkspaceEditorTab[],
+  workspaceRoot: string,
+  actions: WorkspaceActions
+): WorkspaceContextMenuItem[] {
+  const index = tabs.findIndex((candidate) => candidate.id === tab.id);
+  const otherIds = tabs.filter((candidate) => candidate.id !== tab.id).map((candidate) => candidate.id);
+  const rightIds = tabs.slice(index + 1).map((candidate) => candidate.id);
+  const relativePath = workspaceRelativePath(tab.path, workspaceRoot);
+  const absolutePath = absoluteWorkspacePath(tab.path, workspaceRoot);
+  return [
+    {
+      id: 'close',
+      label: '关闭',
+      icon: <X size={14} />,
+      onSelect: () => actions.closeEditorTabs([tab.id]),
+    },
+    {
+      id: 'close-others',
+      label: '关闭其他标签页',
+      icon: <Files size={14} />,
+      disabled: otherIds.length === 0,
+      onSelect: () => actions.closeEditorTabs(otherIds),
+    },
+    {
+      id: 'close-right',
+      label: '关闭右侧标签页',
+      icon: <PanelRightClose size={14} />,
+      disabled: rightIds.length === 0,
+      onSelect: () => actions.closeEditorTabs(rightIds),
+    },
+    {
+      id: 'close-all',
+      label: '关闭全部标签页',
+      icon: <XCircle size={14} />,
+      onSelect: () => actions.closeEditorTabs(tabs.map((candidate) => candidate.id)),
+    },
+    {
+      id: 'copy-path',
+      label: '复制路径',
+      icon: <Copy size={14} />,
+      separatorBefore: true,
+      onSelect: () => void copyPath(absolutePath),
+    },
+    {
+      id: 'copy-relative-path',
+      label: '复制相对路径',
+      icon: <Copy size={14} />,
+      onSelect: () => void copyPath(relativePath),
+    },
+  ];
+}
+
+async function copyPath(path: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(path);
+    showToast('路径已复制', 'success');
+  } catch {
+    showToast('无法复制路径', 'error');
+  }
+}
+
+function absoluteWorkspacePath(path: string, root: string): string {
+  if (path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)) return path;
+  const separator = root.includes('\\') && !root.includes('/') ? '\\' : '/';
+  return `${root.replace(/[\\/]$/, '')}${separator}${path}`;
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path;
 }

--- a/apps/web/src/features/workspace/components/workspace-flow.test.tsx
+++ b/apps/web/src/features/workspace/components/workspace-flow.test.tsx
@@ -117,6 +117,41 @@ describe('Workspace review flow', () => {
     hook.unmount();
   });
 
+  it('closes a tab group in order without skipping dirty-file decisions', () => {
+    const first = setOpenFileTab('/repo/first.ts', 'saved', 'first draft');
+    const clean: WorkspaceFileEditorTab = {
+      ...first,
+      id: fileEditorTabId('/repo/clean.ts'),
+      path: '/repo/clean.ts',
+      content: 'clean',
+      draft: 'clean',
+    };
+    const last: WorkspaceFileEditorTab = {
+      ...first,
+      id: fileEditorTabId('/repo/last.ts'),
+      path: '/repo/last.ts',
+      content: 'saved',
+      draft: 'last draft',
+    };
+    appState.editorTabs = [first, clean, last];
+    appState.activeEditorTabId = first.id;
+    const hook = renderHook(() => useWorkspaceController());
+
+    act(() => hook.result.current.closeEditorTabs(appState.editorTabs.map((tab) => tab.id)));
+
+    expect(appState.editorTabs.map((tab) => tab.id)).toEqual([first.id, last.id]);
+    expect(appState.pendingEditorTabCloseId).toBe(first.id);
+
+    act(() => hook.result.current.confirmEditorTabClose());
+    expect(appState.editorTabs.map((tab) => tab.id)).toEqual([last.id]);
+    expect(appState.pendingEditorTabCloseId).toBe(last.id);
+
+    act(() => hook.result.current.cancelEditorTabClose());
+    expect(appState.editorTabs.map((tab) => tab.id)).toEqual([last.id]);
+    expect(appState.pendingEditorTabCloseId).toBeNull();
+    hook.unmount();
+  });
+
   it('opens a complete Monaco diff as another editor tab', async () => {
     setOpenFileTab('/repo/app.ts', 'const value = 1;\n');
     vi.spyOn(codeApi, 'gitDiff').mockResolvedValue({

--- a/apps/web/src/features/workspace/use-workspace-controller.ts
+++ b/apps/web/src/features/workspace/use-workspace-controller.ts
@@ -155,6 +155,10 @@ function updateDiffTab(tabId: string, update: (tab: WorkspaceDiffEditorTab) => v
 }
 
 export function useWorkspaceController() {
+  const pendingCloseQueueRef = useRef<{ generation: number; ids: string[] }>({
+    generation: appState.workspaceGeneration,
+    ids: [],
+  });
   const workspaceSearchRequestId = useRef(0);
   const directoryRequestIds = useRef(new Map<string, number>());
   const fileLoadOperations = useRef(new WeakMap<WorkspaceFileEditorTab, symbol>());
@@ -342,14 +346,39 @@ export function useWorkspaceController() {
     navigateTask('review');
   });
 
-  const closeEditorTab = useMemoizedFn((tabId: string) => {
-    const tab = appState.editorTabs.find((candidate) => candidate.id === tabId);
-    if (!tab) return;
-    if (tab.kind === 'file' && isFileEditorTabDirty(tab)) {
-      appState.pendingEditorTabCloseId = tabId;
+  const continueEditorTabClose = useMemoizedFn(() => {
+    const queue = pendingCloseQueueRef.current;
+    if (queue.generation !== appState.workspaceGeneration) {
+      pendingCloseQueueRef.current = { generation: appState.workspaceGeneration, ids: [] };
       return;
     }
-    removeEditorTabs((candidate) => candidate.id === tabId);
+    while (queue.ids.length > 0) {
+      const tabId = queue.ids.shift();
+      if (!tabId) continue;
+      const tab = appState.editorTabs.find((candidate) => candidate.id === tabId);
+      if (!tab) continue;
+      if (tab.kind === 'file' && isFileEditorTabDirty(tab)) {
+        appState.pendingEditorTabCloseId = tabId;
+        return;
+      }
+      removeEditorTabs((candidate) => candidate.id === tabId);
+    }
+  });
+
+  const closeEditorTabs = useMemoizedFn((tabIds: readonly string[]) => {
+    const requestedIds = new Set(tabIds);
+    const requestedTabs = appState.editorTabs.filter((tab) => requestedIds.has(tab.id));
+    pendingCloseQueueRef.current = {
+      generation: appState.workspaceGeneration,
+      ids: requestedTabs.filter((tab) => tab.kind === 'file' && isFileEditorTabDirty(tab)).map((tab) => tab.id),
+    };
+    appState.pendingEditorTabCloseId = null;
+    removeEditorTabs((tab) => requestedIds.has(tab.id) && !(tab.kind === 'file' && isFileEditorTabDirty(tab)));
+    continueEditorTabClose();
+  });
+
+  const closeEditorTab = useMemoizedFn((tabId: string) => {
+    closeEditorTabs([tabId]);
   });
 
   const confirmEditorTabClose = useMemoizedFn(() => {
@@ -358,9 +387,11 @@ export function useWorkspaceController() {
     appState.pendingEditorTabCloseId = null;
     if (appState.fileConflict?.tabId === tabId) appState.fileConflict = null;
     removeEditorTabs((tab) => tab.id === tabId);
+    continueEditorTabClose();
   });
 
   const cancelEditorTabClose = useMemoizedFn(() => {
+    pendingCloseQueueRef.current = { generation: appState.workspaceGeneration, ids: [] };
     appState.pendingEditorTabCloseId = null;
   });
 
@@ -840,6 +871,7 @@ export function useWorkspaceController() {
     consumeEditorLocation,
     activateEditorTab,
     closeEditorTab,
+    closeEditorTabs,
     confirmEditorTabClose,
     cancelEditorTabClose,
     updateEditorDraft,

--- a/apps/web/src/features/workspace/workspace-actions.ts
+++ b/apps/web/src/features/workspace/workspace-actions.ts
@@ -15,6 +15,7 @@ export interface WorkspaceActions {
   consumeEditorLocation(tabId: string): void;
   activateEditorTab(tabId: string): void;
   closeEditorTab(tabId: string): void;
+  closeEditorTabs(tabIds: readonly string[]): void;
   confirmEditorTabClose(): void;
   cancelEditorTabClose(): void;
   updateEditorDraft(tabId: string, content: string): void;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -27,3 +27,4 @@
 @import "./styles/task-runtime-floating-panel.css";
 @import "./styles/tool-calls.css";
 @import "./styles/execution-markdown.css";
+@import "./styles/tool-command.css";

--- a/apps/web/src/styles/execution-markdown.css
+++ b/apps/web/src/styles/execution-markdown.css
@@ -1,9 +1,12 @@
 .execution-markdown .streaming-markdown {
+  --markdown-soft-accent: color-mix(in srgb, var(--a3s-blue) 6%, var(--a3s-panel));
   min-width: 0;
   color: var(--a3s-ink);
   font-size: inherit;
-  line-height: inherit;
+  line-height: 1.72;
+  letter-spacing: 0.002em;
   overflow-wrap: anywhere;
+  text-wrap: pretty;
 }
 
 .execution-markdown .streaming-markdown.is-streaming > :last-child::after {
@@ -26,51 +29,173 @@
   margin-bottom: 0;
 }
 
-.execution-markdown .streaming-markdown :where(h1, h2, h3, h4) {
-  margin: 1.35em 0 0.55em;
+.execution-markdown .streaming-markdown :where(h1, h2, h3, h4, h5, h6) {
+  margin: 1.55em 0 0.58em;
+  scroll-margin-top: 18px;
   color: var(--a3s-ink);
-  font-weight: 650;
-  letter-spacing: -0.02em;
+  font-weight: 680;
+  letter-spacing: -0.024em;
+  line-height: 1.28;
+  text-wrap: balance;
 }
 
 .execution-markdown .streaming-markdown :where(h1) {
-  font-size: 1.45em;
+  font-size: 1.55em;
+  font-weight: 720;
 }
 
 .execution-markdown .streaming-markdown :where(h2) {
-  font-size: 1.25em;
+  padding-bottom: 0.32em;
+  border-bottom: 1px solid color-mix(in srgb, var(--a3s-line) 82%, transparent);
+  font-size: 1.32em;
 }
 
-.execution-markdown .streaming-markdown :where(h3, h4) {
-  font-size: 1.08em;
+.execution-markdown .streaming-markdown :where(h3) {
+  font-size: 1.14em;
 }
 
-.execution-markdown .streaming-markdown :where(p, ul, ol, blockquote, table) {
-  margin: 0.65em 0;
+.execution-markdown .streaming-markdown :where(h4) {
+  font-size: 1.04em;
+}
+
+.execution-markdown .streaming-markdown :where(h5, h6) {
+  color: var(--a3s-muted);
+  font-size: 0.96em;
+  letter-spacing: 0;
+}
+
+.execution-markdown .streaming-markdown :where(p, ul, ol, blockquote, table, details) {
+  margin: 0.78em 0;
+}
+
+.execution-markdown .streaming-markdown :where(strong) {
+  color: color-mix(in srgb, var(--a3s-ink) 94%, black);
+  font-weight: 670;
+}
+
+:root.dark .execution-markdown .streaming-markdown :where(strong) {
+  color: color-mix(in srgb, var(--a3s-ink) 96%, white);
+}
+
+.execution-markdown .streaming-markdown :where(em) {
+  text-decoration-color: color-mix(in srgb, var(--a3s-blue) 20%, transparent);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.14em;
+}
+
+.execution-markdown .streaming-markdown :where(del) {
+  color: var(--a3s-faint);
+  text-decoration-color: color-mix(in srgb, var(--a3s-red) 58%, transparent);
 }
 
 .execution-markdown .streaming-markdown :where(ul, ol) {
-  padding-left: 1.5em;
+  padding-left: 1.55em;
 }
 
-.execution-markdown .streaming-markdown :where(a) {
+.execution-markdown .streaming-markdown :where(li) {
+  margin: 0.26em 0;
+  padding-left: 0.12em;
+}
+
+.execution-markdown .streaming-markdown :where(li > p) {
+  margin: 0.32em 0;
+}
+
+.execution-markdown .streaming-markdown :where(li > ul, li > ol) {
+  margin: 0.34em 0 0.2em;
+}
+
+.execution-markdown .streaming-markdown :where(ul > li)::marker {
+  color: color-mix(in srgb, var(--a3s-blue) 70%, var(--a3s-muted));
+  font-size: 0.86em;
+}
+
+.execution-markdown .streaming-markdown :where(ol > li)::marker {
+  color: var(--a3s-muted);
+  font-size: 0.92em;
+  font-variant-numeric: tabular-nums;
+  font-weight: 620;
+}
+
+.execution-markdown .streaming-markdown :where(.contains-task-list) {
+  padding-left: 0.18em;
+  list-style: none;
+}
+
+.execution-markdown .streaming-markdown :where(.task-list-item) {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55em;
+  padding: 0.18em 0;
+}
+
+.execution-markdown .streaming-markdown :where(.task-list-item > input[type="checkbox"]) {
+  width: 1.05em;
+  height: 1.05em;
+  margin: 0.28em 0 0;
+  flex: 0 0 auto;
+  accent-color: var(--a3s-blue);
+}
+
+.execution-markdown .streaming-markdown :where(a, [data-streamdown="link"]) {
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--a3s-blue);
-  text-decoration-color: color-mix(in srgb, var(--a3s-blue) 35%, transparent);
-  text-underline-offset: 2px;
+  cursor: pointer;
+  font-weight: 520;
+  text-decoration-color: color-mix(in srgb, var(--a3s-blue) 32%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+  transition:
+    color 120ms ease,
+    text-decoration-color 120ms ease;
+}
+
+.execution-markdown .streaming-markdown :where(a:hover, [data-streamdown="link"]:hover) {
+  color: color-mix(in srgb, var(--a3s-blue) 82%, var(--a3s-ink));
+  text-decoration-color: currentColor;
 }
 
 .execution-markdown .streaming-markdown :where(blockquote) {
-  padding-left: 12px;
-  border-left: 2px solid var(--a3s-line-strong);
+  padding: 0.68em 0.9em 0.68em 1em;
+  border: 1px solid color-mix(in srgb, var(--a3s-blue) 12%, var(--a3s-line));
+  border-left: 3px solid color-mix(in srgb, var(--a3s-blue) 55%, var(--a3s-line-strong));
+  border-radius: 0 8px 8px 0;
+  background: var(--markdown-soft-accent);
   color: var(--a3s-muted);
+  font-style: normal;
+}
+
+.execution-markdown .streaming-markdown :where(blockquote > :first-child) {
+  margin-top: 0;
+}
+
+.execution-markdown .streaming-markdown :where(blockquote > :last-child) {
+  margin-bottom: 0;
+}
+
+.execution-markdown .streaming-markdown :where(hr) {
+  height: 1px;
+  margin: 1.65em 0;
+  border: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--a3s-line-strong) 12%,
+    var(--a3s-line-strong) 88%,
+    transparent
+  );
 }
 
 .execution-markdown .streaming-markdown :where(:not(pre) > code) {
-  padding: 1px 5px;
-  border: 1px solid var(--a3s-line);
+  padding: 0.08em 0.38em 0.12em;
+  border: 1px solid color-mix(in srgb, var(--a3s-line-strong) 82%, transparent);
   border-radius: 5px;
-  background: var(--a3s-panel-soft);
-  font: 0.92em/1.5 "SFMono-Regular", Consolas, monospace;
+  background: color-mix(in srgb, var(--a3s-panel-soft) 82%, var(--a3s-panel));
+  color: color-mix(in srgb, var(--a3s-ink) 86%, var(--a3s-purple));
+  font: 0.9em/1.55 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+  white-space: break-spaces;
 }
 
 .execution-markdown .streaming-markdown :where(pre) {
@@ -82,19 +207,88 @@
 
 .execution-markdown .streaming-markdown :where(table) {
   width: 100%;
+  margin: 0;
   border-collapse: collapse;
-  font-size: 0.94em;
+  font-size: 0.92em;
+  line-height: 1.5;
 }
 
 .execution-markdown .streaming-markdown :where(th, td) {
-  padding: 7px 9px;
-  border: 1px solid var(--a3s-line);
+  padding: 8px 10px;
+  border: 0;
+  border-right: 1px solid var(--a3s-line);
+  border-bottom: 1px solid var(--a3s-line);
   text-align: left;
+  vertical-align: top;
+}
+
+.execution-markdown .streaming-markdown :where(th:last-child, td:last-child) {
+  border-right: 0;
 }
 
 .execution-markdown .streaming-markdown :where(th) {
+  background: color-mix(in srgb, var(--a3s-panel-soft) 88%, var(--a3s-panel));
+  color: var(--a3s-muted);
+  font-size: 0.94em;
+  font-weight: 650;
+  letter-spacing: 0.015em;
+}
+
+.execution-markdown .streaming-markdown :where(tbody tr:nth-child(even)) {
+  background: color-mix(in srgb, var(--a3s-panel-soft) 42%, transparent);
+}
+
+.execution-markdown .streaming-markdown :where(tbody tr:hover) {
+  background: color-mix(in srgb, var(--a3s-blue) 4%, var(--a3s-panel));
+}
+
+.execution-markdown .streaming-markdown :where(img) {
+  display: block;
+  max-width: min(100%, 880px);
+  height: auto;
+  margin: 1.1em auto;
+  border: 1px solid var(--a3s-line);
+  border-radius: 10px;
+  background:
+    linear-gradient(45deg, var(--a3s-panel-soft) 25%, transparent 25%) 0 0 / 12px 12px,
+    linear-gradient(-45deg, var(--a3s-panel-soft) 25%, transparent 25%) 0 0 / 12px 12px,
+    var(--a3s-panel);
+  box-shadow: 0 8px 24px color-mix(in srgb, black 8%, transparent);
+}
+
+.execution-markdown .streaming-markdown :where(kbd) {
+  display: inline-flex;
+  min-width: 1.7em;
+  min-height: 1.55em;
+  align-items: center;
+  justify-content: center;
+  padding: 0.02em 0.42em;
+  border: 1px solid var(--a3s-line-strong);
+  border-bottom-width: 2px;
+  border-radius: 5px;
   background: var(--a3s-panel-soft);
-  font-weight: 600;
+  color: var(--a3s-muted);
+  font: 0.82em/1.4 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+}
+
+.execution-markdown .streaming-markdown :where(details) {
+  padding: 0.7em 0.85em;
+  border: 1px solid var(--a3s-line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--a3s-panel-soft) 52%, var(--a3s-panel));
+}
+
+.execution-markdown .streaming-markdown :where(summary) {
+  color: var(--a3s-ink);
+  cursor: pointer;
+  font-weight: 620;
+}
+
+.execution-markdown .streaming-markdown :where(mark) {
+  padding: 0.04em 0.2em;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--a3s-warning) 20%, transparent);
+  color: inherit;
 }
 
 .execution-markdown-fallback {
@@ -105,20 +299,25 @@
 .execution-markdown [data-streamdown="code-block"],
 .execution-markdown [data-streamdown="table-wrapper"] {
   gap: 0 !important;
-  margin: 1em 0 !important;
+  margin: 1.05em 0 !important;
   padding: 0 !important;
   overflow: hidden;
   border: 1px solid var(--a3s-line) !important;
-  border-radius: 9px !important;
+  border-radius: 10px !important;
   background: var(--a3s-panel) !important;
+  box-shadow: 0 4px 14px color-mix(in srgb, black 4%, transparent) !important;
 }
 
 .execution-markdown [data-streamdown="code-block-header"] {
-  height: 32px !important;
-  padding: 0 9px;
+  height: 34px !important;
+  padding: 0 11px;
   border-bottom: 1px solid var(--a3s-line);
   background: var(--a3s-panel-soft);
   color: var(--a3s-muted);
+  font-size: 10px;
+  font-weight: 620;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .execution-markdown [data-streamdown="code-block-actions"] {
@@ -135,14 +334,32 @@
   --sdm-bg: var(--a3s-panel);
   --shiki-dark-bg: var(--a3s-panel);
   max-height: 480px;
-  padding: 12px 13px !important;
+  padding: 13px 14px 14px !important;
   border: 0 !important;
   border-radius: 0 !important;
   background: var(--a3s-panel) !important;
 }
 
+.execution-markdown [data-streamdown="code-block-body"] pre {
+  margin: 0;
+  font: 11.5px/1.72 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+  tab-size: 2;
+}
+
+.execution-markdown [data-streamdown="code-block-body"] pre code > span {
+  min-height: 1.72em;
+}
+
+.execution-markdown [data-streamdown="code-block-body"] pre code > span::before {
+  width: 2.2em !important;
+  margin-right: 1.15em !important;
+  color: var(--a3s-faint) !important;
+  font-size: 0.88em !important;
+  font-variant-numeric: tabular-nums;
+}
+
 .execution-markdown [data-streamdown="table-wrapper"] > div:first-child {
-  min-height: 32px;
+  min-height: 34px;
   padding: 3px 6px;
   border-bottom: 1px solid var(--a3s-line);
   background: var(--a3s-panel-soft);
@@ -150,11 +367,12 @@
 
 .execution-markdown [data-streamdown="table-wrapper"] > div:first-child::before {
   margin-right: auto;
-  padding-left: 4px;
+  padding-left: 5px;
   color: var(--a3s-muted);
   content: "表格";
   font-size: 10px;
-  font-weight: 550;
+  font-weight: 620;
+  letter-spacing: 0.04em;
 }
 
 .execution-markdown [data-streamdown="table-wrapper"] > div:last-child {
@@ -162,6 +380,10 @@
   border: 0 !important;
   border-radius: 0 !important;
   background: var(--a3s-panel) !important;
+}
+
+.execution-markdown [data-streamdown="table-wrapper"] > div:last-child table {
+  min-width: 460px;
 }
 
 .execution-markdown [data-streamdown="table-wrapper"] button,
@@ -178,6 +400,18 @@
   color: var(--a3s-ink);
 }
 
+.execution-markdown .streaming-markdown :where([data-footnotes]) {
+  margin-top: 1.8em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--a3s-line);
+  color: var(--a3s-muted);
+  font-size: 0.9em;
+}
+
+.execution-markdown .streaming-markdown ::selection {
+  background: color-mix(in srgb, var(--a3s-blue) 22%, transparent);
+}
+
 :root.dark .execution-markdown [data-streamdown="code-block"],
 :root.dark .execution-markdown [data-streamdown="table-wrapper"] {
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 2%);
@@ -190,7 +424,35 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .execution-markdown .streaming-markdown :where(a, [data-streamdown="link"]) {
+    transition: none;
+  }
+
   .execution-markdown .streaming-markdown.is-streaming > :last-child::after {
     animation: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .execution-markdown .streaming-markdown {
+    line-height: 1.68;
+  }
+
+  .execution-markdown .streaming-markdown :where(h1) {
+    font-size: 1.42em;
+  }
+
+  .execution-markdown .streaming-markdown :where(h2) {
+    font-size: 1.24em;
+  }
+
+  .execution-markdown [data-streamdown="code-block-body"] {
+    padding-right: 10px !important;
+    padding-left: 10px !important;
+  }
+
+  .execution-markdown [data-streamdown="code-block-body"] pre code > span::before {
+    width: 1.8em !important;
+    margin-right: 0.8em !important;
   }
 }

--- a/apps/web/src/styles/tool-command.css
+++ b/apps/web/src/styles/tool-command.css
@@ -1,0 +1,236 @@
+.tool-call-timeline {
+  --tool-syntax-program: #386fc4;
+  --tool-syntax-argument: #646a74;
+  --tool-syntax-flag: #c04f73;
+  --tool-syntax-string: #32865a;
+  --tool-syntax-path: #626873;
+  --tool-syntax-keyword: #7958b5;
+  --tool-syntax-operator: #278a89;
+  --tool-syntax-number: #aa681e;
+  --tool-syntax-variable: #a04e9b;
+  --tool-syntax-comment: #959aa4;
+  --tool-syntax-key: #386fc4;
+}
+
+:root.dark .tool-call-timeline {
+  --tool-syntax-program: #89b4fa;
+  --tool-syntax-argument: #b2b5bb;
+  --tool-syntax-flag: #e891a4;
+  --tool-syntax-string: #94d399;
+  --tool-syntax-path: #b9bbbf;
+  --tool-syntax-keyword: #c4a1e8;
+  --tool-syntax-operator: #84cac3;
+  --tool-syntax-number: #e2b57e;
+  --tool-syntax-variable: #d7a8cf;
+  --tool-syntax-comment: #777d88;
+  --tool-syntax-key: #89b4fa;
+}
+
+.tool-invocation-inline {
+  display: inline;
+  font-family: "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+  font-size: 0.96em;
+}
+
+.tool-command-preview {
+  overflow: hidden;
+  border: 1px solid var(--a3s-line);
+  border-radius: 8px;
+  background: var(--a3s-panel);
+}
+
+.tool-command-preview.running {
+  border-color: color-mix(in srgb, var(--a3s-blue) 23%, var(--a3s-line));
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--a3s-blue) 72%, transparent);
+}
+
+.tool-command-preview > header {
+  display: flex;
+  min-height: 29px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 5px 0 9px;
+  border-bottom: 1px solid var(--a3s-line);
+  background: color-mix(in srgb, var(--a3s-panel-soft) 72%, var(--a3s-panel));
+}
+
+.tool-command-preview > header > span,
+.tool-command-preview-actions,
+.tool-command-preview-actions output {
+  display: inline-flex;
+  align-items: center;
+}
+
+.tool-command-preview > header > span:first-child {
+  gap: 6px;
+  color: var(--a3s-muted);
+}
+
+.tool-command-preview > header strong {
+  color: var(--a3s-muted);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+}
+
+.tool-command-preview-actions {
+  gap: 3px;
+}
+
+.tool-command-preview-actions output {
+  min-height: 21px;
+  gap: 4px;
+  padding: 0 6px;
+  color: var(--a3s-blue);
+  font-size: 9px;
+}
+
+.tool-command-preview-actions .conversation-copy-action {
+  background: transparent;
+}
+
+.tool-command-line {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 17px minmax(0, 1fr);
+  gap: 6px;
+  padding: 10px 11px 9px;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--a3s-blue) 3%, transparent), transparent 45%),
+    var(--a3s-panel);
+}
+
+.tool-command-prompt {
+  color: var(--a3s-green);
+  font: 650 11px/1.7 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+  user-select: none;
+}
+
+.tool-command-line > code {
+  min-width: 0;
+  color: var(--a3s-ink);
+  font: 11px/1.7 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+  overflow-wrap: anywhere;
+  tab-size: 2;
+  white-space: pre-wrap;
+}
+
+.tool-command-preview > footer {
+  display: flex;
+  min-height: 25px;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  border-top: 1px solid color-mix(in srgb, var(--a3s-line) 75%, transparent);
+  color: var(--a3s-faint);
+  font-size: 9px;
+}
+
+.tool-command-preview > footer code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--a3s-muted);
+  font: 9px/1.4 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-syntax-role="program"] {
+  color: var(--tool-syntax-program);
+  font-weight: 650;
+}
+
+[data-syntax-role="argument"] {
+  color: var(--tool-syntax-argument);
+}
+
+[data-syntax-role="flag"] {
+  color: var(--tool-syntax-flag);
+}
+
+[data-syntax-role="string"] {
+  color: var(--tool-syntax-string);
+}
+
+[data-syntax-role="path"] {
+  color: var(--tool-syntax-path);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 18%, transparent);
+  text-underline-offset: 2px;
+}
+
+[data-syntax-role="keyword"] {
+  color: var(--tool-syntax-keyword);
+}
+
+[data-syntax-role="operator"] {
+  color: var(--tool-syntax-operator);
+}
+
+[data-syntax-role="redirection"],
+[data-syntax-role="number"] {
+  color: var(--tool-syntax-number);
+}
+
+[data-syntax-role="variable"] {
+  color: var(--tool-syntax-variable);
+}
+
+[data-syntax-role="comment"] {
+  color: var(--tool-syntax-comment);
+  font-style: italic;
+}
+
+[data-syntax-role="key"] {
+  color: var(--tool-syntax-key);
+}
+
+[data-syntax-role="plain"] {
+  color: inherit;
+}
+
+.tool-call-collapsed-preview {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 5px;
+  padding: 0 31px 8px 43px;
+  color: var(--a3s-faint);
+}
+
+.tool-output-connector {
+  color: var(--a3s-line-strong);
+  font: 12px/1.55 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+}
+
+.tool-call-collapsed-preview > code {
+  display: flex;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--a3s-muted);
+  font: 10px/1.55 "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+  flex-direction: column;
+}
+
+.tool-call-collapsed-preview > code > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-call-collapsed-preview .tool-output-omitted {
+  color: var(--a3s-faint);
+  font-size: 9px;
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .tool-call-collapsed-preview {
+    padding-right: 12px;
+  }
+
+  .tool-command-preview-actions output {
+    display: none;
+  }
+}

--- a/apps/web/src/styles/workspace-editor.css
+++ b/apps/web/src/styles/workspace-editor.css
@@ -114,6 +114,11 @@
   color: var(--a3s-ink);
 }
 
+.workspace-editor-tab.contextual {
+  background: var(--a3s-panel-strong);
+  color: var(--a3s-ink);
+}
+
 .workspace-editor-tab.active {
   background: var(--a3s-panel);
   color: var(--a3s-ink);


### PR DESCRIPTION
## Summary

- refine streamed Markdown typography for headings, lists, quotes, tables, links, images, footnotes, inline code, and line-numbered code blocks
- render tool commands and arguments with semantic highlighting, working-directory context, live progress metrics, copy actions, and compact output previews
- localize Monaco context menus to Simplified Chinese and add pointer/keyboard context menus for editor tabs

## Validation

- npm run format:check
- npm run lint:check
- npm run typecheck
- npm test (459 tests)
- npm run build
- production browser QA

The final apps/web tree is byte-identical to the fully validated integration tree containing PRs #24-#27.