### PR TITLE
fix(web): keep PDF live preview at panel height

### DIFF
--- a/apps/web/src/features/work/components/work-live-preview-layout.test.ts
+++ b/apps/web/src/features/work/components/work-live-preview-layout.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const livePreviewStyles = readFileSync(resolve(process.cwd(), 'src/styles/work-live-preview.css'), 'utf8');
+
+describe('Work live preview layout', () => {
+  it('keeps the complete PDF renderer chain at the panel height', () => {
+    expect(livePreviewStyles).toMatch(/\.work-live-preview-document\s*\{[^}]*\n\s*height:\s*100%;/s);
+    expect(livePreviewStyles).toMatch(
+      /\.work-live-preview-document > \.work-pdf-viewer,\s*\.work-live-preview-document \.work-pdf-embed,\s*\.work-live-preview-document \.work-pdf-native-viewer,\s*\.work-live-preview-document embedpdf-container\s*\{[^}]*height:\s*100%;/s
+    );
+  });
+});

--- a/apps/web/src/styles/work-live-preview.css
+++ b/apps/web/src/styles/work-live-preview.css
@@ -276,6 +276,7 @@
 
 .work-live-preview-document {
   min-width: 0;
+  height: 100%;
   min-height: 100%;
   background: var(--a3s-panel);
 }
@@ -290,6 +291,13 @@
 .work-live-preview-document > .work-quick-look-artifact,
 .work-live-preview-document > .work-pdf-viewer {
   min-height: 100%;
+}
+
+.work-live-preview-document > .work-pdf-viewer,
+.work-live-preview-document .work-pdf-embed,
+.work-live-preview-document .work-pdf-native-viewer,
+.work-live-preview-document embedpdf-container {
+  height: 100%;
 }
 
 .work-live-preview-loading,


### PR DESCRIPTION
## Summary

- give the Live Preview document surface a definite height
- propagate that height through the EmbedPDF renderer chain
- add a CSS regression test for the full PDF layout chain

## Release QA

The public v0.10.12 binary rendered the PDF toolbar at only 71px while the preview stage was 422px. With this patch, the document surface, PDF viewer, embed wrapper, native viewer, and `embedpdf-container` all measure 422px in a real browser session.

## Validation

- `bun run format:check`
- `bun run lint:check`
- `bun run typecheck`
- `bun run build`
- `bun run test` (205 files, 1,230 tests)