### PR TITLE
fix(update): bridge legacy SRT archive checks

### DIFF
--- a/.github/workflows/a3s-cli-release.yml
+++ b/.github/workflows/a3s-cli-release.yml
@@ -552,7 +552,7 @@ jobs:
           bin: a3s
           target: ${{ matrix.target }}
           archive: a3s-$tag-$target
-          include: web,${{ matrix.helper }}
+          include: web,release-compat,${{ matrix.helper }}
           tar: all
           zip: windows
           checksum: sha256
@@ -598,6 +598,27 @@ jobs:
               exit 1
             fi
           done
+          bridge_root='release-compat/support/managed-srt'
+          bridge_lock="${bridge_root}/package-lock.json"
+          bridge_cli="${bridge_root}/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js"
+          tar_entries="$(tar -tzf "${base}.tar.gz")"
+          for bridge_path in "$bridge_lock" "$bridge_cli"; do
+            bridge_count="$(grep -Ec "(^|/)${bridge_path}$" <<<"$tar_entries" || true)"
+            if [[ "$bridge_count" -ne 1 ]]; then
+              echo "::error::Release archive must contain exactly one legacy self-update bridge path ${bridge_path}; found ${bridge_count}"
+              exit 1
+            fi
+          done
+          if [[ "$RELEASE_TARGET" == "x86_64-pc-windows-msvc" ]]; then
+            zip_entries="$(unzip -Z1 "${base}.zip")"
+            for bridge_path in "$bridge_lock" "$bridge_cli"; do
+              bridge_count="$(grep -Ec "(^|/)${bridge_path}$" <<<"$zip_entries" || true)"
+              if [[ "$bridge_count" -ne 1 ]]; then
+                echo "::error::Windows release archive must contain exactly one legacy self-update bridge path ${bridge_path}; found ${bridge_count}"
+                exit 1
+              fi
+            done
+          fi
           gh release upload "$tag" "${assets[@]}" --clobber
 
   crate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored self-updates from A3S 0.9.9 through 0.10.10 by shipping an inert
+  compatibility marker for their retired managed-SRT archive validation. The
+  marker contains no sandbox runtime and always fails closed if invoked.
+
 ## [0.11.0] - 2026-07-29
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities"]
 include = [
     "src/**",
     "tests/**",
+    "!tests/legacy_self_update_bridge.rs",
     "skills/**",
     "build.rs",
     "Cargo.toml",
@@ -19,6 +20,7 @@ include = [
     "CHANGELOG.md",
     "README.md",
     "LICENSE",
+    "!release-compat/**",
 ]
 
 [[bin]]

--- a/release-compat/README.md
+++ b/release-compat/README.md
@@ -1,0 +1,12 @@
+# Legacy self-update bridge
+
+This directory is included only in release archives.
+
+A3S 0.9.9 through 0.10.10 required every self-update archive to contain a
+`support/managed-srt` tree before they would install the new binary. A3S 0.10.11
+removed the Anthropic SRT runtime, so omitting that tree made those older
+clients unable to update themselves.
+
+The nested package is an inert, fail-closed compatibility marker. Current A3S
+versions do not discover or execute it, and it must never acquire sandbox
+runtime dependencies or implementation code.

--- a/release-compat/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js
+++ b/release-compat/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+"use strict";
+
+process.stderr.write(
+  "Anthropic SRT was removed from A3S. This inert file exists only so legacy A3S self-updaters can install the current release.\n",
+);
+process.exitCode = 1;

--- a/release-compat/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/package.json
+++ b/release-compat/support/managed-srt/node_modules/@anthropic-ai/sandbox-runtime/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@anthropic-ai/sandbox-runtime",
+  "version": "0.0.0-a3s-retired",
+  "private": true,
+  "description": "Inert compatibility marker; Anthropic SRT is not bundled",
+  "bin": {
+    "sandbox-runtime": "dist/cli.js"
+  }
+}

--- a/release-compat/support/managed-srt/package-lock.json
+++ b/release-compat/support/managed-srt/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "a3s-managed-srt-retirement-bridge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "a3s-managed-srt-retirement-bridge",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.0-a3s-retired"
+      }
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime": {
+      "name": "@anthropic-ai/sandbox-runtime",
+      "version": "0.0.0-a3s-retired",
+      "bin": {
+        "sandbox-runtime": "dist/cli.js"
+      }
+    }
+  }
+}

