### PR TITLE
fix(install): make a3s 0.10 setup complete and rollback-safe

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -8,6 +8,9 @@ on:
       - "install.ps1"
       - "scripts/test-install.sh"
       - "scripts/test-install.ps1"
+      - "scripts/ensure-dev-submodules.sh"
+      - "scripts/test-ensure-dev-submodules.sh"
+      - "justfile"
       - ".github/workflows/installers.yml"
       - "README.md"
   pull_request:
@@ -17,6 +20,9 @@ on:
       - "install.ps1"
       - "scripts/test-install.sh"
       - "scripts/test-install.ps1"
+      - "scripts/ensure-dev-submodules.sh"
+      - "scripts/test-ensure-dev-submodules.sh"
+      - "justfile"
       - ".github/workflows/installers.yml"
       - "README.md"
   workflow_dispatch:
@@ -36,10 +42,15 @@ jobs:
       - name: Check shell syntax
         run: |
           sh -n install.sh
+          sh -n scripts/ensure-dev-submodules.sh
           bash -n scripts/test-install.sh
+          bash -n scripts/test-ensure-dev-submodules.sh
 
       - name: Run installer fixtures
         run: bash scripts/test-install.sh
+
+      - name: Run development submodule preflight fixtures
+        run: bash scripts/test-ensure-dev-submodules.sh
 
   windows-tests:
     name: Windows fixtures
@@ -128,4 +139,26 @@ jobs:
           $index = Join-Path $env:A3S_DATA_HOME "web\$($Matches[1])\index.html"
           if (-not (Test-Path -LiteralPath $index -PathType Leaf)) {
             throw "missing Web workspace: $index"
+          }
+          $supportManifest = Join-Path $installDir 'support\managed-srt\package.json'
+          if (Test-Path -LiteralPath $supportManifest -PathType Leaf) {
+            $supportCli = Join-Path $installDir 'support\managed-srt\node_modules\@anthropic-ai\sandbox-runtime\dist\cli.js'
+            if (-not (Test-Path -LiteralPath $supportCli -PathType Leaf)) {
+              throw "managed sandbox support is incomplete: $supportCli"
+            }
+          }
+          $env:A3S_STATE_HOME = Join-Path $env:RUNNER_TEMP 'a3s-smoke\state'
+          $env:A3S_CACHE_HOME = Join-Path $env:RUNNER_TEMP 'a3s-smoke\cache'
+          $env:A3S_RUNTIME_HOME = Join-Path $env:RUNNER_TEMP 'a3s-smoke\runtime'
+          $env:A3S_WEBVIEW_INSTALL_DIR = Join-Path $env:RUNNER_TEMP 'a3s-smoke\components\webview'
+          $siblingWebview = Join-Path $installDir 'a3s-webview.exe'
+          if (-not (Test-Path -LiteralPath $siblingWebview -PathType Leaf)) {
+            & $binary --no-progress install webview
+            if ($LASTEXITCODE -ne 0) {
+              throw "WebView first-use installation failed with exit code $LASTEXITCODE"
+            }
+          }
+          & $binary --no-progress doctor webview
+          if ($LASTEXITCODE -ne 0) {
+            throw "WebView doctor failed with exit code $LASTEXITCODE"
           }

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -136,7 +136,9 @@ jobs:
           if ($output -notmatch '^a3s (\d+\.\d+\.\d+)$') {
             throw "unexpected version output: $output"
           }
-          $index = Join-Path $env:A3S_DATA_HOME "web\$($Matches[1])\index.html"
+          $versionText = $Matches[1]
+          $installedVersion = [version]$versionText
+          $index = Join-Path $env:A3S_DATA_HOME "web\$versionText\index.html"
           if (-not (Test-Path -LiteralPath $index -PathType Leaf)) {
             throw "missing Web workspace: $index"
           }
@@ -151,6 +153,14 @@ jobs:
           $env:A3S_CACHE_HOME = Join-Path $env:RUNNER_TEMP 'a3s-smoke\cache'
           $env:A3S_RUNTIME_HOME = Join-Path $env:RUNNER_TEMP 'a3s-smoke\runtime'
           $env:A3S_WEBVIEW_INSTALL_DIR = Join-Path $env:RUNNER_TEMP 'a3s-smoke\components\webview'
