### PR TITLE
feat(web): harden DeepResearch report delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,11 @@ to loopback by default.
   Centered MacBook notches are derived from native safe-area geometry and fused
   into a top-edge layout, while a dedicated handle supports manual placement
   without later recenter or expand/collapse snap-back.
-- **Evidence-First Research**: Gather bounded local evidence and materialize
-  source-backed Markdown and HTML reports
+- **Evidence-First Research**: Use the standalone, domain-agnostic DeepResearch
+  engine to gather bounded evidence, pin the report to the reader's language,
+  require cross-source analysis for comprehensive output, and materialize
+  synthesized, qualified, source-backed, or explicit no-evidence Markdown and
+  editable HTML reports
 - **Scientific Capability Packages**: Reuse the independently versioned A3S
   Science catalog of scientific Skills, MCP data services, compute workflows,
   and research tooling
@@ -158,7 +161,7 @@ to loopback by default.
 | Coding agent | A3S CLI, Code, TUI | Streaming TUI, workspace tools, sessions, context, memory, knowledge, local assets, subagents, and dynamic workflows | Model execution requires a configured provider or compatible account; remote OS actions require login |
 | Browser workspace | A3S CLI, Code Web | Local task conversations, tool approval, context, configuration, Monaco editing, Git review, and session persistence | Requires a compatible built frontend; binds to `127.0.0.1` by default; do not expose workspace APIs without an authenticated gateway |
 | Local command isolation | A3S CLI, Code | Managed SRT provider for routine workspace commands, with network denial, bounded filesystem access, scrubbed environment, timeout, streaming, and cancellation | Official CLI archives include the fixed support payload and require Node.js 20.11 or newer; source and Cargo installs may also need npm for development bootstrap |
-| Research | A3S CLI, Code, Flow | `a3s code research` runs a bounded local retrieval-summary workflow and writes Markdown and HTML report artifacts | The explicit OS research mode is reserved but currently disabled; signed-in Runtime remains available to ordinary Code workflows |
+| Research | A3S CLI, Code, Flow | CLI, TUI, and Web share the typed `a3s-deep-research` runtime and publish run-scoped Markdown and editable HTML artifacts | Evidence is admitted only from fetched text or validated workspace sources; local-only scope remains network-free |
 | Scientific packages | A3S Science | First-party scientific Skills, MCP data services, compute workflows, and research tooling | Package contracts and release cadence are owned by the independent Science repository |
 | Isolation | A3S Box | Docker-like lifecycle for Linux OCI workloads in per-workload MicroVMs | Requires a supported host and virtualization backend; CRI, TEE, and Windows paths retain platform-specific validation requirements |
 | OCI runtime foundation | A3S OCI Runtime | Versioned driver inventory with native Linux namespace/cgroup v2, Linux KVM, macOS HVF, and Windows WHPX evidence, plus the OCI create/start lifecycle state contract | Experimental: every driver remains `probe-only`; host availability does not mean that OCI workloads can launch |