--- a/release-compat/support/managed-srt/package.json
+++ b/release-compat/support/managed-srt/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "a3s-managed-srt-retirement-bridge",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Inert release marker for legacy A3S self-updaters",
+  "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "0.0.0-a3s-retired"
+  }
+}

--- a/tests/legacy_self_update_bridge.rs
+++ b/tests/legacy_self_update_bridge.rs
@@ -1,0 +1,75 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+const RETIRED_PACKAGE_VERSION: &str = "0.0.0-a3s-retired";
+
+fn repository_path(relative: impl AsRef<Path>) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+#[test]
+fn bridge_matches_the_legacy_updater_contract_and_fails_closed() {
+    let root = repository_path("release-compat/support/managed-srt");
+    let package_path = root.join("node_modules/@anthropic-ai/sandbox-runtime/package.json");
+    let package: Value = serde_json::from_slice(&fs::read(&package_path).unwrap()).unwrap();
+    assert_eq!(
+        package.get("name").and_then(Value::as_str),
+        Some("@anthropic-ai/sandbox-runtime")
+    );
+    assert_eq!(
+        package.get("version").and_then(Value::as_str),
+        Some(RETIRED_PACKAGE_VERSION)
+    );
+
+    let lock_path = root.join("package-lock.json");
+    let lock: Value = serde_json::from_slice(&fs::read(&lock_path).unwrap()).unwrap();
+    assert_eq!(lock.get("lockfileVersion").and_then(Value::as_u64), Some(3));
+    assert_eq!(
+        lock.pointer("/packages/node_modules~1@anthropic-ai~1sandbox-runtime/version")
+            .and_then(Value::as_str),
+        Some(RETIRED_PACKAGE_VERSION)
+    );
+    assert_eq!(
+        lock.pointer("/packages//dependencies/@anthropic-ai~1sandbox-runtime")
+            .and_then(Value::as_str),
+        Some(RETIRED_PACKAGE_VERSION)
+    );
+
+    let cli_path = root.join("node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js");
+    let cli = fs::read_to_string(&cli_path).unwrap();
+    assert!(cli.contains("Anthropic SRT was removed from A3S"));
+    assert!(cli.contains("process.exitCode = 1"));
+    for forbidden in ["child_process", "require(", "import ", "eval("] {
+        assert!(
+            !cli.contains(forbidden),
+            "bridge must not contain {forbidden}"
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_ne!(
+            fs::metadata(cli_path).unwrap().permissions().mode() & 0o111,
+            0
+        );
+    }
+}
+
+#[test]
+fn release_workflow_packages_and_verifies_the_bridge() {
+    let workflow =
+        fs::read_to_string(repository_path(".github/workflows/a3s-cli-release.yml")).unwrap();
+    assert!(workflow.contains("include: web,release-compat,${{ matrix.helper }}"));
+    assert!(workflow.contains("bridge_root='release-compat/support/managed-srt'"));
+    assert!(workflow.contains("bridge_lock=\"${bridge_root}/package-lock.json\""));
+    assert!(workflow.contains(
+        "bridge_cli=\"${bridge_root}/node_modules/@anthropic-ai/sandbox-runtime/dist/cli.js\""
+    ));
+
+    let manifest = fs::read_to_string(repository_path("Cargo.toml")).unwrap();
+    assert!(manifest.contains("\"!tests/legacy_self_update_bridge.rs\""));
+    assert!(manifest.contains("\"!release-compat/**\""));
+}


### PR DESCRIPTION
## Summary

- ship an inert, fail-closed managed-SRT compatibility marker only in GitHub binary archives
- verify every tarball and Windows ZIP contains exactly one legacy bridge path
- exclude the archive-only marker and its repository integration test from the crates.io package
- document restored self-updates for A3S 0.9.9 through 0.10.10

## Validation

- `cargo test --test legacy_self_update_bridge`
- `cargo fmt --all -- --check`
- `bash .github/scripts/check-cli-integration.sh`
- `cargo package --allow-dirty --list` (bridge and repository-only test absent)
- bridge stub exits 1 and writes only the retirement message