+          if ($installedVersion -lt [version]'0.10.0') {
+            # Released CLIs before 0.10.0 require HOME even on native Windows.
+            $env:HOME = Join-Path $env:RUNNER_TEMP 'a3s-smoke\legacy-home'
+            New-Item -ItemType Directory -Force -Path $env:HOME | Out-Null
+          } else {
+            # Native Windows normally exposes USERPROFILE rather than HOME.
+            Remove-Item Env:HOME -ErrorAction SilentlyContinue
+          }
           $siblingWebview = Join-Path $installDir 'a3s-webview.exe'
           if (-not (Test-Path -LiteralPath $siblingWebview -PathType Leaf)) {
             & $binary --no-progress install webview

--- a/README.md
+++ b/README.md
@@ -217,12 +217,15 @@ Both installers:
 
 - resolve `latest` or an exact stable `vX.Y.Z` release from
   [`A3S-Lab/CLI`](https://github.com/A3S-Lab/CLI/releases);
+- retry bounded transient GitHub metadata and asset-download failures;
 - require one exact asset for the detected operating system and architecture;
 - verify the asset against GitHub's SHA-256 release digest;
 - reject unexpected, duplicate, linked, or traversal archive entries;
 - verify the staged binary reports the requested version before activation;
-- install the bundled Web workspace into the CLI's versioned data cache; and
-- preserve the previous binary and Web cache if activation cannot complete.
+- install the bundled Web workspace plus matching `a3s-webview` and managed
+  sandbox support payloads when the selected release includes them; and
+- preserve the previous CLI, WebView companion, managed support payload, and
+  Web cache if any activation step cannot complete.
 
 The default installation paths require neither `sudo` nor an administrator
 session. Supported overrides are `A3S_VERSION`, `A3S_INSTALL_DIR`,
@@ -243,18 +246,21 @@ Homebrew remains available on macOS and Linux:
 brew install a3s-lab/tap/a3s
 ```
 
-Homebrew and the one-command installers include the matching Web workspace.
-`cargo install a3s` installs only the binary; the first allowed `a3s web`
-startup downloads and verifies its exact-version Web asset. On macOS and Linux,
-use `a3s self update` for a standalone CLI. On Windows, rerun the installer to
+Homebrew installs the matching Web workspace and WebView formula. The
+one-command installers support both older CLI archives and complete newer
+bundles; bundled helpers and managed support payloads activate transactionally.
+`cargo install a3s` installs only the main binary. The first allowed `a3s web`
+startup downloads and verifies its exact-version Web asset, and the first
+allowed `a3s code` startup similarly installs the verified WebView component
+before terminal takeover whenever no bundled helper is ready. Offline mode and
+`A3S_NO_AUTO_INSTALL=1` never perform these downloads; run `a3s install webview`
+while online to prepare it explicitly. On macOS and Linux, use
+`a3s self update` for a standalone CLI. On Windows, rerun the installer to
 upgrade because in-place self-update is not yet supported there.
 
-The release archives and Homebrew formula also install `a3s-webview` beside
-`a3s`, which provides RemoteUI windows and the native Agent Island. A repository
-checkout launched with `just code` builds the local WebView helper and injects
-its absolute path automatically. Other source installations must also build the
-helper from `crates/webview` or set `A3S_AGENT_ISLAND_BIN` to an installed
-helper.
+The WebView companion provides RemoteUI windows and the native Agent Island. A
+repository checkout launched with `just code` builds the local helper and
+injects its absolute path automatically.
 
 The Homebrew tap is released independently and can trail the CLI source tree.
 The command reference below follows the current CLI source; check
@@ -727,6 +733,12 @@ cd crates/gui
 cargo test
 ```
 
+The `just a3s`, `just code`, `just web`, and `just use-hotplug-e2e` recipes
+initialize only their missing required submodules. They never reset an already
+initialized submodule. If a required manifest was deleted from a dirty
+submodule, the recipe stops with recovery guidance instead of overwriting local
+work.
+
 If Git reports that a submodule path has no mapping, do not delete or re-add the
 component blindly. First check whether the root checkout mixes `.gitmodules`
 from one revision with gitlinks from another, or whether a submodule migration
@@ -744,7 +756,10 @@ just windhole # start the local A3S Bench visual laboratory
 just use-hotplug-e2e # verify real Use hot-plug plus release-shaped Code first-use
 ```
 
-Install app-local JavaScript dependencies before running application recipes.
+`just web` requires [Bun](https://bun.sh/docs/installation) and automatically
+runs `bun install --frozen-lockfile` from the checked-in `bun.lock`; it does not
+use npm. Install dependencies explicitly for other app-local recipes when their
+own README requires it.
 Platform-specific products may require additional toolchains, system libraries,
 container engines, brokers, databases, or virtualization support; follow the
 owning project's README.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -565,10 +565,11 @@ SHA-256 is `72b94cf69a95dc6153f865c4f8742c0f67079caa876f35f8b2b5f970ea795a2d`.
 
 ## Development
 
-Install dependencies once:
+Install [Bun](https://bun.sh/docs/installation), then install the exact locked
+dependencies for direct app-local commands:
 
 ```sh
-bun install
+bun install --frozen-lockfile
 ```
 
 Start the CLI API from the monorepo root:
@@ -592,9 +593,10 @@ bun run build
 ```
 
 The production output is `dist/workspace`. From the monorepo root, `just web`
-builds this application and starts the complete local service. If port `29653`
-is already in use, stop the existing local server or set `A3S_PORT` to another
-port before starting a second instance.
+checks for Bun, runs the frozen dependency install, builds this application, and
+starts the complete local service. If port `29653` is already in use, stop the
+existing local server or set `A3S_PORT` to another port before starting a second
+instance.
 
 ## Validation
 

--- a/apps/web/justfile
+++ b/apps/web/justfile
@@ -4,20 +4,33 @@ port := env_var_or_default("A3S_PORT", "29653")
 default:
     @just --list
 
+[private]
+ensure-bun:
+    #!/usr/bin/env sh
+    if ! command -v bun >/dev/null 2>&1; then
+        echo "error: Bun is required to build A3S Web." >&2
+        echo "Install it from https://bun.sh/docs/installation and rerun this command." >&2
+        exit 127
+    fi
+
+[private]
+dependencies: ensure-bun
+    bun install --frozen-lockfile
+
 # Start the Rsbuild frontend with requests proxied to a running `a3s web`.
-dev:
-    A3S_CODE_API_ORIGIN=http://{{host}}:{{port}} npm run dev
+dev: dependencies
+    A3S_CODE_API_ORIGIN=http://{{host}}:{{port}} bun run dev
 
 # Build the production frontend consumed by `a3s web`.
-build:
-    npm run build
+build: dependencies
+    bun run build
 
 # Build and start the complete local A3S Code Web application.
 web: build
     cd ../.. && cargo run --manifest-path crates/cli/Cargo.toml -- web --host {{host}} --port {{port}} --web-dir apps/web/dist/workspace
 
-check:
-    npm run typecheck
-    npm run lint
-    npm test
-    npm run build
+check: dependencies
+    bun run typecheck
+    bun run lint:check
+    bun run test
+    bun run build

--- a/install.ps1
+++ b/install.ps1
@@ -42,6 +42,27 @@ param(
         Write-Warning "a3s installer: $Message"
     }
 
+    function Invoke-InstallerRequest {
+        param(
+            [Parameter(Mandatory = $true)][scriptblock]$Operation,
+            [Parameter(Mandatory = $true)][string]$Description,
+            [int]$MaximumAttempts = 4
+        )
+
+        for ($attempt = 1; $attempt -le $MaximumAttempts; $attempt++) {
+            try {
+                return & $Operation
+            } catch {
+                if ($attempt -eq $MaximumAttempts) {
+                    throw
+                }
+                $delaySeconds = [Math]::Pow(2, $attempt - 1)
+                Write-InstallerWarning "$Description failed on attempt $attempt of $MaximumAttempts; retrying in $delaySeconds second(s): $($_.Exception.Message)"
+                Start-Sleep -Seconds $delaySeconds
+            }
+        }
+    }
+
     function Remove-GeneratedDirectory {
         param(
             [string]$Path,
@@ -56,7 +77,7 @@ param(
         $parentWithSeparator = $fullParent + [IO.Path]::DirectorySeparatorChar
         $leaf = [IO.Path]::GetFileName($fullPath)
         if (-not $fullPath.StartsWith($parentWithSeparator, [StringComparison]::OrdinalIgnoreCase) -or
-            $leaf -notmatch '^\.a3s-web\.(new|backup|failed)\.[0-9a-f-]+$') {
+            $leaf -notmatch '^\.a3s-(?:web|support)\.(new|backup|failed)\.[0-9a-f-]+$') {
             throw "refusing to remove unexpected directory $fullPath"
         }
         Remove-Item -LiteralPath $fullPath -Recurse -Force
@@ -76,7 +97,7 @@ param(
         $parentWithSeparator = $fullParent + [IO.Path]::DirectorySeparatorChar
         $leaf = [IO.Path]::GetFileName($fullPath)
         if (-not $fullPath.StartsWith($parentWithSeparator, [StringComparison]::OrdinalIgnoreCase) -or
-            $leaf -notmatch '^\.a3s\.(new|backup|failed)\.[0-9a-f-]+\.exe$') {
+            $leaf -notmatch '^\.a3s(?:-webview)?\.(new|backup|failed)\.[0-9a-f-]+\.exe$') {
             throw "refusing to remove unexpected file $fullPath"
         }
         Remove-Item -LiteralPath $fullPath -Force
@@ -218,7 +239,9 @@ param(
     }
 
     Write-InstallerInfo "resolving $RequestedVersion release for $target"
-    $release = Invoke-RestMethod -Uri $releaseApi -Headers $apiHeaders
+    $release = Invoke-InstallerRequest -Description 'GitHub release lookup' -Operation {
+        Invoke-RestMethod -Uri $releaseApi -Headers $apiHeaders -TimeoutSec 60
+    }
     $releaseTag = [string]$release.tag_name
     if ($releaseTag -notmatch '^v\d+\.\d+\.\d+$') {
         throw 'GitHub returned an invalid stable release tag'
@@ -256,6 +279,8 @@ param(
     $archive = Join-Path $tempDir $assetName
     $extracted = Join-Path $tempDir 'extracted'
     $binaryPath = Join-Path $installDir 'a3s.exe'
+    $webviewPath = Join-Path $installDir 'a3s-webview.exe'
+    $supportPath = Join-Path $installDir 'support'
 
     $webParent = ''
     $webDir = ''
@@ -265,12 +290,26 @@ param(
     $stagedBinary = ''
     $backupBinary = ''
     $failedBinary = ''
+    $stagedWebview = ''
+    $backupWebview = ''
+    $failedWebview = ''
+    $stagedSupport = ''
+    $backupSupport = ''
+    $failedSupport = ''
     $webActive = $false
     $oldWebSaved = $false
     $binaryActive = $false
     $oldBinarySaved = $false
+    $webviewActive = $false
+    $oldWebviewSaved = $false
+    $supportActive = $false
+    $oldSupportSaved = $false
     $webActivationStarted = $false
     $binaryActivationStarted = $false
+    $webviewActivationStarted = $false
+    $supportActivationStarted = $false
+    $hasBundledWebview = $false
+    $hasBundledSupport = $false
     $committed = $false
     $installerMutex = $null
     $mutexAcquired = $false
@@ -294,9 +333,14 @@ param(
     try {
         [IO.Directory]::CreateDirectory($tempDir) | Out-Null
         Write-InstallerInfo "downloading $assetName"
-        Invoke-WebRequest -UseBasicParsing -Uri $expectedAssetUrl -OutFile $archive -Headers @{
-            'User-Agent' = 'a3s-installer'
-        }
+        Invoke-InstallerRequest -Description "download of $assetName" -Operation {
+            if (Test-Path -LiteralPath $archive) {
+                Remove-Item -LiteralPath $archive -Force
+            }
+            Invoke-WebRequest -UseBasicParsing -Uri $expectedAssetUrl -OutFile $archive -TimeoutSec 600 -Headers @{
+                'User-Agent' = 'a3s-installer'
+            }
+        } | Out-Null
 
         $actualSha = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
         if ($actualSha -ne $expectedSha) {
@@ -319,9 +363,28 @@ param(
                 }
             }
             $entryNames = @($entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+            $webviewEntryCount = @($entryNames | Where-Object { $_ -ceq 'a3s-webview.exe' }).Count
             if (@($entryNames | Where-Object { $_ -ceq 'a3s.exe' }).Count -ne 1 -or
+                $webviewEntryCount -gt 1 -or
                 @($entryNames | Where-Object { $_ -ceq 'web/index.html' }).Count -ne 1) {
-                throw 'release archive must contain exactly one a3s.exe and web/index.html'
+                throw 'release archive must contain exactly one a3s.exe and web/index.html, and at most one a3s-webview.exe'
+            }
+            $hasBundledWebview = $webviewEntryCount -eq 1
+            $supportEntryCount = @($entryNames | Where-Object {
+                $_ -ceq 'support' -or $_.StartsWith('support/', [StringComparison]::Ordinal)
+            }).Count
+            if ($supportEntryCount -gt 0) {
+                foreach ($requiredSupportEntry in @(
+                    'support/managed-srt/package.json',
+                    'support/managed-srt/package-lock.json',
+                    'support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js',
+                    'support/managed-srt.tree-sha256'
+                )) {
+                    if (@($entryNames | Where-Object { $_ -ceq $requiredSupportEntry }).Count -ne 1) {
+                        throw "release support payload must contain exactly one $requiredSupportEntry"
+                    }
+                }
+                $hasBundledSupport = $true
             }
             $entryKeys = @($entryNames | ForEach-Object { $_.TrimEnd('/') })
             if (@($entryKeys | Group-Object | Where-Object { $_.Count -ne 1 }).Count -ne 0) {
@@ -330,7 +393,7 @@ param(
             foreach ($entry in $entries) {
                 $entryName = $entry.FullName.Replace('\', '/')
                 $unixFileType = (($entry.ExternalAttributes -shr 16) -band 0xF000)
-                if ($entryName -notmatch '^(a3s\.exe|web/?|web/.+)$' -or
+                if ($entryName -notmatch '^(a3s\.exe|a3s-webview\.exe|web/?|web/.+|support/?|support/.+)$' -or
                     ('/' + $entryName + '/') -match '/(\.|\.\.)/' -or
                     $unixFileType -notin @(0, 0x4000, 0x8000) -or
                     ($entry.ExternalAttributes -band [int][IO.FileAttributes]::ReparsePoint) -ne 0) {
@@ -343,10 +406,25 @@ param(
 
         Expand-Archive -LiteralPath $archive -DestinationPath $extracted
         $extractedBinary = Join-Path $extracted 'a3s.exe'
+        $extractedWebview = Join-Path $extracted 'a3s-webview.exe'
         $extractedWeb = Join-Path $extracted 'web'
+        $extractedSupport = Join-Path $extracted 'support'
         if (-not (Test-Path -LiteralPath $extractedBinary -PathType Leaf) -or
+            ($hasBundledWebview -and -not (Test-Path -LiteralPath $extractedWebview -PathType Leaf)) -or
             -not (Test-Path -LiteralPath (Join-Path $extractedWeb 'index.html') -PathType Leaf)) {
             throw 'the extracted release layout is invalid'
+        }
+        if ($hasBundledSupport) {
+            foreach ($requiredSupportPath in @(
+                'managed-srt\package.json',
+                'managed-srt\package-lock.json',
+                'managed-srt\node_modules\@anthropic-ai\sandbox-runtime\dist\cli.js',
+                'managed-srt.tree-sha256'
+            )) {
+                if (-not (Test-Path -LiteralPath (Join-Path $extractedSupport $requiredSupportPath) -PathType Leaf)) {
+                    throw "the extracted managed sandbox support payload is missing $requiredSupportPath"
+                }
+            }
         }
         $reparseEntries = @(Get-ChildItem -LiteralPath $extracted -Recurse -Force |
             Where-Object { ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 })
@@ -391,10 +469,18 @@ param(
         $stagedBinary = Join-Path $installDir ".a3s.new.$activationId.exe"
         $backupBinary = Join-Path $installDir ".a3s.backup.$activationId.exe"
         $failedBinary = Join-Path $installDir ".a3s.failed.$activationId.exe"
+        $stagedWebview = Join-Path $installDir ".a3s-webview.new.$activationId.exe"
+        $backupWebview = Join-Path $installDir ".a3s-webview.backup.$activationId.exe"
+        $failedWebview = Join-Path $installDir ".a3s-webview.failed.$activationId.exe"
+        $stagedSupport = Join-Path $installDir ".a3s-support.new.$activationId"
+        $backupSupport = Join-Path $installDir ".a3s-support.backup.$activationId"
+        $failedSupport = Join-Path $installDir ".a3s-support.failed.$activationId"
 
         foreach ($generatedPath in @(
             $stagedWeb, $backupWeb, $failedWeb,
-            $stagedBinary, $backupBinary, $failedBinary
+            $stagedBinary, $backupBinary, $failedBinary,
+            $stagedWebview, $backupWebview, $failedWebview,
+            $stagedSupport, $backupSupport, $failedSupport
         )) {
             if (Test-Path -LiteralPath $generatedPath) {
                 throw "temporary activation path already exists: $generatedPath"
@@ -403,6 +489,12 @@ param(
 
         Move-Item -LiteralPath $extractedWeb -Destination $stagedWeb
         Copy-Item -LiteralPath $extractedBinary -Destination $stagedBinary
+        if ($hasBundledWebview) {
+            Copy-Item -LiteralPath $extractedWebview -Destination $stagedWebview
+        }
+        if ($hasBundledSupport) {
+            Move-Item -LiteralPath $extractedSupport -Destination $stagedSupport
+        }
         Assert-A3sVersion -Path $stagedBinary -ExpectedVersion $expectedVersion
 
         $webActivationStarted = $true
@@ -419,6 +511,56 @@ param(
         Move-Item -LiteralPath $stagedWeb -Destination $webDir
         $webActive = $true
         $stagedWeb = ''
+
+        if ($hasBundledSupport) {
+            $supportActivationStarted = $true
+            if (Test-Path -LiteralPath $supportPath) {
+                Assert-NoReparsePoint -Path $supportPath
+                $existingSupport = Get-Item -LiteralPath $supportPath -Force
+                if (-not $existingSupport.PSIsContainer) {
+                    throw "$supportPath is not a directory"
+                }
+                if (-not (Test-Path -LiteralPath (Join-Path $supportPath 'managed-srt\package.json') -PathType Leaf)) {
+                    throw "$supportPath is not an installer-managed support directory"
+                }
+                $supportReparseEntries = @(Get-ChildItem -LiteralPath $supportPath -Recurse -Force |
+                    Where-Object { ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 })
+                if ($supportReparseEntries.Count -ne 0) {
+                    throw "refusing to replace support assets containing a reparse point: $($supportReparseEntries[0].FullName)"
+                }
+                Move-Item -LiteralPath $supportPath -Destination $backupSupport
+                $oldSupportSaved = $true
+            }
+            Move-Item -LiteralPath $stagedSupport -Destination $supportPath
+            $supportActive = $true
+            $stagedSupport = ''
+        }
+
+        if ($hasBundledWebview) {
+            $webviewActivationStarted = $true
+            if (Test-Path -LiteralPath $webviewPath) {
+                $existingWebview = Get-Item -LiteralPath $webviewPath -Force
+                if (($existingWebview.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                    throw "refusing to replace reparse-point companion $webviewPath"
+                }
+                if (-not $existingWebview.PSIsContainer) {
+                    try {
+                        [IO.File]::Replace($stagedWebview, $webviewPath, $backupWebview, $true)
+                    } catch {
+                        throw "failed to replace $webviewPath; close Agent Island and all running a3s processes, then retry: $($_.Exception.Message)"
+                    }
+                    $oldWebviewSaved = $true
+                    $webviewActive = $true
+                    $stagedWebview = ''
+                } else {
+                    throw "$webviewPath is not a regular file"
+                }
+            } else {
+                Move-Item -LiteralPath $stagedWebview -Destination $webviewPath
+                $webviewActive = $true
+                $stagedWebview = ''
+            }
+        }
 
         $binaryActivationStarted = $true
         if (Test-Path -LiteralPath $binaryPath) {
@@ -459,6 +601,24 @@ param(
                 $backupBinary = ''
             } catch {
                 Write-InstallerWarning "could not remove the old binary backup at $backupBinary`: $($_.Exception.Message)"
+            }
+        }
+        if ($oldWebviewSaved) {
+            try {
+                Remove-GeneratedFile -Path $backupWebview -ExpectedParent $installDir
+                $oldWebviewSaved = $false
+                $backupWebview = ''
+            } catch {
+                Write-InstallerWarning "could not remove the old WebView helper backup at $backupWebview`: $($_.Exception.Message)"
+            }
+        }
+        if ($oldSupportSaved) {
+            try {
+                Remove-GeneratedDirectory -Path $backupSupport -ExpectedParent $installDir
+                $oldSupportSaved = $false
+                $backupSupport = ''
+            } catch {
+                Write-InstallerWarning "could not remove the old support payload backup at $backupSupport`: $($_.Exception.Message)"
             }
         }
 
@@ -507,6 +667,14 @@ param(
         }
 
         Write-InstallerInfo "installed a3s $expectedVersion to $binaryPath"
+        if ($hasBundledWebview) {
+            Write-InstallerInfo "installed a3s-webview to $webviewPath"
+        } else {
+            Write-InstallerInfo "release $releaseTag has no bundled a3s-webview; a3s code will install the verified component on first use"
+        }
+        if ($hasBundledSupport) {
+            Write-InstallerInfo "installed managed sandbox support to $supportPath"
+        }
         Write-InstallerInfo "installed Web assets to $webDir"
     } finally {
         if (-not $committed) {
@@ -547,6 +715,86 @@ param(
                     }
                 } else {
                     $oldBinarySaved = $false
+                }
+            }
+
+            if ($webviewActivationStarted) {
+                $stagedWebviewPresent = -not [string]::IsNullOrEmpty($stagedWebview) -and
+                    (Test-Path -LiteralPath $stagedWebview)
+                if (-not $stagedWebviewPresent) {
+                    if (Test-Path -LiteralPath $webviewPath) {
+                        try {
+                            Move-Item -LiteralPath $webviewPath -Destination $failedWebview
+                            $webviewActive = $false
+                        } catch {
+                            $webviewActive = $true
+                            Write-InstallerWarning "could not move the failed WebView helper; the previous helper is preserved at $backupWebview"
+                        }
+                    } else {
+                        $webviewActive = $false
+                    }
+                } else {
+                    $webviewActive = $false
+                }
+
+                if (Test-Path -LiteralPath $backupWebview) {
+                    if (-not (Test-Path -LiteralPath $webviewPath)) {
+                        try {
+                            Move-Item -LiteralPath $backupWebview -Destination $webviewPath
+                            $oldWebviewSaved = $false
+                        } catch {
+                            $oldWebviewSaved = $true
+                            Write-InstallerWarning "could not restore the previous WebView helper; its backup is preserved at $backupWebview"
+                        }
+                    } elseif ($stagedWebviewPresent) {
+                        # Activation did not consume the staged companion; the original is still active.
+                        $oldWebviewSaved = $false
+                    } else {
+                        $oldWebviewSaved = $true
+                        Write-InstallerWarning "could not restore the previous WebView helper; its backup is preserved at $backupWebview"
+                    }
+                } else {
+                    $oldWebviewSaved = $false
+                }
+            }
+
+            if ($supportActivationStarted) {
+                $stagedSupportPresent = -not [string]::IsNullOrEmpty($stagedSupport) -and
+                    (Test-Path -LiteralPath $stagedSupport)
+                if (-not $stagedSupportPresent) {
+                    if (Test-Path -LiteralPath $supportPath) {
+                        try {
+                            Move-Item -LiteralPath $supportPath -Destination $failedSupport
+                            $supportActive = $false
+                        } catch {
+                            $supportActive = $true
+                            Write-InstallerWarning "could not move the failed support payload; the previous payload is preserved at $backupSupport"
+                        }
+                    } else {
+                        $supportActive = $false
+                    }
+                } else {
+                    $supportActive = $false
+                }
+
+                if (Test-Path -LiteralPath $backupSupport) {
+                    if (-not (Test-Path -LiteralPath $supportPath)) {
+                        try {
+                            Move-Item -LiteralPath $backupSupport -Destination $supportPath
+                            $oldSupportSaved = $false
+                        } catch {
+                            $oldSupportSaved = $true
+                            Write-InstallerWarning "could not restore the previous support payload; its backup is preserved at $backupSupport"
+                        }
+                    } elseif ($stagedSupportPresent) {
+                        # Activation did not consume the staged payload; the original is still active.
+                        $oldSupportSaved = $false
+                    } else {
+                        $oldSupportSaved = $true
+                        Write-InstallerWarning "could not restore the previous support payload; its backup is preserved at $backupSupport"
+                    }
+                } else {
+                    $oldSupportSaved = $false
                 }
             }
 
@@ -613,6 +861,20 @@ param(
                 Write-InstallerWarning "cleanup failed for $path`: $($_.Exception.Message)"
             }
         }
+        foreach ($path in @($stagedWebview, $failedWebview)) {
+            try {
+                Remove-GeneratedFile -Path $path -ExpectedParent $installDir
+            } catch {
+                Write-InstallerWarning "cleanup failed for $path`: $($_.Exception.Message)"
+            }
+        }
+        foreach ($path in @($stagedSupport, $failedSupport)) {
+            try {
+                Remove-GeneratedDirectory -Path $path -ExpectedParent $installDir
+            } catch {
+                Write-InstallerWarning "cleanup failed for $path`: $($_.Exception.Message)"
+            }
+        }
         if ($oldBinarySaved) {
             Write-InstallerWarning "preserved the previous binary at $backupBinary"
         } else {
@@ -620,6 +882,24 @@ param(
                 Remove-GeneratedFile -Path $backupBinary -ExpectedParent $installDir
             } catch {
                 Write-InstallerWarning "cleanup failed for $backupBinary`: $($_.Exception.Message)"
+            }
+        }
+        if ($oldWebviewSaved) {
+            Write-InstallerWarning "preserved the previous WebView helper at $backupWebview"
+        } else {
+            try {
+                Remove-GeneratedFile -Path $backupWebview -ExpectedParent $installDir
+            } catch {
+                Write-InstallerWarning "cleanup failed for $backupWebview`: $($_.Exception.Message)"
+            }
+        }
+        if ($oldSupportSaved) {
+            Write-InstallerWarning "preserved the previous support payload at $backupSupport"
+        } else {
+            try {
+                Remove-GeneratedDirectory -Path $backupSupport -ExpectedParent $installDir
+            } catch {
+                Write-InstallerWarning "cleanup failed for $backupSupport`: $($_.Exception.Message)"
             }
         }
         try {

--- a/install.sh
+++ b/install.sh
@@ -296,12 +296,25 @@ failed_web=""
 staged_binary=""
 backup_binary=""
 failed_binary=""
+staged_webview=""
+backup_webview=""
+failed_webview=""
+support_dir=""
+staged_support=""
+backup_support=""
+failed_support=""
 web_active=0
 old_web_saved=0
 binary_active=0
 old_binary_saved=0
+webview_active=0
+old_webview_saved=0
+support_active=0
+old_support_saved=0
 web_activation_started=0
 binary_activation_started=0
+webview_activation_started=0
+support_activation_started=0
 committed=0
 
 remove_generated_web_tree() {
@@ -313,11 +326,20 @@ remove_generated_web_tree() {
     esac
 }
 
+remove_generated_support_tree() {
+    generated_path=${1:-}
+    [ -n "$generated_path" ] || return 0
+    case "$generated_path" in
+        "$install_dir"/.a3s-support.*) rm -rf -- "$generated_path" ;;
+        *) warn "refusing to remove unexpected support directory $generated_path" ;;
+    esac
+}
+
 remove_generated_binary() {
     generated_path=${1:-}
     [ -n "$generated_path" ] || return 0
     case "$generated_path" in
-        "$install_dir"/.a3s.*) rm -f -- "$generated_path" ;;
+        "$install_dir"/.a3s.*|"$install_dir"/.a3s-webview.*) rm -f -- "$generated_path" ;;
         *) warn "refusing to remove unexpected file $generated_path" ;;
     esac
 }
@@ -356,6 +378,78 @@ rollback_activation() {
             fi
         else
             old_binary_saved=0
+        fi
+    fi
+
+    if [ "$webview_activation_started" -eq 1 ]; then
+        if [ ! -e "$staged_webview" ] && [ ! -L "$staged_webview" ]; then
+            if [ -e "$install_dir/a3s-webview" ] || [ -L "$install_dir/a3s-webview" ]; then
+                if mv "$install_dir/a3s-webview" "$failed_webview"; then
+                    webview_active=0
+                else
+                    webview_active=1
+                    warn "could not move the failed WebView helper; the previous helper is preserved at $backup_webview"
+                fi
+            else
+                webview_active=0
+            fi
+        else
+            webview_active=0
+        fi
+
+        if [ -e "$backup_webview" ] || [ -L "$backup_webview" ]; then
+            if [ ! -e "$install_dir/a3s-webview" ] && [ ! -L "$install_dir/a3s-webview" ]; then
+                if mv "$backup_webview" "$install_dir/a3s-webview"; then
+                    old_webview_saved=0
+                else
+                    old_webview_saved=1
+                    warn "could not restore the previous WebView helper; its backup is preserved at $backup_webview"
+                fi
+            elif [ -e "$staged_webview" ] || [ -L "$staged_webview" ]; then
+                # Activation did not consume the staged helper; the original is still active.
+                old_webview_saved=0
+            else
+                old_webview_saved=1
+                warn "could not restore the previous WebView helper; its backup is preserved at $backup_webview"
+            fi
+        else
+            old_webview_saved=0
+        fi
+    fi
+
+    if [ "$support_activation_started" -eq 1 ]; then
+        if [ ! -e "$staged_support" ] && [ ! -L "$staged_support" ]; then
+            if [ -e "$support_dir" ] || [ -L "$support_dir" ]; then
+                if mv "$support_dir" "$failed_support"; then
+                    support_active=0
+                else
+                    support_active=1
+                    warn "could not move the failed support payload; the previous payload is preserved at $backup_support"
+                fi
+            else
+                support_active=0
+            fi
+        else
+            support_active=0
+        fi
+
+        if [ -e "$backup_support" ] || [ -L "$backup_support" ]; then
+            if [ ! -e "$support_dir" ] && [ ! -L "$support_dir" ]; then
+                if mv "$backup_support" "$support_dir"; then
+                    old_support_saved=0
+                else
+                    old_support_saved=1
+                    warn "could not restore the previous support payload; its backup is preserved at $backup_support"
+                fi
+            elif [ -e "$staged_support" ] || [ -L "$staged_support" ]; then
+                # Activation did not consume the staged payload; the original is still active.
+                old_support_saved=0
+            else
+                old_support_saved=1
+                warn "could not restore the previous support payload; its backup is preserved at $backup_support"
+            fi
+        else
+            old_support_saved=0
         fi
     fi
 
@@ -414,9 +508,26 @@ cleanup() {
         warn "preserved the previous binary at $backup_binary"
     fi
     remove_generated_binary "$failed_binary"
-    rm -f -- "$archive" "$archive_list" "$temp_dir/a3s"
+    remove_generated_binary "$staged_webview"
+    if [ "$old_webview_saved" -eq 0 ]; then
+        remove_generated_binary "$backup_webview"
+    elif [ -e "$backup_webview" ] || [ -L "$backup_webview" ]; then
+        warn "preserved the previous WebView helper at $backup_webview"
+    fi
+    remove_generated_binary "$failed_webview"
+    remove_generated_support_tree "$staged_support"
+    if [ "$old_support_saved" -eq 0 ]; then
+        remove_generated_support_tree "$backup_support"
+    elif [ -e "$backup_support" ] || [ -L "$backup_support" ]; then
+        warn "preserved the previous support payload at $backup_support"
+    fi
+    remove_generated_support_tree "$failed_support"
+    rm -f -- "$archive" "$archive_list" "$temp_dir/a3s" "$temp_dir/a3s-webview"
     if [ -d "$temp_dir/web" ]; then
         rm -rf -- "$temp_dir/web"
+    fi
+    if [ -d "$temp_dir/support" ]; then
+        rm -rf -- "$temp_dir/support"
     fi
     rmdir "$temp_dir" 2>/dev/null
     release_web_lock
@@ -449,6 +560,26 @@ info "verified SHA-256 $actual_sha"
 tar -tzf "$archive" >"$archive_list" || die "failed to inspect $asset_name"
 [ "$(grep -Fxc 'a3s' "$archive_list")" -eq 1 ] \
     || die "release archive must contain exactly one a3s binary"
+webview_entry_count=$(awk '$0 == "a3s-webview" { count += 1 } END { print count + 0 }' "$archive_list")
+[ "$webview_entry_count" -le 1 ] \
+    || die "release archive must contain at most one a3s-webview companion"
+has_bundled_webview=0
+if [ "$webview_entry_count" -eq 1 ]; then
+    has_bundled_webview=1
+fi
+support_entry_count=$(awk '$0 == "support" || index($0, "support/") == 1 { count += 1 } END { print count + 0 }' "$archive_list")
+has_bundled_support=0
+if [ "$support_entry_count" -gt 0 ]; then
+    for required_support_entry in \
+        support/managed-srt/package.json \
+        support/managed-srt/package-lock.json \
+        support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js \
+        support/managed-srt.tree-sha256; do
+        [ "$(grep -Fxc "$required_support_entry" "$archive_list")" -eq 1 ] \
+            || die "release support payload must contain exactly one $required_support_entry"
+    done
+    has_bundled_support=1
+fi
 [ "$(grep -Fxc 'web/index.html' "$archive_list")" -eq 1 ] \
     || die "release archive must contain exactly one web/index.html"
 duplicate_entries=$(awk '{ sub(/\/$/, ""); print }' "$archive_list" | LC_ALL=C sort | uniq -d)
@@ -460,7 +591,7 @@ tar -tvzf "$archive" | awk '
 ' || die "release archive contains a link or special file"
 while IFS= read -r entry; do
     case "$entry" in
-        a3s|web|web/|web/*) ;;
+        a3s|a3s-webview|web|web/|web/*|support|support/|support/*) ;;
         *) die "release archive contains an unexpected path: $entry" ;;
     esac
     case "/$entry/" in
@@ -468,16 +599,43 @@ while IFS= read -r entry; do
     esac
 done <"$archive_list"
 
-tar --no-same-owner --no-same-permissions -xzf "$archive" -C "$temp_dir" a3s web \
+archive_members="a3s web"
+if [ "$has_bundled_webview" -eq 1 ]; then
+    archive_members="$archive_members a3s-webview"
+fi
+if [ "$has_bundled_support" -eq 1 ]; then
+    archive_members="$archive_members support"
+fi
+# The validated archive member names never contain whitespace.
+# shellcheck disable=SC2086
+tar --no-same-owner --no-same-permissions -xzf "$archive" -C "$temp_dir" $archive_members \
     || die "failed to extract $asset_name"
 [ -f "$temp_dir/a3s" ] && [ ! -L "$temp_dir/a3s" ] \
     || die "the extracted a3s binary is not a regular file"
+if [ "$has_bundled_webview" -eq 1 ]; then
+    [ -f "$temp_dir/a3s-webview" ] && [ ! -L "$temp_dir/a3s-webview" ] \
+        || die "the extracted a3s-webview companion is not a regular file"
+fi
+if [ "$has_bundled_support" -eq 1 ]; then
+    [ -f "$temp_dir/support/managed-srt/package.json" ] \
+        && [ -f "$temp_dir/support/managed-srt/package-lock.json" ] \
+        && [ -f "$temp_dir/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js" ] \
+        && [ -f "$temp_dir/support/managed-srt.tree-sha256" ] \
+        || die "the extracted managed sandbox support payload is invalid"
+    unsafe_support=$(find "$temp_dir/support" ! -type d ! -type f -print)
+    [ -z "$unsafe_support" ] \
+        || die "the extracted support payload contains a link or special file: $unsafe_support"
+fi
 [ -f "$temp_dir/web/index.html" ] && [ ! -L "$temp_dir/web/index.html" ] \
     || die "the extracted Web workspace is invalid"
 unsafe_extracted=$(find "$temp_dir/web" ! -type d ! -type f -print)
 [ -z "$unsafe_extracted" ] \
     || die "the extracted Web workspace contains a link or special file: $unsafe_extracted"
 chmod 755 "$temp_dir/a3s" || die "failed to make the staged a3s binary executable"
+if [ "$has_bundled_webview" -eq 1 ]; then
+    chmod 755 "$temp_dir/a3s-webview" \
+        || die "failed to make the staged a3s-webview companion executable"
+fi
 
 verify_binary_version() {
     candidate=$1
@@ -535,9 +693,22 @@ failed_web="$web_parent/.a3s-web.failed.$activation_id"
 staged_binary="$install_dir/.a3s.new.$activation_id"
 backup_binary="$install_dir/.a3s.backup.$activation_id"
 failed_binary="$install_dir/.a3s.failed.$activation_id"
+if [ "$has_bundled_webview" -eq 1 ]; then
+    staged_webview="$install_dir/.a3s-webview.new.$activation_id"
+    backup_webview="$install_dir/.a3s-webview.backup.$activation_id"
+    failed_webview="$install_dir/.a3s-webview.failed.$activation_id"
+fi
+if [ "$has_bundled_support" -eq 1 ]; then
+    support_dir="$install_dir/support"
+    staged_support="$install_dir/.a3s-support.new.$activation_id"
+    backup_support="$install_dir/.a3s-support.backup.$activation_id"
+    failed_support="$install_dir/.a3s-support.failed.$activation_id"
+fi
 
 for generated_path in "$staged_web" "$backup_web" "$failed_web" \
-    "$staged_binary" "$backup_binary" "$failed_binary"; do
+    "$staged_binary" "$backup_binary" "$failed_binary" \
+    "$staged_webview" "$backup_webview" "$failed_webview" \
+    "$staged_support" "$backup_support" "$failed_support"; do
     [ ! -e "$generated_path" ] && [ ! -L "$generated_path" ] \
         || die "temporary activation path already exists: $generated_path"
 done
@@ -545,6 +716,16 @@ done
 mv "$temp_dir/web" "$staged_web" || die "failed to stage Web assets"
 cp "$temp_dir/a3s" "$staged_binary" || die "failed to stage the a3s binary"
 chmod 755 "$staged_binary" || die "failed to make the a3s binary executable"
+if [ "$has_bundled_webview" -eq 1 ]; then
+    cp "$temp_dir/a3s-webview" "$staged_webview" \
+        || die "failed to stage the a3s-webview companion"
+    chmod 755 "$staged_webview" \
+        || die "failed to make the a3s-webview companion executable"
+fi
+if [ "$has_bundled_support" -eq 1 ]; then
+    mv "$temp_dir/support" "$staged_support" \
+        || die "failed to stage the managed sandbox support payload"
+fi
 verify_binary_version "$staged_binary" \
     || die "the staged a3s binary failed its version check"
 
@@ -560,6 +741,48 @@ fi
 mv "$staged_web" "$web_dir" || die "failed to activate the Web assets"
 web_active=1
 staged_web=""
+
+if [ "$has_bundled_support" -eq 1 ]; then
+    support_activation_started=1
+    if [ -L "$support_dir" ]; then
+        die "refusing to replace symlink $support_dir"
+    fi
+    if [ -e "$support_dir" ]; then
+        [ -d "$support_dir" ] || die "$support_dir is not a directory"
+        [ -f "$support_dir/managed-srt/package.json" ] \
+            || die "$support_dir is not an installer-managed support directory"
+        unsafe_existing_support=$(find "$support_dir" ! -type d ! -type f -print)
+        [ -z "$unsafe_existing_support" ] \
+            || die "refusing to replace support assets containing a link or special file: $unsafe_existing_support"
+        mv "$support_dir" "$backup_support" \
+            || die "failed to back up the existing support payload"
+        old_support_saved=1
+    fi
+    mv "$staged_support" "$support_dir" \
+        || die "failed to activate the managed sandbox support payload"
+    support_active=1
+    staged_support=""
+fi
+
+if [ "$has_bundled_webview" -eq 1 ]; then
+    webview_activation_started=1
+    if [ -L "$install_dir/a3s-webview" ]; then
+        die "refusing to replace symlink $install_dir/a3s-webview"
+    fi
+    if [ -e "$install_dir/a3s-webview" ]; then
+        [ -f "$install_dir/a3s-webview" ] \
+            || die "$install_dir/a3s-webview is not a regular file"
+        cp -p "$install_dir/a3s-webview" "$backup_webview" \
+            || die "failed to back up the existing a3s-webview companion"
+        old_webview_saved=1
+    fi
+    mv -f "$staged_webview" "$install_dir/a3s-webview" \
+        || die "failed to activate the a3s-webview companion"
+    webview_active=1
+    staged_webview=""
+    [ -x "$install_dir/a3s-webview" ] \
+        || die "the installed a3s-webview companion is not executable"
+fi
 
 binary_activation_started=1
 if [ -L "$install_dir/a3s" ]; then
@@ -590,6 +813,18 @@ if remove_generated_binary "$backup_binary"; then
     backup_binary=""
 else
     warn "could not remove the old binary backup at $backup_binary"
+fi
+if remove_generated_binary "$backup_webview"; then
+    old_webview_saved=0
+    backup_webview=""
+else
+    warn "could not remove the old WebView helper backup at $backup_webview"
+fi
+if remove_generated_support_tree "$backup_support"; then
+    old_support_saved=0
+    backup_support=""
+else
+    warn "could not remove the old support payload backup at $backup_support"
 fi
 
 path_is_ready=0
@@ -647,4 +882,12 @@ if [ -n "$active_a3s" ] && [ "$active_a3s" != "$install_dir/a3s" ]; then
 fi
 
 info "installed a3s $expected_version to $install_dir/a3s"
+if [ "$has_bundled_webview" -eq 1 ]; then
+    info "installed a3s-webview to $install_dir/a3s-webview"
+else
+    info "release $release_tag has no bundled a3s-webview; a3s code will install the verified component on first use"
+fi
+if [ "$has_bundled_support" -eq 1 ]; then
+    info "installed managed sandbox support to $support_dir"
+fi
 info "installed Web assets to $web_dir"

--- a/justfile
+++ b/justfile
@@ -9,6 +9,24 @@ agent_island_target := justfile_directory() / "target/agent-island-dev"
 agent_island_executable := if os() == "windows" { "a3s-webview.exe" } else { "a3s-webview" }
 agent_island_bin := agent_island_target / "debug" / agent_island_executable
 
+[private]
+cli-submodules:
+    sh scripts/ensure-dev-submodules.sh \
+        crates/acl:Cargo.toml \
+        crates/boot:Cargo.toml \
+        crates/cli:Cargo.toml \
+        crates/code:core/Cargo.toml \
+        crates/flow:Cargo.toml \
+        crates/lane:Cargo.toml \
+        crates/memory:Cargo.toml \
+        crates/search:Cargo.toml \
+        crates/tui:Cargo.toml \
+        crates/use:crates/extension/Cargo.toml
+
+[private]
+webview-submodule:
+    sh scripts/ensure-dev-submodules.sh crates/webview:Cargo.toml
+
 default:
     @just --list
 
@@ -49,22 +67,22 @@ playground:
 # Run the local umbrella CLI and forward all arguments
 
 # Example: `just a3s search status` or `just a3s --help`
-a3s *args:
+a3s *args: cli-submodules
     cargo --config 'patch.crates-io.a3s-code-core.path="crates/code/core"' --config 'patch.crates-io.a3s-memory.path="crates/memory"' --config 'patch.crates-io.a3s-search.path="crates/search"' --config 'patch.crates-io.a3s-tui.path="crates/tui"' run --manifest-path crates/cli/Cargo.toml -- {{ args }}
 
 # Start the A3S Code TUI in the current repository
-code:
+code: cli-submodules webview-submodule
     CARGO_TARGET_DIR='{{ agent_island_target }}' cargo build --manifest-path crates/webview/Cargo.toml --bin a3s-webview
     A3S_AGENT_ISLAND_BIN='{{ agent_island_bin }}' cargo --config 'patch.crates-io.a3s-code-core.path="crates/code/core"' --config 'patch.crates-io.a3s-memory.path="crates/memory"' --config 'patch.crates-io.a3s-tui.path="crates/tui"' run --manifest-path crates/cli/Cargo.toml -- code
 
 # Test Code hot-plug against a real, independently built A3S Use process
-use-hotplug-e2e:
+use-hotplug-e2e: cli-submodules
     CARGO_TARGET_DIR='{{ use_e2e_use_target }}' cargo build --manifest-path crates/use/Cargo.toml -p a3s-use -p a3s-use-browser-driver
     CARGO_TARGET_DIR='{{ use_e2e_code_target }}' A3S_USE_E2E_BIN='{{ use_e2e_use_target }}/debug/a3s-use' cargo test --manifest-path crates/cli/Cargo.toml --lib use_registry::tests::real_use_process_converges_install_upgrade_rebuild_disable_and_enable -- --ignored --nocapture
     CARGO_TARGET_DIR='{{ use_e2e_code_target }}' A3S_USE_E2E_BIN='{{ use_e2e_use_target }}/debug/a3s-use' A3S_USE_E2E_SOURCE_ROOT='{{ justfile_directory() }}/crates/use' cargo test --manifest-path crates/cli/Cargo.toml --test code_use_first_use code_tui_first_use_installs_a_real_use_release_before_the_first_turn -- --ignored --nocapture
 
 # Build and start the A3S Web application
-web:
+web: cli-submodules
     cd apps/web && A3S_HOST={{ host }} A3S_PORT={{ port }} just web
 
 # Start the Windhole visual A3S Bench laboratory

--- a/scripts/ensure-dev-submodules.sh
+++ b/scripts/ensure-dev-submodules.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# Initialize only the submodules needed by a development recipe. Existing
+# submodule worktrees are never reset or checked out by this helper.
+
+set -eu
+
+die() {
+    printf 'a3s dev setup: error: %s\n' "$*" >&2
+    exit 1
+}
+
+[ "$#" -gt 0 ] || die "no required submodules were specified"
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) \
+    || die "run this command from an A3S repository checkout"
+cd "$repo_root"
+
+missing_submodules=""
+for requirement in "$@"; do
+    case "$requirement" in
+        *:*) submodule=${requirement%%:*} ;;
+        *) die "invalid submodule requirement: $requirement" ;;
+    esac
+    [ -n "$submodule" ] || die "invalid submodule requirement: $requirement"
+    if [ ! -e "$submodule/.git" ]; then
+        missing_submodules="${missing_submodules}${missing_submodules:+ }$submodule"
+    fi
+done
+
+if [ -n "$missing_submodules" ]; then
+    printf 'a3s dev setup: initializing required submodules:%s\n' \
+        "${missing_submodules:+ $missing_submodules}"
+    # The registered repository paths never contain whitespace.
+    # shellcheck disable=SC2086
+    git submodule update --init -- $missing_submodules \
+        || die "could not initialize the required submodules"
+fi
+
+for requirement in "$@"; do
+    submodule=${requirement%%:*}
+    required_file=${requirement#*:}
+    [ -n "$required_file" ] \
+        || die "invalid submodule requirement: $requirement"
+    [ -e "$submodule/.git" ] \
+        || die "$submodule is not an initialized Git submodule"
+    if [ ! -f "$submodule/$required_file" ]; then
+        printf 'a3s dev setup: error: required file is missing: %s/%s\n' \
+            "$submodule" "$required_file" >&2
+        printf 'a3s dev setup: the initialized submodule was left unchanged to preserve local work.\n' >&2
+        git -C "$submodule" status --short 2>/dev/null | sed -n '1,12p' >&2 || true
+        printf 'a3s dev setup: stash or commit that submodule, then synchronize it with:\n' >&2
+        printf '  git submodule update --init -- %s\n' "$submodule" >&2
+        exit 1
+    fi
+done

--- a/scripts/test-ensure-dev-submodules.sh
+++ b/scripts/test-ensure-dev-submodules.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+helper="$script_dir/ensure-dev-submodules.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/a3s-submodule-preflight.XXXXXX")
+trap 'rm -rf -- "$test_root"' EXIT
+
+fail() {
+    printf 'submodule preflight test failed: %s\n' "$*" >&2
+    exit 1
+}
+
+source_repo="$test_root/source"
+super_repo="$test_root/super"
+mkdir -p "$source_repo" "$super_repo"
+
+git -C "$source_repo" init -q
+git -C "$source_repo" config user.name 'A3S Test'
+git -C "$source_repo" config user.email 'test@a3s.local'
+printf '[package]\nname = "fixture"\nversion = "0.1.0"\n' >"$source_repo/Cargo.toml"
+git -C "$source_repo" add Cargo.toml
+git -C "$source_repo" commit -qm 'fixture source'
+
+git -C "$super_repo" init -q
+git -C "$super_repo" config user.name 'A3S Test'
+git -C "$super_repo" config user.email 'test@a3s.local'
+git -C "$super_repo" -c protocol.file.allow=always \
+    submodule add -q "$source_repo" crates/example
+git -C "$super_repo" commit -qam 'register fixture submodule'
+
+git -C "$super_repo" submodule deinit -f -- crates/example >/dev/null
+rm -rf -- "$super_repo/crates/example"
+
+(
+    cd "$super_repo"
+    GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0=protocol.file.allow \
+    GIT_CONFIG_VALUE_0=always \
+        sh "$helper" crates/example:Cargo.toml
+)
+[[ -f "$super_repo/crates/example/Cargo.toml" ]] \
+    || fail 'missing submodule was not initialized'
+
+rm -f -- "$super_repo/crates/example/Cargo.toml"
+error_log="$test_root/missing-manifest.log"
+if (cd "$super_repo" && sh "$helper" crates/example:Cargo.toml >"$error_log" 2>&1); then
+    fail 'an initialized submodule with a deleted manifest unexpectedly passed'
+fi
+[[ ! -e "$super_repo/crates/example/Cargo.toml" ]] \
+    || fail 'preflight overwrote the initialized submodule worktree'
+grep -Fq 'the initialized submodule was left unchanged' "$error_log" \
+    || fail 'missing-manifest diagnostic did not explain worktree preservation'
+
+printf 'development submodule preflight tests passed\n'

--- a/scripts/test-install.ps1
+++ b/scripts/test-install.ps1
@@ -36,7 +36,7 @@ function Assert-Content {
 function Assert-NoGeneratedPaths {
     param([string]$Root)
     $leftovers = @(Get-ChildItem -LiteralPath $Root -Recurse -Force |
-        Where-Object { $_.Name -match '^\.a3s(-web)?\.(new|backup|failed)\.' })
+        Where-Object { $_.Name -match '^\.a3s(?:-web|-webview|-support)?\.(new|backup|failed)\.' })
     if ($leftovers.Count -ne 0) {
         Fail-Test "installer left temporary path $($leftovers[0].FullName)"
     }
@@ -60,13 +60,21 @@ $global:A3sInstallerMockArchive = ''
 $global:A3sInstallerMoveFault = ''
 $global:A3sInstallerMoveFaultVersion = ''
 $global:A3sInstallerMoveFaultTriggered = $false
+$global:A3sInstallerRestFailures = 0
+$global:A3sInstallerWebFailures = 0
+$global:A3sInstallerRetryDelays = 0
 
 function Invoke-RestMethod {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]$Uri,
-        [Parameter(Mandatory = $true)]$Headers
+        [Parameter(Mandatory = $true)]$Headers,
+        [int]$TimeoutSec
     )
+    if ($global:A3sInstallerRestFailures -gt 0) {
+        $global:A3sInstallerRestFailures--
+        throw 'injected transient release lookup failure'
+    }
     if ($null -eq $global:A3sInstallerMockRelease) {
         throw 'mock release was not configured'
     }
@@ -79,9 +87,20 @@ function Invoke-WebRequest {
         [switch]$UseBasicParsing,
         [Parameter(Mandatory = $true)]$Uri,
         [Parameter(Mandatory = $true)][string]$OutFile,
-        [Parameter(Mandatory = $true)]$Headers
+        [Parameter(Mandatory = $true)]$Headers,
+        [int]$TimeoutSec
     )
+    if ($global:A3sInstallerWebFailures -gt 0) {
+        $global:A3sInstallerWebFailures--
+        throw 'injected transient asset download failure'
+    }
     Copy-Item -LiteralPath $global:A3sInstallerMockArchive -Destination $OutFile
+}
+
+function Start-Sleep {
+    [CmdletBinding()]
+    param([double]$Seconds)
+    $global:A3sInstallerRetryDelays++
 }
 
 function Move-Item {
@@ -116,6 +135,16 @@ function Move-Item {
                 $destinationLeaf -ceq 'a3s.exe'
             break
         }
+        'webview-activate' {
+            $sourceLeaf -match '^\.a3s-webview\.new\.[0-9a-f-]+\.exe$' -and
+                $destinationLeaf -ceq 'a3s-webview.exe'
+            break
+        }
+        'support-activate' {
+            $sourceLeaf -match '^\.a3s-support\.new\.[0-9a-f-]+$' -and
+                $destinationLeaf -ceq 'support'
+            break
+        }
         default { $false }
     }
     if ($inject) {
@@ -127,10 +156,29 @@ function Move-Item {
 function New-FixtureExecutable {
     param(
         [string]$Version,
-        [string]$Destination
+        [string]$Destination,
+        [ValidateSet('a3s', 'webview')][string]$Product = 'a3s'
     )
     $typeName = 'Program_' + $Version.Replace('.', '_') + '_' + [Guid]::NewGuid().ToString('N')
-    $source = @"
+    $source = if ($Product -eq 'webview') {
+        @"
+using System;
+public static class $typeName
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length > 0 && args[0] == "--agent-island")
+        {
+            Console.Error.WriteLine("usage: a3s-webview --agent-island --snapshot <absolute-path> --lock-file <absolute-path>");
+            return 2;
+        }
+        Console.WriteLine("a3s-webview $Version");
+        return 0;
+    }
+}
+"@
+    } else {
+        @"
 using System;
 public static class $typeName
 {
@@ -141,6 +189,7 @@ public static class $typeName
     }
 }
 "@
+    }
     $compilerCandidates = @(
         (Join-Path $env:WINDIR 'Microsoft.NET\Framework64\v4.0.30319\csc.exe'),
         (Join-Path $env:WINDIR 'Microsoft.NET\Framework\v4.0.30319\csc.exe')
@@ -166,7 +215,9 @@ public static class $typeName
 function Set-ReleaseFixture {
     param(
         [string]$Version,
-        [switch]$UnsafeMember
+        [switch]$UnsafeMember,
+        [switch]$WithoutWebview,
+        [switch]$WithoutSupport
     )
 
     $payload = Join-Path $fixtureRoot 'payload'
@@ -175,7 +226,23 @@ function Set-ReleaseFixture {
     }
     [IO.Directory]::CreateDirectory((Join-Path $payload 'web')) | Out-Null
     New-FixtureExecutable -Version $Version -Destination (Join-Path $payload 'a3s.exe')
+    if (-not $WithoutWebview) {
+        New-FixtureExecutable -Version $Version -Destination (Join-Path $payload 'a3s-webview.exe') -Product webview
+    }
     Set-Content -LiteralPath (Join-Path $payload 'web\index.html') -Value "<!doctype html><title>A3S $Version</title>" -Encoding UTF8
+    if (-not $WithoutSupport) {
+        $supportRoot = Join-Path $payload 'support\managed-srt'
+        $supportDist = Join-Path $supportRoot 'node_modules\@anthropic-ai\sandbox-runtime\dist'
+        [IO.Directory]::CreateDirectory($supportDist) | Out-Null
+        Set-Content -LiteralPath (Join-Path $supportRoot 'package.json') `
+            -Value "{`"name`":`"a3s-managed-srt-fixture`",`"version`":`"$Version`"}" -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $supportRoot 'package-lock.json') `
+            -Value '{"name":"a3s-managed-srt-fixture","lockfileVersion":3}' -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $supportDist 'cli.js') `
+            -Value "managed-srt $Version" -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $payload 'support\managed-srt.tree-sha256') `
+            -Value "fixture-tree-sha256-$Version" -Encoding UTF8
+    }
     if ($UnsafeMember) {
         Set-Content -LiteralPath (Join-Path $payload 'escape.txt') -Value 'unexpected' -Encoding UTF8
     }
@@ -230,6 +297,39 @@ try {
     $env:PROCESSOR_ARCHITEW6432 = $null
     $env:LOCALAPPDATA = Join-Path $testRoot 'Local AppData 用户'
 
+    # Transient API and archive transport failures are retried without leaving
+    # a partial download or requiring the user to restart the installer.
+    $retryRoot = Join-Path $testRoot 'transient-network-retry'
+    Set-ReleaseFixture -Version '1.2.1' -WithoutWebview -WithoutSupport
+    $global:A3sInstallerRestFailures = 1
+    $global:A3sInstallerWebFailures = 1
+    $global:A3sInstallerRetryDelays = 0
+    Invoke-TestInstall -Version '1.2.1' -InstallDir (Join-Path $retryRoot 'bin') `
+        -DataHome (Join-Path $retryRoot 'data')
+    Assert-File (Join-Path $retryRoot 'bin\a3s.exe')
+    if ($global:A3sInstallerRestFailures -ne 0 -or
+        $global:A3sInstallerWebFailures -ne 0 -or
+        $global:A3sInstallerRetryDelays -ne 2) {
+        Fail-Test 'transient network failures were not retried exactly once each'
+    }
+    Assert-NoGeneratedPaths -Root $retryRoot
+
+    # Stable archives published before the companion bundle remain installable;
+    # Code owns their verified WebView first-use setup.
+    $legacyRoot = Join-Path $testRoot 'legacy-without-webview'
+    Set-ReleaseFixture -Version '1.2.2' -WithoutWebview -WithoutSupport
+    Invoke-TestInstall -Version '1.2.2' -InstallDir (Join-Path $legacyRoot 'bin') `
+        -DataHome (Join-Path $legacyRoot 'data')
+    Assert-File (Join-Path $legacyRoot 'bin\a3s.exe')
+    Assert-File (Join-Path $legacyRoot 'data\web\1.2.2\index.html')
+    if (Test-Path -LiteralPath (Join-Path $legacyRoot 'bin\a3s-webview.exe')) {
+        Fail-Test 'legacy release unexpectedly installed a WebView companion'
+    }
+    if (Test-Path -LiteralPath (Join-Path $legacyRoot 'bin\support')) {
+        Fail-Test 'legacy release unexpectedly installed a support payload'
+    }
+    Assert-NoGeneratedPaths -Root $legacyRoot
+
     # Initial installation and upgrade keep both versioned Web caches.
     $upgradeRoot = Join-Path $testRoot 'upgrade path 用户'
     $installDir = Join-Path $upgradeRoot 'bin'
@@ -237,11 +337,19 @@ try {
     Set-ReleaseFixture -Version '1.2.3'
     Invoke-TestInstall -Version '1.2.3' -InstallDir $installDir -DataHome $dataHome
     Assert-File (Join-Path $installDir 'a3s.exe')
+    Assert-File (Join-Path $installDir 'a3s-webview.exe')
+    $supportCli = Join-Path $installDir 'support\managed-srt\node_modules\@anthropic-ai\sandbox-runtime\dist\cli.js'
+    Assert-File $supportCli
     Assert-File (Join-Path $dataHome 'web\1.2.3\index.html')
     $installedVersion = (& (Join-Path $installDir 'a3s.exe') --version | Out-String).Trim()
     if ($installedVersion -cne 'a3s 1.2.3') {
         Fail-Test "initial binary reported $installedVersion"
     }
+    $installedWebviewVersion = (& (Join-Path $installDir 'a3s-webview.exe') | Out-String).Trim()
+    if ($installedWebviewVersion -cne 'a3s-webview 1.2.3') {
+        Fail-Test "initial WebView companion reported $installedWebviewVersion"
+    }
+    Assert-Content -Expected 'managed-srt 1.2.3' -Path $supportCli
 
     Set-ReleaseFixture -Version '1.2.4'
     Invoke-TestInstall -Version '1.2.4' -InstallDir $installDir -DataHome $dataHome
@@ -249,6 +357,11 @@ try {
     if ($installedVersion -cne 'a3s 1.2.4') {
         Fail-Test "upgraded binary reported $installedVersion"
     }
+    $installedWebviewVersion = (& (Join-Path $installDir 'a3s-webview.exe') | Out-String).Trim()
+    if ($installedWebviewVersion -cne 'a3s-webview 1.2.4') {
+        Fail-Test "upgraded WebView companion reported $installedWebviewVersion"
+    }
+    Assert-Content -Expected 'managed-srt 1.2.4' -Path $supportCli
     Assert-File (Join-Path $dataHome 'web\1.2.3\index.html')
     Assert-File (Join-Path $dataHome 'web\1.2.4\index.html')
     Assert-NoGeneratedPaths -Root $upgradeRoot
@@ -263,6 +376,11 @@ try {
     if ($installedVersion -cne 'a3s 1.2.4') {
         Fail-Test 'digest failure changed the installed binary'
     }
+    $installedWebviewVersion = (& (Join-Path $installDir 'a3s-webview.exe') | Out-String).Trim()
+    if ($installedWebviewVersion -cne 'a3s-webview 1.2.4') {
+        Fail-Test 'digest failure changed the installed WebView companion'
+    }
+    Assert-Content -Expected 'managed-srt 1.2.4' -Path $supportCli
 
     # Missing digest metadata fails closed.
     Set-ReleaseFixture -Version '1.2.6'
@@ -280,6 +398,11 @@ try {
     if ($installedVersion -cne 'a3s 1.2.4') {
         Fail-Test 'unsafe archive changed the installed binary'
     }
+    $installedWebviewVersion = (& (Join-Path $installDir 'a3s-webview.exe') | Out-String).Trim()
+    if ($installedWebviewVersion -cne 'a3s-webview 1.2.4') {
+        Fail-Test 'unsafe archive changed the installed WebView companion'
+    }
+    Assert-Content -Expected 'managed-srt 1.2.4' -Path $supportCli
 
     # A locked executable forces rollback without losing the old binary or Web cache.
     $lockedRoot = Join-Path $testRoot 'locked'
@@ -301,6 +424,12 @@ try {
     if ($installedVersion -cne 'a3s 2.0.0') {
         Fail-Test 'locked upgrade did not preserve the old binary'
     }
+    $installedWebviewVersion = (& (Join-Path $lockedInstallDir 'a3s-webview.exe') | Out-String).Trim()
+    if ($installedWebviewVersion -cne 'a3s-webview 2.0.0') {
+        Fail-Test 'locked upgrade did not restore the old WebView companion'
+    }
+    Assert-Content -Expected 'managed-srt 2.0.0' -Path `
+        (Join-Path $lockedInstallDir 'support\managed-srt\node_modules\@anthropic-ai\sandbox-runtime\dist\cli.js')
     Assert-File (Join-Path $lockedDataHome 'web\2.0.0\index.html')
     if (Test-Path -LiteralPath (Join-Path $lockedDataHome 'web\2.0.1')) {
         Fail-Test 'locked upgrade left the failed Web version active'
@@ -316,6 +445,8 @@ try {
     Invoke-TestInstall -Version '4.0.0' -InstallDir $faultInstallDir -DataHome $faultDataHome
     $faultWeb = Join-Path $faultDataHome 'web\4.0.0\index.html'
     Set-Content -LiteralPath $faultWeb -Value 'old Web sentinel' -Encoding UTF8
+    $faultSupportCli = Join-Path $faultInstallDir 'support\managed-srt\node_modules\@anthropic-ai\sandbox-runtime\dist\cli.js'
+    Set-Content -LiteralPath $faultSupportCli -Value 'old support sentinel' -Encoding UTF8
 
     $global:A3sInstallerMoveFault = 'web-backup'
     $global:A3sInstallerMoveFaultVersion = '4.0.0'
@@ -327,6 +458,7 @@ try {
         Fail-Test 'Web backup fault was not injected'
     }
     Assert-Content -Expected 'old Web sentinel' -Path $faultWeb
+    Assert-Content -Expected 'old support sentinel' -Path $faultSupportCli
     $installedVersion = (& (Join-Path $faultInstallDir 'a3s.exe') --version | Out-String).Trim()
     if ($installedVersion -cne 'a3s 4.0.0') {
         Fail-Test 'Web backup interruption changed the installed binary'
@@ -342,11 +474,54 @@ try {
         Fail-Test 'Web activation fault was not injected'
     }
     Assert-Content -Expected 'old Web sentinel' -Path $faultWeb
+    Assert-Content -Expected 'old support sentinel' -Path $faultSupportCli
     $installedVersion = (& (Join-Path $faultInstallDir 'a3s.exe') --version | Out-String).Trim()
     if ($installedVersion -cne 'a3s 4.0.0') {
         Fail-Test 'Web activation interruption changed the installed binary'
     }
     Assert-NoGeneratedPaths -Root $faultRoot
+
+    $global:A3sInstallerMoveFault = 'support-activate'
+    $global:A3sInstallerMoveFaultTriggered = $false
+    Expect-Failure 'interruption after support payload activation' {
+        Invoke-TestInstall -Version '4.0.0' -InstallDir $faultInstallDir -DataHome $faultDataHome
+    }
+    if (-not $global:A3sInstallerMoveFaultTriggered) {
+        Fail-Test 'support payload fault was not injected'
+    }
+    Assert-Content -Expected 'old Web sentinel' -Path $faultWeb
+    Assert-Content -Expected 'old support sentinel' -Path $faultSupportCli
+    $installedVersion = (& (Join-Path $faultInstallDir 'a3s.exe') --version | Out-String).Trim()
+    if ($installedVersion -cne 'a3s 4.0.0') {
+        Fail-Test 'support activation interruption changed the installed binary'
+    }
+    Assert-NoGeneratedPaths -Root $faultRoot
+
+    $initialWebviewFaultRoot = Join-Path $testRoot 'initial-webview-fault'
+    $global:A3sInstallerMoveFault = 'webview-activate'
+    $global:A3sInstallerMoveFaultVersion = '4.0.1'
+    $global:A3sInstallerMoveFaultTriggered = $false
+    Set-ReleaseFixture -Version '4.0.1'
+    Expect-Failure 'interruption after initial WebView companion activation' {
+        Invoke-TestInstall -Version '4.0.1' -InstallDir (Join-Path $initialWebviewFaultRoot 'bin') `
+            -DataHome (Join-Path $initialWebviewFaultRoot 'data')
+    }
+    if (-not $global:A3sInstallerMoveFaultTriggered) {
+        Fail-Test 'WebView companion fault was not injected'
+    }
+    if (Test-Path -LiteralPath (Join-Path $initialWebviewFaultRoot 'bin\a3s-webview.exe')) {
+        Fail-Test 'WebView activation interruption left the new companion active'
+    }
+    if (Test-Path -LiteralPath (Join-Path $initialWebviewFaultRoot 'bin\a3s.exe')) {
+        Fail-Test 'WebView activation interruption left the new binary active'
+    }
+    if (Test-Path -LiteralPath (Join-Path $initialWebviewFaultRoot 'bin\support')) {
+        Fail-Test 'WebView activation interruption left the new support payload active'
+    }
+    if (Test-Path -LiteralPath (Join-Path $initialWebviewFaultRoot 'data\web\4.0.1')) {
+        Fail-Test 'WebView activation interruption left the new Web cache active'
+    }
+    Assert-NoGeneratedPaths -Root $initialWebviewFaultRoot
 
     $initialFaultRoot = Join-Path $testRoot 'initial-binary-fault'
     $global:A3sInstallerMoveFault = 'binary-activate'
@@ -362,6 +537,12 @@ try {
     }
     if (Test-Path -LiteralPath (Join-Path $initialFaultRoot 'bin\a3s.exe')) {
         Fail-Test 'binary activation interruption left the new binary active'
+    }
+    if (Test-Path -LiteralPath (Join-Path $initialFaultRoot 'bin\a3s-webview.exe')) {
+        Fail-Test 'binary activation interruption left the new WebView companion active'
+    }
+    if (Test-Path -LiteralPath (Join-Path $initialFaultRoot 'bin\support')) {
+        Fail-Test 'binary activation interruption left the new support payload active'
     }
     if (Test-Path -LiteralPath (Join-Path $initialFaultRoot 'data\web\4.1.0')) {
         Fail-Test 'binary activation interruption left the new Web cache active'

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -33,7 +33,8 @@ assert_content() {
 assert_no_generated_paths() {
     local root=$1
     local leftovers
-    leftovers=$(find "$root" -name '.a3s.*' -o -name '.a3s-web.*')
+    leftovers=$(find "$root" -name '.a3s.*' -o -name '.a3s-web.*' -o \
+        -name '.a3s-webview.*' -o -name '.a3s-support.*')
     [[ -z "$leftovers" ]] || fail "installer left temporary paths: $leftovers"
 }
 
@@ -134,6 +135,16 @@ case "$MOCK_MV_FAULT" in
             .a3s.new.*:a3s) inject=1 ;;
         esac
         ;;
+    webview-activate)
+        case "$source_leaf:$destination_leaf" in
+            .a3s-webview.new.*:a3s-webview) inject=1 ;;
+        esac
+        ;;
+    support-activate)
+        case "$source_leaf:$destination_leaf" in
+            .a3s-support.new.*:support) inject=1 ;;
+        esac
+        ;;
 esac
 
 if [ "$inject" -eq 1 ]; then
@@ -162,9 +173,12 @@ sha256_file() {
 make_fixture() {
     local version=$1
     local target=$2
+    local include_webview=${3:-1}
+    local include_support=${4:-1}
     local payload="$fixture_root/payload"
     local archive="$fixture_root/a3s-v${version}-${target}.tar.gz"
     local asset_name="a3s-v${version}-${target}.tar.gz"
+    local archive_members=(a3s web)
     local digest
 
     rm -rf -- "$payload"
@@ -172,7 +186,25 @@ make_fixture() {
     printf '#!/bin/sh\nprintf "a3s %s\\n"\n' "$version" >"$payload/a3s"
     chmod +x "$payload/a3s"
     printf '<!doctype html><title>A3S %s</title>\n' "$version" >"$payload/web/index.html"
-    tar -czf "$archive" -C "$payload" a3s web
+    if [ "$include_webview" -eq 1 ]; then
+        printf '#!/bin/sh\nif [ "${1:-}" = "--agent-island" ]; then\n  printf "%%s\\n" "usage: a3s-webview --agent-island --snapshot <absolute-path> --lock-file <absolute-path>" >&2\n  exit 2\nfi\nprintf "a3s-webview %s\\n"\n' \
+            "$version" >"$payload/a3s-webview"
+        chmod +x "$payload/a3s-webview"
+        archive_members+=(a3s-webview)
+    fi
+    if [ "$include_support" -eq 1 ]; then
+        mkdir -p "$payload/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist"
+        printf '{"name":"a3s-managed-srt-fixture","version":"%s"}\n' \
+            "$version" >"$payload/support/managed-srt/package.json"
+        printf '{"name":"a3s-managed-srt-fixture","lockfileVersion":3}\n' \
+            >"$payload/support/managed-srt/package-lock.json"
+        printf 'managed-srt %s\n' \
+            "$version" >"$payload/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
+        printf 'fixture-tree-sha256-%s\n' \
+            "$version" >"$payload/support/managed-srt.tree-sha256"
+        archive_members+=(support)
+    fi
+    tar -czf "$archive" -C "$payload" "${archive_members[@]}"
     digest=$(sha256_file "$archive")
 
     MOCK_ARCHIVE=$archive
@@ -197,6 +229,20 @@ run_install() {
 
 mkdir -p "$test_root/home"
 
+# Stable archives published before the companion bundle remain installable;
+# Code owns their verified WebView first-use setup.
+export MOCK_UNAME_S=Linux MOCK_UNAME_M=x86_64
+make_fixture 1.2.2 x86_64-unknown-linux-gnu 0 0
+legacy_root="$test_root/legacy-without-webview"
+run_install 1.2.2 "$legacy_root/bin" "$legacy_root/data"
+assert_file "$legacy_root/bin/a3s"
+assert_file "$legacy_root/data/web/1.2.2/index.html"
+[[ ! -e "$legacy_root/bin/a3s-webview" ]] \
+    || fail 'legacy release unexpectedly installed a WebView companion'
+[[ ! -e "$legacy_root/bin/support" ]] \
+    || fail 'legacy release unexpectedly installed a support payload'
+assert_no_generated_paths "$legacy_root"
+
 # Every published Unix target maps to the exact release asset name.
 for target_case in \
     'Linux x86_64 x86_64-unknown-linux-gnu' \
@@ -209,9 +255,15 @@ for target_case in \
     case_root="$test_root/targets/$target"
     run_install 1.2.3 "$case_root/bin" "$case_root/data"
     assert_file "$case_root/bin/a3s"
+    assert_file "$case_root/bin/a3s-webview"
+    assert_file "$case_root/bin/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
     assert_file "$case_root/data/web/1.2.3/index.html"
     [[ "$("$case_root/bin/a3s" --version)" == 'a3s 1.2.3' ]] \
         || fail "wrong installed version for $target"
+    [[ "$("$case_root/bin/a3s-webview")" == 'a3s-webview 1.2.3' ]] \
+        || fail "wrong installed WebView companion for $target"
+    assert_content 'managed-srt 1.2.3' \
+        "$case_root/bin/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
     assert_no_generated_paths "$case_root"
 done
 
@@ -223,6 +275,10 @@ run_install 1.2.3 "$upgrade_root/bin" "$upgrade_root/data"
 make_fixture 1.2.4 x86_64-unknown-linux-gnu
 run_install 1.2.4 "$upgrade_root/bin" "$upgrade_root/data"
 [[ "$("$upgrade_root/bin/a3s" --version)" == 'a3s 1.2.4' ]] || fail 'upgrade did not replace binary'
+[[ "$("$upgrade_root/bin/a3s-webview")" == 'a3s-webview 1.2.4' ]] \
+    || fail 'upgrade did not replace WebView companion'
+assert_content 'managed-srt 1.2.4' \
+    "$upgrade_root/bin/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
 assert_file "$upgrade_root/data/web/1.2.3/index.html"
 assert_file "$upgrade_root/data/web/1.2.4/index.html"
 assert_no_generated_paths "$upgrade_root"
@@ -235,6 +291,10 @@ MOCK_RELEASE_JSON="$fixture_root/bad-digest.json"
 export MOCK_RELEASE_JSON
 expect_failure 'digest mismatch' run_install 1.2.5 "$upgrade_root/bin" "$upgrade_root/data"
 [[ "$("$upgrade_root/bin/a3s" --version)" == 'a3s 1.2.4' ]] || fail 'digest failure changed old binary'
+[[ "$("$upgrade_root/bin/a3s-webview")" == 'a3s-webview 1.2.4' ]] \
+    || fail 'digest failure changed old WebView companion'
+assert_content 'managed-srt 1.2.4' \
+    "$upgrade_root/bin/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
 assert_file "$upgrade_root/data/web/1.2.4/index.html"
 
 # A missing target digest cannot borrow the following asset's digest.
@@ -254,10 +314,12 @@ rm -rf -- "$payload"
 mkdir -p "$payload/web"
 printf '#!/bin/sh\nprintf "a3s 1.2.7\\n"\n' >"$payload/a3s"
 chmod +x "$payload/a3s"
+printf '#!/bin/sh\nprintf "a3s-webview 1.2.7\\n"\n' >"$payload/a3s-webview"
+chmod +x "$payload/a3s-webview"
 printf '<!doctype html>\n' >"$payload/web/index.html"
 printf 'unexpected\n' >"$payload/escape"
 MOCK_ARCHIVE="$fixture_root/a3s-v1.2.7-x86_64-unknown-linux-gnu.tar.gz"
-tar -czf "$MOCK_ARCHIVE" -C "$payload" a3s web escape
+tar -czf "$MOCK_ARCHIVE" -C "$payload" a3s a3s-webview web escape
 export MOCK_ARCHIVE
 unsafe_digest=$(sha256_file "$MOCK_ARCHIVE")
 unsafe_asset=$(basename "$MOCK_ARCHIVE")
@@ -268,6 +330,10 @@ MOCK_RELEASE_JSON="$fixture_root/unsafe.json"
 export MOCK_RELEASE_JSON
 expect_failure 'unsafe archive member' run_install 1.2.7 "$upgrade_root/bin" "$upgrade_root/data"
 [[ "$("$upgrade_root/bin/a3s" --version)" == 'a3s 1.2.4' ]] || fail 'unsafe archive changed old binary'
+[[ "$("$upgrade_root/bin/a3s-webview")" == 'a3s-webview 1.2.4' ]] \
+    || fail 'unsafe archive changed old WebView companion'
+assert_content 'managed-srt 1.2.4' \
+    "$upgrade_root/bin/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
 
 # Unsupported and non-glibc hosts fail before making a network request.
 rm -f "$MOCK_CURL_CALLED"
@@ -303,6 +369,9 @@ fault_root="$test_root/fault-injection"
 make_fixture 4.0.0 x86_64-unknown-linux-gnu
 run_install 4.0.0 "$fault_root/bin" "$fault_root/data"
 printf 'old Web sentinel\n' >"$fault_root/data/web/4.0.0/index.html"
+support_cli="$fault_root/bin/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
+printf 'old support sentinel\n' >"$support_cli"
+old_webview_sha=$(sha256_file "$fault_root/bin/a3s-webview")
 
 export MOCK_MV_FAULT=web-backup MOCK_MV_FAULT_VERSION=4.0.0
 rm -f "$MOCK_MV_FAULT_MARKER"
@@ -310,8 +379,22 @@ expect_failure 'interruption after Web backup' \
     run_install 4.0.0 "$fault_root/bin" "$fault_root/data"
 [[ -e "$MOCK_MV_FAULT_MARKER" ]] || fail 'Web backup fault was not injected'
 assert_content 'old Web sentinel' "$fault_root/data/web/4.0.0/index.html"
+assert_content 'old support sentinel' "$support_cli"
 [[ "$("$fault_root/bin/a3s" --version)" == 'a3s 4.0.0' ]] \
     || fail 'Web backup interruption changed the installed binary'
+assert_no_generated_paths "$fault_root"
+
+export MOCK_MV_FAULT=webview-activate
+rm -f "$MOCK_MV_FAULT_MARKER"
+expect_failure 'interruption after WebView companion activation' \
+    run_install 4.0.0 "$fault_root/bin" "$fault_root/data"
+[[ -e "$MOCK_MV_FAULT_MARKER" ]] || fail 'WebView companion fault was not injected'
+assert_content 'old Web sentinel' "$fault_root/data/web/4.0.0/index.html"
+assert_content 'old support sentinel' "$support_cli"
+[[ "$(sha256_file "$fault_root/bin/a3s-webview")" == "$old_webview_sha" ]] \
+    || fail 'WebView activation interruption did not restore the previous companion'
+[[ "$("$fault_root/bin/a3s" --version)" == 'a3s 4.0.0' ]] \
+    || fail 'WebView activation interruption changed the installed binary'
 assert_no_generated_paths "$fault_root"
 
 export MOCK_MV_FAULT=web-activate
@@ -320,8 +403,20 @@ expect_failure 'interruption after Web activation' \
     run_install 4.0.0 "$fault_root/bin" "$fault_root/data"
 [[ -e "$MOCK_MV_FAULT_MARKER" ]] || fail 'Web activation fault was not injected'
 assert_content 'old Web sentinel' "$fault_root/data/web/4.0.0/index.html"
+assert_content 'old support sentinel' "$support_cli"
 [[ "$("$fault_root/bin/a3s" --version)" == 'a3s 4.0.0' ]] \
     || fail 'Web activation interruption changed the installed binary'
+assert_no_generated_paths "$fault_root"
+
+export MOCK_MV_FAULT=support-activate
+rm -f "$MOCK_MV_FAULT_MARKER"
+expect_failure 'interruption after support payload activation' \
+    run_install 4.0.0 "$fault_root/bin" "$fault_root/data"
+[[ -e "$MOCK_MV_FAULT_MARKER" ]] || fail 'support payload fault was not injected'
+assert_content 'old Web sentinel' "$fault_root/data/web/4.0.0/index.html"
+assert_content 'old support sentinel' "$support_cli"
+[[ "$("$fault_root/bin/a3s" --version)" == 'a3s 4.0.0' ]] \
+    || fail 'support activation interruption changed the installed binary'
 assert_no_generated_paths "$fault_root"
 
 make_fixture 4.0.1 x86_64-unknown-linux-gnu
@@ -332,6 +427,9 @@ expect_failure 'interruption after binary activation' \
 [[ -e "$MOCK_MV_FAULT_MARKER" ]] || fail 'binary activation fault was not injected'
 [[ "$("$fault_root/bin/a3s" --version)" == 'a3s 4.0.0' ]] \
     || fail 'binary activation interruption did not restore the previous binary'
+[[ "$(sha256_file "$fault_root/bin/a3s-webview")" == "$old_webview_sha" ]] \
+    || fail 'binary activation interruption did not restore the previous WebView companion'
+assert_content 'old support sentinel' "$support_cli"
 [[ ! -e "$fault_root/data/web/4.0.1" ]] \
     || fail 'binary activation interruption left the new Web cache active'
 assert_content 'old Web sentinel' "$fault_root/data/web/4.0.0/index.html"


### PR DESCRIPTION
## Summary

- install CLI, versioned Web assets, bundled WebView, and managed sandbox support as one validated transaction
- retain compatibility with older archives and verified first-use WebView installation
- add bounded Windows GitHub retries and strict archive validation
- initialize only missing development submodules without overwriting dirty worktrees
- use Bun with the frozen lockfile for the Web development entrypoint instead of npm
- extend installer CI and documentation for the complete lifecycle

## Validation

- bash scripts/test-install.sh
- powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/test-install.ps1
- bash scripts/test-ensure-dev-submodules.sh
- bash/sh and PowerShell parser checks
- just --list plus dry runs for code and web
- a3s-webview build and Agent Island protocol probe
- CLI offline cargo check

The CLI gitlink will be advanced in a follow-up commit after A3S-Lab/CLI#46 passes and merges, before this PR is merged.