### PR TITLE
chore: sync v0.10.5 release pointers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = git@github.com:A3S-Lab/Observer.git
 [submodule "crates/cli"]
 	path = crates/cli
-	url = git@github.com:A3S-Lab/Cli.git
+	url = git@github.com:A3S-Lab/CLI.git
 [submodule "crates/sentry"]
 	path = crates/sentry
 	url = git@github.com:A3S-Lab/Sentry.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = git@github.com:A3S-Lab/Observer.git
 [submodule "crates/cli"]
 	path = crates/cli
-	url = git@github.com:A3S-Lab/CLI.git
+	url = git@github.com:A3S-Lab/Cli.git
 [submodule "crates/sentry"]
 	path = crates/sentry
 	url = git@github.com:A3S-Lab/Sentry.git


### PR DESCRIPTION
Sync the CLI submodule to the v0.10.5 merge commit and the Homebrew tap submodule to the automated 0.10.5 formula update.