@@ -417,12 +420,27 @@ a3s code research --local-only "Map this repository's release process"
 ```
 
 `research` is the canonical command; `deepresearch` and `deep-research` remain
-aliases. The command produces report artifacts instead of treating raw retrieval
-output as the final result. `--web` and `--local-only` select the evidence
+aliases. Headless CLI, TUI, and A3S Web launch the same typed
+`a3s-deep-research` runner. `--web` and `--local-only` select the evidence
 boundary explicitly; the retired `--runtime`, `--local`, and `--os` routes are
-rejected. Web research uses native AnySearch and Tavily discovery with
-DuckDuckGo, then admits only fetched source text into its closed evidence
-ledger. Provider ranking, snippets, and dates remain discovery metadata.
+rejected. Each run writes `report.md`, editable `index.html`, and a bounded
+event journal under `.a3s/research/`, keyed by an opaque run ID. Publication is
+reported as `synthesized`, `qualified`, `source_backed`, or `no_evidence`.
+
+The request language is pinned across planning, admission, and publication.
+Comprehensive reports must meet report-wide volume and diversity floors and a
+per-dimension depth gate: multi-source facts, explicit source comparison,
+mechanism or trade-off analysis, cross-source synthesis, and a supported
+implication or applicability boundary. A closed narrative plan groups admitted
+claims into natural sections and continuous prose without changing evidence.
+Source-by-source summaries, repeated openings, and near-duplicate claims cannot
+satisfy the depth gate.
+
+The self-contained HTML follows the A3S Web design system, with a left action
+menu, centered editable report, right table of contents, save and print actions,
+and a responsive stacked layout. Web report routes accept only a validated run
+ID and artifact kind; persisted events and streamed metadata never expose an
+absolute artifact path.
 
 ### Manage optional products
 

--- a/apps/docs/content/docs/en/cli/code-tui.mdx
+++ b/apps/docs/content/docs/en/cli/code-tui.mdx
@@ -489,82 +489,85 @@ PTC scripts run inside QuickJS, so they do not execute `parallel_task`
 directly. Dynamic workflows schedule a Flow step named `parallel_task`; the TUI
 host then runs the native local fan-out implementation outside QuickJS.
 
-DeepResearch uses a transient, host-managed Loop Engineering contract. One
-tool-free planner creates up to four stable research tracks, four exact provider
-queries, optional canonical seed URLs, evidence requirements, and observable
-completion criteria. The fixed stage graph then permits one initial retrieval,
-one closed semantic selection, at most one typed-coverage supplement, one closed
-obligation-review stage, Host assessment, and one durable report transaction.
-There is no maker/checker loop, adaptive route, query-generating follow-up wave,
-or hidden continuation.
+DeepResearch is implemented by the independent `a3s-deep-research` engine. The
+CLI provides model execution, Flow-backed retrieval, workspace publication, and
+progress adapters through explicit ports; planning, fallback, evidence
+admission, quality gates, and rendering have no second CLI implementation.
+Headless CLI, TUI, and A3S Web launch the engine through the same typed
+`CodeDeepResearchRunner`. The runner creates an isolated read-only Code session,
+does not expose Web tools in local-only mode, and closes that session on
+success, failure, or settled cancellation.
 
-Web queries are sent byte-for-byte through `web_search`, which inherits the
-active `config.acl` engine selection. Without an engine block it uses
-DuckDuckGo and Wikipedia; AnySearch and Tavily are opt-in. Structured provider
-failures and empty results use the generic fallback policy, and degradation
-notices remain visible in partial research metadata. Web plans have eight
-initial fetch slots and local-only plans have zero. Seed URLs enter the same
-semantic catalog as provider results without reserving a slot. A semantic
-candidate-ID decision fills the available initial slots with coverage
-opportunities and useful authoritative alternatives when enough candidates
-exist. Provider rank, title, snippet, engine, and date are discovery metadata
-only; only fetched source text can become evidence or establish a report date.
-Fetched pages, bounded document ranges, and Host-reread local ranges enter one
-closed multilingual chunk catalog.
+Every run starts exact-query bootstrap retrieval and one tool-free semantic
+outline concurrently. The outline declares `focused` or `comprehensive` scope,
+one to four evidence tracks, observable completion criteria, and at most seven
+supplemental plain-text queries. It cannot return URLs, facts, conclusions, or
+transport budgets. The engine preserves the exact query, rejects duplicate and
+URL-shaped supplements, and falls back to the unchanged query plus one generic
+track when planning is unavailable or invalid. For Web-capable requests, up to
+three explicit HTTP(S) references in the user query are normalized as direct
+fetch seeds; credential-bearing URLs are rejected, and local-only requests do
+not emit URL seeds. Named comparisons receive a shared synthesis track, while
+required question roles are validated across the complete plan.
 
-Selectors return only closed chunk IDs plus typed source/obligation relevance
-edges and full criterion/role coverage edges. Relevance keeps useful partial
-text reviewable; a criterion is covered only when the selected fetched text
-resolves every material element. Catalogs over 10 chunks
-use one complete selector per canonical source, retain at most four excerpts per
-source, and never split a source into positional windows. Each source becomes
-one accepted evidence item, keeping its claims and citations source-local.
-Missing typed coverage or evidence lost to an initial fetch/source-selection
-failure may authorize one supplement of at most two additional previously
-unselected candidates. The supplement never searches again or rewrites a query,
-and avoids a fetch-failed transport surface when a distinct candidate remains.
-The initial evidence portfolio is durably checkpointed first; if the shared
-retrieval deadline interrupts optional supplemental work, the Host validates
-and restores that exact run/query checkpoint instead of erasing completed
-material evidence.
-Questions linked to the same obligation share one closed-evidence review over
-their relevance-linked evidence plus unscoped legacy evidence before Host
-assessment and cited section generation. Models return short Host-owned
-evidence references such as `E1`; the Host maps them to exact evidence IDs per
-question. It decodes each expected question independently, so one malformed
-entry or invalid reference cannot discard a valid sibling answer. An entry that
-claims `answered` while carrying an explicit limitation is safely downgraded to
-`partial`.
+The request language is inferred once and carried as a Host-owned BCP 47 output
+language through planning, report schema, admission, and publication. Planner
+titles, research tracks, report labels, claims, analysis, and limitations use
+that language. A supplemental query may use the native language of a likely
+primary source when that improves recall, but source language never changes the
+report language.
+
+`web_search` inherits the active `config.acl` engine policy. Without an
+override, it uses DuckDuckGo and Wikipedia; AnySearch and Tavily are opt-in.
+Quota exhaustion, provider errors, and empty results use the same generic
+fallback policy, and degradation notices remain visible in run metadata.
+Provider rank, title, snippet, engine, and date are discovery metadata only.
+Only safely fetched, query-relevant source text can support a report claim.
+Planned retrieval reuses the durable bootstrap packet, searches only validated
+supplements that bootstrap did not already cover, and merges both packets under
+fixed transport and fetch budgets. Candidate admission, source sanitization,
+and publication gates are domain-agnostic.
 
 Enter `? <query>` or `? --web <query>` in the TUI. Use
 `? --local-only <query>` (or `--offline`) to enforce workspace-only evidence.
-Free-form phrases such as “do not use web” do not change scope. A successful or
-qualified run writes `.a3s/research/<slug>/report.md` and `index.html`; the HTML
-opens through a loopback-only viewer without `/login`. Insufficient or
-untraceable evidence produces an explicitly degraded Recovery report instead
-of a false completed result.
+Free-form phrases such as “do not use web” do not change scope. Once safe
+evidence exists, the engine atomically stages a source-backed `report.md` and
+`index.html` before attempting one typed claim-graph proposal. The compiler
+validates exact dimension/source/chunk IDs, facts, inferences, recommendations,
+basis and derivation edges, contradiction relations, and typed gaps. Complete
+material coverage publishes `synthesized`; supported but incomplete work can
+publish `qualified` only after passing the same depth gate and retaining a typed
+material gap. Invalid or unavailable synthesis leaves the `source_backed`
+artifact intact, while an empty safe-source set produces `no_evidence`.
 
-The report phase is closed to new evidence and validates accepted claim/source
-bindings, exact inline citations, headings, replay identity, and artifact
-quality. Every committed evidence binding requires one exact same-binding
-source citation; if the first draft misses one, the single targeted revision
-receives that uncited binding and its accepted source alternatives. Bounded
-claim excerpts control factual transcription, and ISO, English, and Chinese
-full dates must normalize to a committed claim before publication. Each
-closed review, section/revision, and editorial frame preserves source-field
-meaning and forbids unstated interval calculations, dependency-to-incompatibility
-inference, discontinuation-to-no-future-fix inference, unsupported replacement
-properties, and ecosystem-wide conclusions from a few examples. Internal
-fetch/review diagnostics stay out of the reader-facing source ledger.
-Reader-facing review, section/revision, and frame text stays in the query
-language, and a question-local evidence gap cannot become a report-wide
-absence. Each
-obligation review and report section has an independent durable
-Flow identity, completed siblings survive interruption, and the complete
-transaction shares bounded deadlines and one targeted-revision allowance.
-Every complete replacement receives exact citation alternatives for all
-bindings. Only a strict same-origin child path can be reduced to the longest
-committed parent; similar or wider URLs still fail closed.
+Comprehensive output retains a report-wide floor of five findings, six admitted
+claims, two cited sources, and 1,200 substantive characters. Every resolved
+material dimension also needs two factual findings across two sources, two
+inferences, three analytical claims, one cross-source synthesis, and 800
+substantive characters. Source comparison, mechanism or trade-off, implication,
+and applicability boundary are separate analytical obligations. Repeated
+openings, near-duplicate claims, multi-cited facts, and source-by-source
+summaries do not satisfy this gate. If every dimension remains bounded, exactly
+one deeply analyzed partial dimension may qualify only through the same
+two-source analytical chain and an explicit gap.
+
+After claim admission, a closed narrative plan selects natural headings and
+groups adjacent claim IDs without adding, rewriting, or omitting evidence. The
+renderer produces continuous prose and keeps basis and derivation edges in a
+collapsed traceability disclosure. The editable, self-contained HTML follows
+the A3S Web design tokens with a sticky left action menu, centered report, sticky
+right table of contents, save and print actions, and a responsive stacked
+layout.
+
+Artifacts are isolated by run under
+`.a3s/research/artifacts/<run-id>/report.md` and `index.html`. The bounded typed
+journal lives at `.a3s/research/runs/<run-id>/journal-v2.jsonl`; it stores
+lifecycle, stage, publication, and quality events without absolute artifact
+paths. A3S Web restores live progress from that projection and serves reports
+only through a validated `runId` plus `html` or `markdown` kind. Web context
+attachments must be existing, non-empty, non-symlink relative workspace paths.
+Selected Skills are rejected explicitly because the isolated runner does not
+load the interactive session's Skill registry.
 
 The same pipeline is available without the full-screen TUI:
 
@@ -574,8 +577,8 @@ a3s code research [--local-only|--web] <query>
 
 `research` is canonical; `deepresearch` and `deep-research` remain aliases.
 The retired `--runtime`, `--local`, and `--os` routes are rejected. The command
-writes `report.md` and `index.html` in the selected workspace and reports a
-terminal `completed`, `qualified`, or `degraded` outcome explicitly.
+writes the run-scoped artifact pair and reports exactly one publication outcome:
+`synthesized`, `qualified`, `source_backed`, or `no_evidence`.
 
 ## Updates
 

--- a/apps/docs/content/docs/en/cli/commands.mdx
+++ b/apps/docs/content/docs/en/cli/commands.mdx
@@ -14,7 +14,7 @@ behavior remains in the component that implements it.
 | Command | Behavior |
 | --- | --- |
 | `a3s code [command]` | Launch or automate A3S Code, including session resume and update compatibility paths. |
-| `a3s code research [--local-only\|--web] QUERY` | Run the host-managed DeepResearch pipeline without the full-screen TUI and write local `report.md` and `index.html` artifacts. `deepresearch` and `deep-research` remain aliases; retired runtime-selection flags are rejected. |
+| `a3s code research [--local-only\|--web] QUERY` | Run the shared typed DeepResearch engine without the full-screen TUI. Artifacts are written under `.a3s/research/artifacts/<run-id>/`, and the result distinguishes `synthesized`, `qualified`, `source_backed`, and `no_evidence`. `deepresearch` and `deep-research` remain aliases; retired runtime-selection flags are rejected. |
 | `a3s code resume <id>` | Resume a saved session by id. |
 | `a3s code resume` | Resume the newest saved session in the current workspace. |
 | `a3s code update` | Alias for the CLI self-update path. |

--- a/apps/docs/content/docs/en/code/tui.mdx
+++ b/apps/docs/content/docs/en/code/tui.mdx
@@ -104,18 +104,37 @@ fan-out, trusted runtime views, and engineered automation loops.
 | Dynamic workflows | `ultracode` and `?` DeepResearch can use `DynamicWorkflowRuntime`, a local A3S Flow-backed runtime that records workflow and step history while sandboxed PTC scripts perform tool work. |
 | Parallel work | Local fan-out uses native host-side `parallel_task`. Dynamic workflows schedule a Flow step named `parallel_task` when they need local parallel subagents; QuickJS/PTC scripts do not call `parallel_task` directly. |
 | Optional runtime tools | A3S OS can register runtime tools after `/login`; local tools and `parallel_task` remain available without an account. |
-| Deep research | Prefix a prompt with `?` to start DeepResearch. The TUI gathers a bounded web seed, then either takes a direct fast path or runs local `parallel_task` tracks and bounded follow-up rounds before synthesizing cited report artifacts. A3S OS Runtime tool-call fan-out is currently disabled for DeepResearch until Function-as-a-Service support is available. |
+| Deep research | Prefix a prompt with `?` to start the standalone evidence-first engine. Exact-query bootstrap and bounded semantic planning run concurrently, fetched evidence is published before optional synthesis, and generic fallback never depends on a topic or named entity. |
 | Asset development | `/agent`, `/mcp`, `/skill`, and `/okf` enter local development modes with an active asset, review commands, clone/draft flows, and publish/deploy/status surfaces. |
 | Workflow assets | `/flow` selects or drafts workflow DAG files for local review and optional host publication. |
 | Knowledge | `/kb` manages a local personal knowledge vault. `/okf` manages shareable OKF knowledge-package assets. |
 | Engineered loops | `/loop init`, `/loop run`, `/loop audit`, and `/loop logs` manage durable maker/checker loops under `.a3s/loops` with reports, budgets, state files, and optional runtime/view evidence. |
 | Operations | `/help` opens the command guide, `/theme` changes syntax themes, `/plugin` and `/reload` refresh skills/plugins, `Open view` reopens the latest validated local report or trusted runtime view when shown, and `/update` upgrades and restarts the CLI. |
 
-DeepResearch writes completed artifacts to
-`.a3s/research/<slug>/report.md` and `.a3s/research/<slug>/index.html`. The HTML
-uses a loopback-only, no-auth viewer that remains available while signed out. If
-evidence collection cannot support a completed source-backed report, the same
-paths hold a clearly labeled, low-confidence recovery report instead.
+DeepResearch writes progressively publishable artifacts to
+`.a3s/research/artifacts/<run-id>/report.md` and
+`.a3s/research/artifacts/<run-id>/index.html`. The independent
+`a3s-deep-research` crate owns orchestration, evidence admission, typed
+claim-graph compilation, quality gates, and rendering; CLI, TUI, and A3S Web
+share one typed runner and supply only product adapters.
+
+The request language is pinned across planning, admission, and publication.
+Comprehensive publication requires report-wide volume and source diversity plus
+a multi-step analytical chain in every resolved material dimension: multi-source
+facts, comparison, mechanism or trade-off analysis, cross-source synthesis, and
+a supported implication or applicability boundary. Repeated openings,
+near-duplicate claims, and source-by-source summaries do not satisfy that gate.
+A closed narrative plan selects natural headings and paragraph groups without
+changing evidence; rendering uses continuous prose and keeps traceability in a
+collapsed disclosure.
+
+The self-contained HTML follows A3S Web's design tokens with a sticky left
+action menu, centered editable report, sticky right table of contents, save and
+print actions, and a responsive stacked layout. Each run also records a bounded
+`.a3s/research/runs/<run-id>/journal-v2.jsonl` projection without absolute
+artifact paths. Complete material coverage publishes `synthesized`; supported
+incomplete work may publish depth-gated `qualified`; failed synthesis preserves
+`source_backed`; and an empty safe-source set produces `no_evidence`.
 
 ## Browser, Office, And OCR Through A3S Use
 
@@ -222,7 +241,7 @@ from raw source without truncating headings, code, URLs, graphemes, or cells.
 | `/tasks` | Opens live delegated-task control with search, progress/output inspection, refresh, and confirmed cancellation. |
 | `/permissions` | Searches exact session/project grants, opens canonical arguments, and revokes only after a second matching confirmation. |
 | `! <command>` | Runs a direct shell turn through the same workspace output surface. |
-| `? <question>` | Starts DeepResearch with dynamic workflow evidence gathering before synthesis. |
+| `? <question>` | Starts exact-query bootstrap and bounded semantic planning, stages a source-backed report, then optionally compiles a typed claim graph into synthesized or qualified output. |
 | `@<path>` | Attaches a workspace file through the file picker path. |
 | `/` | Opens the command palette and slash command registry. |
 | `Shift+Enter` | Inserts a newline in the input. |

--- a/apps/web/src/features/tasks/components/assistant-response.tsx
+++ b/apps/web/src/features/tasks/components/assistant-response.tsx
@@ -68,7 +68,7 @@ export function AssistantResponse({
         )}
       </div>
       <DeliverySummary sessionId={message.sessionId} events={message.events ?? []} />
-      <DeepResearchReportCard calls={toolCalls} sessionId={message.sessionId} actions={actions} />
+      <DeepResearchReportCard calls={toolCalls} sessionId={message.sessionId} />
       <ArtifactEntries calls={toolCalls} sessionId={message.sessionId} actions={actions} />
       <RecoveryNotice events={message.events ?? []} retryContent={retryContent} />
     </article>

--- a/apps/web/src/features/tasks/components/composer-match-highlight.test.ts
+++ b/apps/web/src/features/tasks/components/composer-match-highlight.test.ts
@@ -3,9 +3,9 @@ import { splitComposerMatchText } from './composer-match-highlight';
 
 describe('Composer match highlighting', () => {
   it('highlights every case-insensitive query match without changing text', () => {
-    expect(splitComposerMatchText('Report Master report workflow', 'report')).toEqual([
+    expect(splitComposerMatchText('Report reviewer report workflow', 'report')).toEqual([
       { text: 'Report', highlighted: true },
-      { text: ' Master ', highlighted: false },
+      { text: ' reviewer ', highlighted: false },
       { text: 'report', highlighted: true },
       { text: ' workflow', highlighted: false },
     ]);

--- a/apps/web/src/features/tasks/components/composer-suggestion-ranking.test.ts
+++ b/apps/web/src/features/tasks/components/composer-suggestion-ranking.test.ts
@@ -11,19 +11,19 @@ describe('Skill suggestion ranking', () => {
     const items = [
       skill('artifact-template-design-report'),
       skill('pdf', 'Create a polished report'),
-      skill('report-master'),
+      skill('report-reviewer'),
       skill('report'),
     ];
 
     expect(matchingSkills(items, 'report').map((item) => item.name)).toEqual([
       'report',
-      'report-master',
+      'report-reviewer',
       'artifact-template-design-report',
       'pdf',
     ]);
   });
 
   it('returns no unrelated Skills', () => {
-    expect(matchingSkills([skill('reviewer'), skill('report-master')], 'deploy')).toEqual([]);
+    expect(matchingSkills([skill('reviewer'), skill('report-reviewer')], 'deploy')).toEqual([]);
   });
 });

--- a/apps/web/src/features/tasks/components/deep-research-report-card.test.tsx
+++ b/apps/web/src/features/tasks/components/deep-research-report-card.test.tsx
@@ -1,32 +1,11 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, expect, it, vi } from 'vitest';
-import { appState } from '../../../state/app-state';
-import type { TaskActions } from '../task-actions';
+import { render, screen } from '@testing-library/react';
+import { expect, it } from 'vitest';
 import { DeepResearchReportCard } from './deep-research-report-card';
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  appState.sessions = [];
-});
-
-it('opens the generated HTML report safely and exposes the Markdown artifact in the workspace', () => {
-  appState.sessions = [
-    {
-      sessionId: 'session/report',
-      workspace: '/repo',
-      cwd: '/repo',
-      model: 'codex/gpt',
-      followDefaultModel: false,
-      permissionMode: 'default',
-      state: 'idle',
-      createdAt: 1,
-    },
-  ];
-  const selectFile = vi.fn(async () => undefined);
+it('opens run-scoped HTML and Markdown artifacts without accepting filesystem paths', () => {
   render(
     <DeepResearchReportCard
       sessionId='session/report'
-      actions={{ selectFile } as unknown as TaskActions}
       calls={[
         {
           id: 'deep-research-1',
@@ -36,9 +15,9 @@ it('opens the generated HTML report safely and exposes the Markdown artifact in 
           output: 'published',
           metadata: {
             report: {
-              status: 'completed',
-              htmlPath: '.a3s/research/topic/index.html',
-              markdownPath: '.a3s/research/topic/report.md',
+              runId: 'web-run-123',
+              status: 'synthesized',
+              artifactKinds: ['markdown', 'html'],
             },
           },
         },
@@ -49,11 +28,13 @@ it('opens the generated HTML report safely and exposes the Markdown artifact in 
   const report = screen.getByRole('link', { name: '打开网页版研究报告' });
   expect(report).toHaveAttribute(
     'href',
-    '/api/v1/kernel/sessions/session%2Freport/research-report?path=.a3s%2Fresearch%2Ftopic%2Findex.html'
+    '/api/v1/kernel/sessions/session%2Freport/research-artifact?runId=web-run-123&kind=html'
   );
   expect(report).toHaveAttribute('target', '_blank');
-  expect(screen.getByText('质量门槛已通过')).toBeInTheDocument();
+  expect(screen.getByText('综合报告已通过质量门槛')).toBeInTheDocument();
 
-  fireEvent.click(screen.getByRole('button', { name: '在工作区打开 Markdown 研究报告' }));
-  expect(selectFile).toHaveBeenCalledWith({ path: '/repo/.a3s/research/topic/report.md', isBinary: false });
+  expect(screen.getByRole('link', { name: '打开 Markdown 研究报告' })).toHaveAttribute(
+    'href',
+    '/api/v1/kernel/sessions/session%2Freport/research-artifact?runId=web-run-123&kind=markdown'
+  );
 });

--- a/apps/web/src/features/tasks/components/deep-research-report-card.tsx
+++ b/apps/web/src/features/tasks/components/deep-research-report-card.tsx
@@ -1,24 +1,17 @@
 import { ExternalLink, FileText, SearchCheck } from 'lucide-react';
-import { Button } from '../../../design-system/primitives';
-import { appState } from '../../../state/app-state';
-import { workspaceAbsolutePath } from '../../workspace/workspace-state';
-import type { TaskActions } from '../task-actions';
 import type { ToolCallProjection } from './tool-call-projection';
 
 interface DeepResearchReport {
-  status: 'completed' | 'qualified' | 'degraded';
-  htmlPath: string;
-  markdownPath: string;
+  status: 'synthesized' | 'qualified' | 'source_backed' | 'no_evidence';
+  runId: string;
 }
 
 export function DeepResearchReportCard({
   calls,
   sessionId,
-  actions,
 }: {
   calls: readonly ToolCallProjection[];
   sessionId: string;
-  actions: TaskActions;
 }) {
   const report = calls
     .filter((call) => call.name === 'deep_research' && call.state === 'succeeded')
@@ -26,10 +19,8 @@ export function DeepResearchReportCard({
     .find((candidate): candidate is DeepResearchReport => Boolean(candidate));
   if (!report) return null;
 
-  const sessionRoot = appState.sessions.find((session) => session.sessionId === sessionId)?.workspace;
-  const href = `/api/v1/kernel/sessions/${encodeURIComponent(sessionId)}/research-report?path=${encodeURIComponent(
-    report.htmlPath
-  )}`;
+  const htmlHref = researchArtifactHref(sessionId, report.runId, 'html');
+  const markdownHref = researchArtifactHref(sessionId, report.runId, 'markdown');
   const status = reportStatus(report.status);
 
   return (
@@ -42,20 +33,11 @@ export function DeepResearchReportCard({
         <small>{status}</small>
       </span>
       <span className='deep-research-report-actions'>
-        <Button
-          tone='quiet'
-          aria-label='在工作区打开 Markdown 研究报告'
-          onClick={() => {
-            void actions.selectFile({
-              path: workspaceAbsolutePath(report.markdownPath, sessionRoot || appState.workspaceRoot),
-              isBinary: false,
-            });
-          }}
-        >
+        <a href={markdownHref} target='_blank' rel='noopener noreferrer' aria-label='打开 Markdown 研究报告'>
           <FileText size={13} />
           Markdown
-        </Button>
-        <a href={href} target='_blank' rel='noopener noreferrer' aria-label='打开网页版研究报告'>
+        </a>
+        <a href={htmlHref} target='_blank' rel='noopener noreferrer' aria-label='打开网页版研究报告'>
           <ExternalLink size={13} />
           打开网页
         </a>
@@ -67,21 +49,28 @@ export function DeepResearchReportCard({
 function reportFromCall(call: ToolCallProjection): DeepResearchReport | null {
   const report = recordValue(call.metadata?.report);
   const status = stringValue(report?.status);
-  const htmlPath = stringValue(report?.htmlPath);
-  const markdownPath = stringValue(report?.markdownPath);
-  if (!['completed', 'qualified', 'degraded'].includes(status ?? '') || !htmlPath || !markdownPath) return null;
-  if (!isResearchArtifact(htmlPath, 'index.html') || !isResearchArtifact(markdownPath, 'report.md')) return null;
-  return { status: status as DeepResearchReport['status'], htmlPath, markdownPath };
+  const runId = stringValue(report?.runId);
+  const artifactKinds = stringArray(report?.artifactKinds);
+  if (!['synthesized', 'qualified', 'source_backed', 'no_evidence'].includes(status ?? '') || !runId) return null;
+  if (!isRunId(runId) || !artifactKinds.includes('html') || !artifactKinds.includes('markdown')) return null;
+  return { status: status as DeepResearchReport['status'], runId };
 }
 
-function isResearchArtifact(path: string, fileName: string): boolean {
-  return path.startsWith('.a3s/research/') && path.endsWith(`/${fileName}`) && !path.split('/').includes('..');
+function researchArtifactHref(sessionId: string, runId: string, kind: 'html' | 'markdown'): string {
+  return `/api/v1/kernel/sessions/${encodeURIComponent(sessionId)}/research-artifact?runId=${encodeURIComponent(
+    runId
+  )}&kind=${kind}`;
+}
+
+function isRunId(value: string): boolean {
+  return value.length <= 128 && /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value);
 }
 
 function reportStatus(status: DeepResearchReport['status']): string {
-  if (status === 'completed') return '质量门槛已通过';
+  if (status === 'synthesized') return '综合报告已通过质量门槛';
   if (status === 'qualified') return '证据充分，建议复核限定条件';
-  return '来源快照已生成，结论仍需复核';
+  if (status === 'source_backed') return '已保留来源报告，综合结论未通过准入';
+  return '未取得可安全发布的证据';
 }
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {
@@ -90,4 +79,8 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }

--- a/apps/web/src/features/tasks/components/execution-stream-rendering.test.tsx
+++ b/apps/web/src/features/tasks/components/execution-stream-rendering.test.tsx
@@ -260,9 +260,9 @@ describe('ExecutionStream rendering and recovery', () => {
             exit_code: 0,
             metadata: {
               report: {
-                status: 'completed',
-                htmlPath: '.a3s/research/topic/index.html',
-                markdownPath: '.a3s/research/topic/report.md',
+                runId: 'web-execution-rendering',
+                status: 'synthesized',
+                artifactKinds: ['markdown', 'html'],
               },
             },
           },

--- a/apps/web/src/features/tasks/components/task-composer.tsx
+++ b/apps/web/src/features/tasks/components/task-composer.tsx
@@ -61,6 +61,12 @@ export function TaskComposer({
   };
   return (
     <div className={`task-composer-dock ${variant}`}>
+      {turnQueue?.research?.lifecycle === 'running' && (
+        <output className='deep-research-refresh-status'>
+          <SearchCheck size={14} />
+          <span>深度研究运行中 · {researchStageLabel(turnQueue.research.stage)}</span>
+        </output>
+      )}
       {queue.length > 0 && (
         <FollowUpQueue
           items={queue as unknown as QueuedTurn[]}
@@ -172,6 +178,25 @@ export function TaskComposer({
       </div>
     </div>
   );
+}
+
+function researchStageLabel(stage?: string | null): string {
+  switch (stage) {
+    case 'planning':
+      return '规划研究问题';
+    case 'bootstrap_retrieval':
+      return '收集初始证据';
+    case 'planned_retrieval':
+      return '检索计划证据';
+    case 'source_publication':
+      return '固化来源证据';
+    case 'report_generation':
+      return '生成研究报告';
+    case 'final_publication':
+      return '发布最终产物';
+    default:
+      return '初始化运行环境';
+  }
 }
 
 function FollowUpQueue({

--- a/apps/web/src/features/tasks/use-task-controller.test.ts
+++ b/apps/web/src/features/tasks/use-task-controller.test.ts
@@ -41,8 +41,8 @@ describe('task file context protocol', () => {
   });
 
   it('adds explicit Skill directives without leaking the picker query', () => {
-    expect(composeTaskPrompt('Review this change', ['src/app.ts'], ['report-master'])).toBe(
-      '[Selected skills]\n- Use your `report-master` skill.\n[/Selected skills]\n\n[Workspace context files]\n- src/app.ts\n[/Workspace context files]\n\nReview this change'
+    expect(composeTaskPrompt('Review this change', ['src/app.ts'], ['reviewer'])).toBe(
+      '[Selected skills]\n- Use your `reviewer` skill.\n[/Selected skills]\n\n[Workspace context files]\n- src/app.ts\n[/Workspace context files]\n\nReview this change'
     );
   });
 });

--- a/apps/web/src/styles/task-surface.css
+++ b/apps/web/src/styles/task-surface.css
@@ -692,7 +692,8 @@
   background: color-mix(in srgb, var(--a3s-blue) 6%, var(--a3s-panel));
 }
 
-.deep-research-report-card.degraded {
+.deep-research-report-card.source_backed,
+.deep-research-report-card.no_evidence {
   border-color: color-mix(in srgb, var(--a3s-warning) 42%, var(--a3s-line));
   background: color-mix(in srgb, var(--a3s-warning) 7%, var(--a3s-panel));
 }
@@ -757,6 +758,20 @@
 .task-composer-dock.active {
   padding: 20px 30px 18px;
   background: linear-gradient(0deg, var(--a3s-panel) 74%, transparent);
+}
+
+.deep-research-refresh-status {
+  display: flex;
+  width: min(800px, 100%);
+  align-items: center;
+  gap: 7px;
+  margin: 0 auto 8px;
+  padding: 7px 11px;
+  border: 1px solid color-mix(in srgb, var(--a3s-blue) 24%, var(--a3s-line));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--a3s-blue) 5%, var(--a3s-panel));
+  color: var(--a3s-muted);
+  font-size: 10px;
 }
 
 .task-composer.active {

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -921,6 +921,7 @@ export interface QueuedTurn {
   contextFiles: string[];
   skillNames: string[];
   mode?: QueuedTurnMode;
+  researchRunId?: string | null;
   priority: number;
   enqueuedAt: number;
 }
@@ -935,6 +936,16 @@ export interface TurnQueue {
   status: 'idle' | 'pending' | 'running' | 'paused';
   paused: boolean;
   active?: ActiveTurn | null;
+  research?: {
+    schemaVersion: 2;
+    runId: string;
+    sequence?: number;
+    recordedAt?: string;
+    lifecycle: 'running' | 'completed' | 'cancelled' | 'failed';
+    stage?: string | null;
+    publication?: 'synthesized' | 'qualified' | 'source_backed' | 'no_evidence' | null;
+    quality?: Record<string, number | string> | null;
+  } | null;
   items: QueuedTurn[];
   total: number;
   nextItemId?: string | null;


### PR DESCRIPTION
## Summary
- restore run-scoped DeepResearch progress after page refresh
- serve Markdown and editable HTML reports by validated run ID instead of filesystem path
- align report statuses and documentation with the shared evidence-first runtime
- remove remaining report-master examples from Web tests

## Validation
- 206 Vitest files / 1,233 tests
- TypeScript typecheck
- Biome lint and format checks
- production build