### PR TITLE
fix(web): migrate leaked anonymous task drafts

### DIFF
--- a/apps/web/src/features/tasks/task-state.ts
+++ b/apps/web/src/features/tasks/task-state.ts
@@ -73,6 +73,8 @@ function readTitles(): Record<string, string> {
 const activeTaskKey = 'a3s-code-web.active-task';
 const workActiveTaskKey = 'a3s-work.ai-assistant.active-session';
 const taskDraftsKey = 'a3s-code-web.task-drafts';
+const taskDraftsSchemaKey = 'a3s-code-web.task-drafts-schema';
+const taskDraftsSchemaVersion = 2;
 const newTaskConfigKey = 'a3s-code-web.new-task-config';
 const goalTimingsKey = 'a3s-code-web.goal-timings';
 export const newTaskDraftKey = '__new_task__';
@@ -216,14 +218,42 @@ export function createTaskState(product: TaskProduct = 'code'): TaskState {
 
 function readTaskDrafts(): Record<string, TaskDraft> {
   const drafts = readRecord<TaskDraft>(taskDraftsKey);
+  const needsAnonymousDraftMigration = readTaskDraftsSchemaVersion() < taskDraftsSchemaVersion;
   let changed = false;
+  // Older builds could persist a Work assistant instruction as the anonymous
+  // Code task while navigating through a system page. Its origin is not
+  // recoverable, so invalidate only that anonymous draft once and preserve all
+  // named task and Work drafts.
+  if (needsAnonymousDraftMigration && Object.hasOwn(drafts, newTaskDraftKey)) {
+    delete drafts[newTaskDraftKey];
+    changed = true;
+  }
   for (const [key, draft] of Object.entries(drafts)) {
     if (!isLegacyEditorInjectedDraft(draft)) continue;
     delete drafts[key];
     changed = true;
   }
-  if (changed) persistTaskDrafts(drafts);
+  const draftsPersisted = !changed || persistTaskDrafts(drafts);
+  if (needsAnonymousDraftMigration && draftsPersisted) persistTaskDraftsSchemaVersion();
   return drafts;
+}
+
+function readTaskDraftsSchemaVersion(): number {
+  try {
+    const value = Number(localStorage.getItem(taskDraftsSchemaKey));
+    return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function persistTaskDraftsSchemaVersion(): boolean {
+  try {
+    localStorage.setItem(taskDraftsSchemaKey, String(taskDraftsSchemaVersion));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isLegacyEditorInjectedDraft(draft: TaskDraft | undefined): boolean {

--- a/apps/web/src/features/tasks/use-task-controller.test.ts
+++ b/apps/web/src/features/tasks/use-task-controller.test.ts
@@ -20,6 +20,7 @@ afterEach(() => {
   localStorage.removeItem('a3s-code-web.active-task');
   localStorage.removeItem('a3s-work.ai-assistant.active-session');
   localStorage.removeItem('a3s-code-web.task-drafts');
+  localStorage.removeItem('a3s-code-web.task-drafts-schema');
   localStorage.removeItem('a3s-code-web.queued-prompts');
   localStorage.removeItem('a3s-code-web.paused-queues');
   localStorage.removeItem('a3s-code-web.new-task-config');
@@ -293,6 +294,50 @@ describe('task-scoped draft recovery', () => {
     expect(restored.composerContextFiles).toEqual(['src/app.ts']);
     expect(restored.composerSkills).toEqual([]);
     expect(restored.composerMode).toBe('standard');
+  });
+
+  it('clears a legacy anonymous Code draft once without removing task or Work drafts', () => {
+    const leakedWorkPrompt = '请概览当前文件夹的内容，说明主要文件、用途和最近值得关注的变化。不要修改文件。';
+    localStorage.removeItem('a3s-code-web.task-drafts-schema');
+    localStorage.setItem(
+      'a3s-code-web.task-drafts',
+      JSON.stringify({
+        [newTaskDraftKey]: {
+          content: leakedWorkPrompt,
+          contextFiles: [],
+          skillNames: [],
+        },
+        __work_ai_assistant__: {
+          content: leakedWorkPrompt,
+          contextFiles: ['Reports'],
+          skillNames: [],
+        },
+        'task-a': {
+          content: 'Keep this task draft',
+          contextFiles: ['src/app.ts'],
+          skillNames: ['review'],
+        },
+      })
+    );
+
+    const migrated = createTaskState();
+
+    expect(migrated.composerValue).toBe('');
+    expect(migrated.draftsByTask[newTaskDraftKey]).toBeUndefined();
+    expect(migrated.draftsByTask.__work_ai_assistant__?.content).toBe(leakedWorkPrompt);
+    expect(migrated.draftsByTask['task-a']?.content).toBe('Keep this task draft');
+    expect(localStorage.getItem('a3s-code-web.task-drafts-schema')).toBe('2');
+
+    persistTaskDrafts({
+      ...migrated.draftsByTask,
+      [newTaskDraftKey]: {
+        content: 'A new intentional draft',
+        contextFiles: [],
+        skillNames: [],
+      },
+    });
+
+    expect(createTaskState().composerValue).toBe('A new intentional draft');
   });
 
   it('removes the legacy editor-injected CLAUDE.md prompt instead of restoring it forever', () => {


### PR DESCRIPTION
## Summary

- invalidate the legacy anonymous Code draft once so Work assistant text leaked by older navigation flows cannot reappear on the Code home page
- preserve named task drafts and the Work assistant draft
- keep intentional anonymous drafts created after the migration

## Validation

- bun run format:check
- bun run lint:check
- bun run typecheck
- bun run test (205 files, 1194 tests)
- bun run build