### PR TITLE
release: prepare a3s 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-07-29
+
 ### Fixed
 
 - Restored self-updates from A3S 0.9.9 through 0.10.10 by shipping an inert

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "a3s"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "a3s-acl 0.2.2",
  "a3s-boot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "a3s — A3S coding agent CLI; `a3s code` launches the interactive TUI"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -287,10 +287,11 @@ Use Cargo when a binary-only installation is intentional:
 cargo install a3s
 ~~~
 
-Cargo does not bundle the complete Web workspace, WebView helper, or managed
-sandbox support tree. When networking and automatic setup are allowed, the CLI
-can install exact-version managed components on first use. `A3S_OFFLINE=1` and
-`A3S_NO_AUTO_INSTALL=1` keep that boundary at zero network and zero mutation.
+Cargo does not bundle the complete Web workspace or WebView helper. When
+networking and automatic setup are allowed, the CLI can install exact-version
+managed components on first use. Local Bash uses the built-in Rust guardrail;
+no installation type downloads a local process sandbox. `A3S_OFFLINE=1` and
+`A3S_NO_AUTO_INSTALL=1` keep automatic setup at zero network and zero mutation.
 
 <details>
 <summary><strong>What the release installers verify</strong></summary>
@@ -313,6 +314,10 @@ Supported controls include `A3S_VERSION`, `A3S_INSTALL_DIR`, `A3S_DATA_HOME`,
 On macOS and Linux, a standalone installation can check or apply CLI updates
 with `a3s self update --check` and `a3s self update`. Homebrew-managed
 installations should use Homebrew.
+
+Standalone versions 0.9.9 through 0.10.10 can update directly to 0.11.1 or
+later through the retained `A3S-Lab/CLI` compatibility endpoint. The update
+then switches future release checks to this repository.
 
 ## Repository map
 

--- a/apps/docs/content/docs/en/cli/code-tui.mdx
+++ b/apps/docs/content/docs/en/cli/code-tui.mdx
@@ -101,50 +101,33 @@ The TUI can also branch and reset state from inside the session:
 | `/auto` | Selects non-interactive Auto mode for future submissions. Calls run only while every check keeps them inside the active boundary. Any confirmation request, including a tool-owned request, is rejected before HITL. Running and queued turns retain their submission-time mode. |
 | `/exit` | Persists session state and quits. |
 
-## Execution Modes And Local Sandbox
+## Execution Modes And Host Guardrail
 
-The TUI separates process confinement from approval routing:
+The TUI separates command classification from approval routing:
 
-| Mode | Inside the established boundary | Outside the boundary |
+| Mode | Quiet execution | Boundary crossing |
 | --- | --- | --- |
-| Default | Workspace writes, governed orchestration, and sandboxed Bash run without repeated prompts. | Explicit host escalation, missing-sandbox Bash, protected control metadata, mutating Git operations, and annotated external side effects require approval. |
+| Default | Workspace writes, governed orchestration, and Bash that the Rust guardrail proves read-only run without repeated prompts. | Unproven host Bash, protected control metadata, mutating Git operations, and annotated external side effects require approval. |
 | Plan | Read-only discovery tools remain available. | File mutation, Bash, and escalation are denied. Approved implementation starts as a new Default turn. |
-| Auto | Uses the same workspace and process sandbox as Default. | Never enters HITL; escape requests and missing-sandbox Bash fail closed. |
+| Auto | Uses the same workspace tools and Rust-proven read-only Bash as Default. | Never enters HITL; unproven Bash and hard policy denials fail closed. |
 
 Permission and confirmation routing are frozen when Core admits a run.
 Delegated, parallel, Skill, and background descendants keep that exact mode
 snapshot after the composer advances to another turn.
 
-Before terminal takeover, `a3s code` reuses a verified user-wide managed SRT
-installation or the immutable support tree shipped in an official release.
-Source builds can prepare the exact supported package when networking and
-automatic first-use setup are allowed. Preparation requires Node.js 20.11 or
-newer and npm, disables package lifecycle scripts, validates registry integrity
-and the complete installed tree, and atomically activates the runtime under the
-A3S component data root. A global `srt` installation is neither required nor
-selected.
+The CLI does not install or launch a local process sandbox. Bash uses the active
+workspace backend's host command runner with the workspace as its current
+directory. The shared Rust guardrail rejects known critical commands and proves
+a narrow read-only subset by inspecting command structure, options, paths,
+pipelines, expansion, redirection, and workspace symlinks. Credential and
+control paths such as `.env*`, `.git/`, `.a3s/`, and SSH keys remain hard
+denials even when an older exact grant exists.
 
-The JavaScript payload does not replace native OS facilities. macOS requires
-`sandbox-exec` and `ripgrep`; Linux requires `bubblewrap`, `socat`, `ripgrep`,
-and permitted unprivileged user namespaces. Homebrew declares these
-dependencies; direct-archive users provide them. Windows requires the one-time
-elevated machine sandbox setup. The TUI performs a 15-second command probe
-through the real OS boundary before marking the sandbox ready.
-
-The sandbox denies command networking, local listeners, and Unix sockets;
-limits writes to the active workspace and a private scratch directory;
-protects repository and agent-control metadata; blocks common credential
-reads; removes shell, dynamic-loader, Node, Python, Ruby, Perl, Lua, and JVM
-bootstrap injection variables; denies existing `.env*` files at every governed
-source-tree depth; masks pre-existing multi-link source files for reads and
-writes; and passes a scrubbed environment. Stdout and stderr remain separate
-under one global byte limit. A command deadline covers
-both output draining and process exit, and timeout or cancellation kills the
-Unix process group, including descendants. There is no unsandboxed fallback:
-offline mode and `A3S_NO_AUTO_INSTALL=1` can reuse a verified installation but
-cannot prepare one. If setup is unavailable or fails, the startup warning
-explains that Default will ask for exact host Bash execution and Auto will deny
-Bash.
+Command deadlines cover output draining and process exit. Timeout,
+cancellation, or TUI shutdown terminates the command process group, including
+descendants, while stdout and stderr remain separately streamed under one
+global byte limit. Official archives and Homebrew installations carry no
+Node.js sandbox payload and require no sandbox-specific operating-system tools.
 
 In-process workspace tools use the corresponding Core credential policy.
 Direct and range reads, writes, edits, patches, and both manifest-backed and
@@ -156,11 +139,11 @@ Read-only Git diff regenerates output only for allowed changed paths;
 option-like revisions cannot become Git flags, and displayed remotes omit
 embedded HTTP credentials and query tokens.
 
-Release publication is gated on real macOS and Linux execution of the exact
-generated payload. The test proves workspace writes and ordinary offline
-toolchain commands succeed, while outside and symlink writes, protected
-metadata, credential reads, network egress, local listeners, and Unix sockets
-remain blocked.
+The Rust guardrail has direct tests and an opt-in real-LLM integration test.
+Together they verify that Default quietly executes a proven read-only command,
+unproven redirection enters approval without creating its target, Auto denies
+unproven Bash without HITL, protected credentials remain unreadable, and Plan
+does not expose Bash to the execution turn.
 
 The same ownership rule covers host bootstrap helpers. Managed npm and Node
 probes, live capability-registry commands, and account-backed model CLI
@@ -168,18 +151,13 @@ requests run in dedicated Unix process groups. Their timeout, cancellation, or
 TUI shutdown path terminates descendants and performs a bounded wait; closing
 stdout early cannot detach a helper from cancellation.
 
-Tasks, Skills, and dynamic workflows inherit the same sandbox and parent
+Tasks, Skills, and dynamic workflows inherit the same guardrail and parent
 confirmation boundary. Child-local confirmation behavior resolves only
 child-local `Ask` decisions; parent or tool-owned escalations remain governed
 by the parent provider. One cancelled or expired invocation settles only its
-own confirmation, and terminal confirmation timeouts always reject. Use this
-lightweight local boundary for routine
-repository commands. Route dependency-heavy, untrusted, OCI, and
+own confirmation, and terminal confirmation timeouts always reject. Host Bash
+is not an isolation boundary; route dependency-heavy, untrusted, OCI, and
 stronger-isolation workloads to A3S Box or an A3S Runtime provider.
-
-The npm preparation path is a source-development fallback. Official archives,
-Homebrew, and standalone updates carry the release-owned support tree without
-changing Code's sandbox interface or execution modes.
 
 ## Runtime Boundaries
 

--- a/apps/docs/content/docs/en/cli/updates.mdx
+++ b/apps/docs/content/docs/en/cli/updates.mdx
@@ -47,6 +47,12 @@ remains roadmap work, while the registered WebView component has a verified
 Windows x86_64 release and managed first-use lifecycle. WSL follows the Linux
 contract.
 
+Standalone A3S 0.9.9 through 0.10.10 read the former `A3S-Lab/CLI` release
+endpoint and require a retired managed-SRT package marker before replacing the
+binary. Version 0.11.1 and later canonical archives carry an inert, fail-closed
+four-file marker and are relayed byte for byte to that endpoint. After this
+one-time update, the installed CLI reads future releases from `A3S-Lab/a3s`.
+
 ## Component Upgrades
 
 `a3s upgrade` with no IDs is read-only. Select IDs explicitly, or use `--all`

--- a/apps/docs/content/docs/en/code/security.mdx
+++ b/apps/docs/content/docs/en/code/security.mdx
@@ -11,44 +11,34 @@ session lifecycle hooks. Treat direct host calls such as `session.tool()` and
 is responsible for deciding whether to expose that power to a user.
 
 Delegated child runs intersect their local permissions with the parent
-permission checker and inherit the parent process sandbox. A child can narrow
-its capabilities but cannot replace the host boundary. Child-local approval
-behavior applies only to an `Ask` introduced by the child policy; a parent
-`Ask`, or a tool-owned escalation after both policies allow, remains under the
-parent confirmation provider. Missing providers fail closed before a HITL
-request is emitted. Keep high-risk release or publish commands behind explicit
-policy.
+permission checker and inherit any process sandbox supplied by the host. A
+child can narrow its capabilities but cannot replace the host boundary.
+Child-local approval behavior applies only to an `Ask` introduced by the child
+policy; a parent `Ask`, or a tool-owned escalation after both policies allow,
+remains under the parent confirmation provider. Missing providers fail closed
+before a HITL request is emitted. Keep high-risk release or publish commands
+behind explicit policy.
 
-## Enforced Execution Boundary
+## Command Governance And Optional Confinement
 
 Permission policy decides whether an operation is allowed, denied, or needs
-approval. It does not, by itself, confine a process. Hosts that expose model
-Bash should attach a concrete `BashSandbox`; otherwise an approved command runs
-through the host workspace runner.
+approval. It does not, by itself, confine a process. Hosts can attach a concrete
+`BashSandbox`; otherwise an approved command runs through the host workspace
+runner.
 
-The Code TUI uses an SRT-backed local process sandbox from a verified user-wide
-installation or the support tree shipped in the CLI release. It checks the
-exact package graph, registry lock, file types, size bounds, complete normalized
-tree digest, Node.js 20.11-or-newer executable, and Core capability handshake.
-Official archives, Homebrew, and standalone self-update preserve that payload.
-Source and Cargo installs may use a fixed npm development bootstrap with
-lifecycle scripts disabled. A global `srt` installation is neither required
-nor selected.
+The Code TUI intentionally does not install or attach a local process sandbox.
+Bash runs through the active workspace's host command runner with the workspace
+as its current directory. One shared Rust guardrail rejects known critical
+commands and proves a deliberately small read-only subset by checking command
+structure, options, paths, pipelines, expansion, redirection, and workspace
+symlinks. Default asks before an unproven command; Plan denies Bash; Auto admits
+only the proven read-only subset and denies the rest without entering HITL.
 
-Package verification is necessary but not sufficient for readiness. macOS
-requires `sandbox-exec` and `ripgrep`; Linux requires `bubblewrap`, `socat`,
-`ripgrep`, and permitted unprivileged user namespaces. Homebrew declares those
-dependencies, while direct-archive users provide them. Windows requires its
-one-time elevated machine sandbox setup. The TUI runs a bounded command through
-the actual OS boundary before attaching it. Failure leaves the sandbox absent,
-so Default can request one exact host invocation and Auto denies Bash.
-
-The adapter fails closed and never silently retries on the host. It denies
-network egress, local binding, and Unix sockets; limits writes to the workspace
-and a private scratch directory; protects `.git`, `.a3s`, `.agents`, `.codex`,
-`.claude`, `.vscode`, `.idea`, and control files; masks common credential
-stores; and scrubs ambient secrets. Delegated tasks, Skills, and workflow steps
-retain the same handle.
+Credential and control paths such as `.env*`, `.git/`, `.a3s/`, and SSH keys
+remain hard denials even when an older exact grant exists. Command deadlines,
+process-group cancellation, bounded output, streaming deltas, and explicit
+environment values are enforced by the host runner. Delegated tasks, Skills,
+and workflow steps retain the same guardrail and parent confirmation boundary.
 
 Because built-in file tools execute in-process, the TUI separately enables
 Core's local workspace credential policy. It covers direct and range reads,
@@ -60,36 +50,36 @@ credential inode. Read-only Git diff regenerates output only for allowed
 changed paths, option-like revisions cannot become Git flags, and displayed
 remotes omit embedded HTTP credentials and query tokens.
 
-The release gate exercises the exact generated support tree on macOS and Linux.
-It proves normal workspace writes and offline toolchain commands remain usable,
-while outside and symlink writes, protected metadata mutations, credential
-reads, network egress, local listeners, and Unix sockets remain blocked.
+The Rust classifier has direct tests and an opt-in real-LLM integration test.
+Together they verify that a read-only command can execute quietly, shell
+redirection enters approval without creating its target, Auto denies unproven
+Bash without HITL, credential reads fail closed, and Plan does not expose Bash
+to the execution turn.
 
-The terminal execution modes apply this boundary as follows:
+The terminal execution modes apply this policy as follows:
 
 | Mode | Process behavior | Approval behavior |
 | --- | --- | --- |
-| Default | Ordinary Bash runs in the installed sandbox. | Only an explicit host escape, missing sandbox, protected metadata mutation, mutating Git call, or annotated external side effect asks. |
+| Default | Rust-proven read-only Bash runs through the host workspace runner. | Unproven Bash, mutating Git, protected metadata changes, and annotated external side effects ask; critical commands and credential/control paths are denied. |
 | Plan | Bash and mutations are unavailable. | Boundary crossings are denied, not queued for later execution. |
-| Auto | Ordinary Bash runs only in the installed sandbox. | HITL is disabled; any operation that cannot stay inside the boundary is denied. |
+| Auto | Rust-proven read-only Bash runs through the host workspace runner. | HITL is disabled; unproven Bash and every operation that would ask are denied. |
 
 ## Threat Model
 
 The protected assets are host files outside the active workspace, repository
-and agent-control metadata, credential stores, host network and listener
-capabilities, process lifetime, and the user's authority to approve a specific
-operation. Model output, repository content, command output, fetched content,
-Skill instructions, and MCP results are untrusted inputs. A malicious
-dependency or child process is assumed able to close output pipes early, fork
-descendants, create symlinks, inspect its environment, and attempt filesystem,
-socket, or network escapes.
+and agent-control metadata, credential stores, process lifetime, and the user's
+authority to approve a specific operation. Model output, repository content,
+command output, fetched content, Skill instructions, and MCP results are
+untrusted inputs. An approved malicious dependency or child process is assumed
+able to act with the host user's authority, close output pipes early, fork
+descendants, create symlinks, inspect its environment, and use filesystem or
+network capabilities.
 
-The trusted computing base is the running CLI/Core binary, the verified
-release support tree, the exact resolved Node executable, the selected sandbox
-provider and operating-system enforcement, and host code that invokes direct
-SDK helpers. A configured MCP server or native integration is a separately
-trusted extension; missing or unsafe behavior annotations cause confirmation
-rather than granting read-only status.
+The trusted computing base is the running CLI/Core binary, the Rust guardrail,
+the host workspace runner, and host code that invokes direct SDK helpers. A
+configured MCP server or native integration is a separately trusted extension;
+missing or unsafe behavior annotations cause confirmation rather than granting
+read-only status.
 
 Trust does not waive process ownership. Each local stdio MCP server leads a
 dedicated Unix process group. Closing or dropping its transport stops pipe
@@ -97,11 +87,11 @@ tasks, clears pending requests, reaps the leader, and terminates descendants.
 The stderr pipe is drained independently so diagnostics cannot stall protocol
 traffic.
 
-This local boundary does not claim kernel-level protection against a compromised
-sandbox provider, Node runtime, CLI binary, or operating system. It also does
-not turn the privileged host-direct SDK into end-user authorization. Use a
-stronger workload provider for hostile multi-tenant code, kernel attack
-resistance, or OCI-level isolation.
+This guardrail is not process confinement and does not claim kernel-level
+protection. Approval can authorize a host command with the user's ambient
+authority, and the privileged host-direct SDK is not end-user authorization.
+Use a stronger workload provider for untrusted dependencies, hostile
+multi-tenant code, kernel attack resistance, or OCI-level isolation.
 
 ## Invocation Ingress
 
@@ -128,14 +118,11 @@ nested invocations. “Deny” means no confirmation event is created. “Confir
 once” means one exact invocation ID is pending; cancelling or expiring it
 cannot settle another prompt.
 
-| Mode | Sandbox | Ordinary Bash | Explicit host Bash | Protected metadata mutation | Tool-owned confirmation | Annotated external side effect |
-| --- | --- | --- | --- | --- | --- | --- |
-| Default | Ready | Execute in sandbox | Confirm exact call once; execute on host only if approved | Confirm exact mutation once | Confirm once | Confirm once |
-| Default | Unavailable | Confirm exact call once; execute on host only if approved | Confirm exact call once; execute on host only if approved | Confirm exact mutation once | Confirm once | Confirm once |
-| Plan | Ready | Deny | Deny | Deny | Deny | Deny |
-| Plan | Unavailable | Deny | Deny | Deny | Deny | Deny |
-| Auto | Ready | Execute in sandbox | Deny | Deny | Deny | Deny |
-| Auto | Unavailable | Deny | Deny | Deny | Deny | Deny |
+| Mode | Rust-proven read-only Bash | Unproven host Bash | Credential/control hard denial | Tool-owned confirmation | Annotated external side effect |
+| --- | --- | --- | --- | --- | --- |
+| Default | Execute on host | Confirm exact call once | Deny | Confirm once | Confirm once |
+| Plan | Deny | Deny | Deny | Deny | Deny |
+| Auto | Execute on host | Deny | Deny | Deny | Deny |
 
 Origin modifies that matrix only as follows:
 
@@ -143,7 +130,7 @@ Origin modifies that matrix only as follows:
 | --- | --- |
 | Agent or ordinary governed nested | Uses the matrix exactly. |
 | Direct host call to a custom tool | The selected top-level call skips model-facing permission/HITL; every public nested call returns to the matrix. |
-| Trusted built-in host-direct nested | Skips model-facing permission/HITL because the host supplied the built-in orchestration and its children. Hooks, budget, timeout, cancellation, recursion checks, sandbox selection, and sanitization still apply. |
+| Trusted built-in host-direct nested | Skips model-facing permission/HITL because the host supplied the built-in orchestration and its children. Hooks, budget, timeout, cancellation, recursion checks, command-runner selection, and sanitization still apply. |
 | Model sub-run born inside any host-direct call | Returns to the Agent row and uses the matrix exactly. |
 
 Decision precedence is fail-closed: active-Skill restrictions and hard
@@ -152,14 +139,13 @@ tool-owned escalation, confirmation availability, and finally execution.
 Terminal policies always use `TimeoutAction::Reject`; Core's generic
 `AutoApprove` option is not accepted by the TUI.
 
-Treat the current SRT integration as a local enforcement provider, not as the
-stack-wide execution contract. A3S Code owns agent policy and its
-`BashSandbox` interface. A3S Runtime owns durable, provider-neutral Task and
-Service lifecycle and placement. A3S Box owns OCI and stronger isolation. A
-release-owned support payload keeps those boundaries and leaves the existing
-capability/version handshake and Core contract unchanged. A3S Observer and A3S
-Sentry can add execution evidence and adaptive runtime enforcement as defense
-in depth; they do not replace the deterministic per-process sandbox boundary.
+Treat the Rust guardrail as a local policy layer, not as the stack-wide
+execution or isolation contract. A3S Code owns agent permission, command
+classification, and its optional `BashSandbox` interface. A3S Runtime owns
+durable, provider-neutral Task and Service lifecycle and placement. A3S Box
+owns OCI and stronger isolation. A3S Observer and A3S Sentry can add execution
+evidence and adaptive enforcement as defense in depth; they do not turn host
+Bash into a process boundary.
 
 ## Permission Policy
 

--- a/apps/docs/content/docs/en/code/tui.mdx
+++ b/apps/docs/content/docs/en/code/tui.mdx
@@ -334,14 +334,14 @@ TUI presents `Resume goal` and `Leave paused`: resume continues the next goal
 iteration without changing the restored execution mode, while leave enters the
 session with the goal paused so `/goal resume` can continue it later.
 
-The TUI owns human-in-the-loop approval, but approval is a sandbox-boundary
+The TUI owns human-in-the-loop approval, but approval is a policy-boundary
 event rather than a tool-category event:
 
 | Mode | Quiet execution | Boundary crossing |
 | --- | --- | --- |
-| Default | Workspace file mutations, governed orchestration, and ordinary Bash inside the installed local process sandbox. | Explicit host Bash escalation, Bash when no process sandbox is available, protected control metadata, mutating Git operations, and annotated external side effects enter HITL. |
+| Default | Workspace file mutations, governed orchestration, and Bash that the Rust guardrail proves read-only. | Unproven host Bash, protected control metadata, mutating Git operations, and annotated external side effects enter HITL. |
 | Plan | Read-only workspace and web discovery only. | Mutations, Bash, and escalation requests are denied. A completed plan is reviewed before implementation starts as a separate Default turn. |
-| Auto | The same bounded workspace mutations and process sandbox as Default. | Auto never opens HITL. Missing-sandbox Bash, host escalation, protected control metadata, and hard policy denials fail closed. |
+| Auto | The same bounded workspace mutations and Rust-proven read-only Bash as Default. | Auto never opens HITL. Unproven Bash, protected control metadata, mutating Git operations, and hard policy denials fail closed. |
 
 Shift+Tab cycles Default, Plan, and Auto. A running or queued turn keeps the
 mode captured when it was submitted. Permission and confirmation routing are
@@ -367,32 +367,20 @@ A3S Code TUI exposes tools through the session registry, not by letting the
 model run arbitrary host APIs. Each tool call carries a name, JSON arguments,
 streamed output, timeout policy, permission decision, and traceable event id.
 
-### Local process sandbox
+### Local host-command guardrail
 
-Before terminal takeover, the TUI reuses a verified user-wide managed SRT
-installation or the exact support tree carried by an official CLI archive. The
-release tree is accepted only after its package graph, file types, size bounds,
-and complete normalized digest match the CLI. It requires Node.js 20.11 or
-newer, performs the Core capability handshake, and does not select a global
-`srt` installation.
+The CLI does not install or launch a local process sandbox. Bash uses the active
+workspace backend's host command runner with the workspace as its current
+directory. One shared Rust guardrail rejects known critical commands and proves
+a deliberately narrow read-only subset by checking command structure, options,
+paths, pipelines, expansion, redirection, and workspace symlinks. Default asks
+before an unproven command; Plan denies Bash; Auto admits only the proven
+read-only subset and denies the rest without entering HITL.
 
-There is no silent host fallback. Offline mode and
-`A3S_NO_AUTO_INSTALL=1` may use verified state or the release payload without
-mutation. Source and Cargo installs without that payload may use a fixed npm
-development bootstrap only when automatic first-use setup is allowed. If no
-verified boundary is available, Default asks before running an exact Bash
-invocation on the host and Auto denies Bash. With the managed runtime, routine
-commands inherit an OS-enforced boundary that:
-
-- denies outbound networking, local listeners, and Unix sockets;
-- limits writes to the workspace and a private per-run scratch directory;
-- keeps repository, A3S, agent, editor, and tool control metadata read-only;
-- blocks reads from common credential stores and removes ambient secrets from
-  the command environment;
-- denies existing `.env*` files at every governed source-tree depth and masks
-  pre-existing multi-link source files for both reads and writes;
-- preserves bounded streaming output, timeout, cancellation, and process-group
-  cleanup.
+Credential and control paths such as `.env*`, `.git/`, `.a3s/`, and SSH keys
+remain hard denials even when an older exact grant exists. Command timeouts,
+process-group cancellation, bounded output, streaming deltas, and explicit
+environment values remain part of the host runner contract.
 
 The TUI also enables Core's local workspace credential policy for built-in
 file operations. Direct and range reads, writes, edits, patches, and both
@@ -404,30 +392,25 @@ Read-only Git diff is regenerated only for allowed changed paths;
 option-like revisions cannot become Git flags, and displayed remotes omit
 embedded HTTP credentials and query tokens.
 
-Delegated tasks, Skills, and dynamic workflow steps inherit the same sandbox,
+Delegated tasks, Skills, and dynamic workflow steps inherit the same guardrail,
 permission checker, and parent confirmation boundary. Child-local `Ask`
 decisions retain the worker's configured confirmation behavior, but a parent
 `Ask` or tool-owned escalation remains governed by the parent provider. A
 child-local allow rule or automatic confirmation provider cannot weaken the TUI
 boundary.
 
-The CLI release, Homebrew formula, and standalone self-update preserve the same
-verified support tree. npm is a development fallback, not the production
-release supply path.
-
-This local process sandbox is the low-latency boundary for routine repository
-commands. A3S Code owns permission and escalation policy; the sandbox provider
-owns OS enforcement. A3S Runtime owns provider-neutral Task and Service
-lifecycle and placement, not per-command approval. Dependency-heavy, untrusted,
-OCI, or stronger-isolation workloads belong on A3S Box or a provider selected
-through A3S Runtime.
+Host Bash is not an isolation boundary. Official archives and Homebrew carry no
+Node.js sandbox payload and require no `sandbox-exec`, `bubblewrap`, `socat`, or
+sandbox-specific `ripgrep` prerequisite. Dependency-heavy, untrusted, OCI, or
+stronger-isolation workloads belong on A3S Box or a provider selected through
+A3S Runtime.
 
 | Tool family | TUI behavior |
 | --- | --- |
-| Workspace tools | `read`, `write`, `edit`, `patch`, `ls`, `glob`, `grep`, `bash`, `git`, `web_fetch`, and `web_search` run through workspace services, path boundaries, timeout handling, sandbox enforcement, and confirmation policy. |
+| Workspace tools | `read`, `write`, `edit`, `patch`, `ls`, `glob`, `grep`, `bash`, `git`, `web_fetch`, and `web_search` run through workspace services, path boundaries, timeout handling, the Rust guardrail, and confirmation policy. |
 | Structured output | `generate_object` uses `Generating/Generated object` cards while keeping schema-shaped JSON in the same bounded event stream as normal tools. |
 | MCP tools | Configured MCP servers are registered as `mcp__<server>__<tool>` names and use the same approval and output rendering path. |
-| PTC scripts | The `program` tool runs sandboxed JavaScript-compatible scripts with a host-provided `ctx` object. Recursive `program`, `dynamic_workflow`, and `parallel_task` calls are kept out of the default PTC allow-list. |
+| PTC scripts | The `program` tool runs bounded JavaScript-compatible scripts with a host-provided `ctx` object. Recursive `program`, `dynamic_workflow`, and `parallel_task` calls are kept out of the default PTC allow-list. |
 | Delegation | `task` launches one child agent. `parallel_task` launches multiple child agents on the native host runtime, preserves input order, emits subagent progress events, and respects `max_parallel_tasks`. |
 | Dynamic workflow | `dynamic_workflow` is registered in the TUI because `ultracode` and `?` DeepResearch use it. It records project-local A3S Flow history under `.a3s/workflow` and can schedule host steps such as `parallel_task`. |
 | Optional runtime | Host-provided runtime tools are registered only after `/login`. Once present, normal model turns and dynamic workflow PTC steps can call them for hosted batch execution. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1951,11 +1951,13 @@ version before treating the update as successful. If restart fails after a
 successful upgrade, the TUI prints the exact `a3s code resume <id>` command for
 the saved session.
 
-Transition note: standalone installations from 0.9.9 through 0.10.10 cannot
-self-update directly to the first SRT-free release because those legacy
-updaters require the support payload that release removes. Install that release
-once from its GitHub archive, or migrate to Homebrew; later standalone updates
-work normally. Homebrew upgrades are unaffected.
+Transition note: standalone installations from 0.9.9 through 0.10.10 can
+self-update directly to 0.11.1 or later. Current release archives carry an
+inert, fail-closed marker that satisfies those clients' retired managed-SRT
+archive check without restoring the sandbox runtime. The canonical archives
+are mirrored at the former `A3S-Lab/CLI` release endpoint for this one-time
+channel migration; after the update, the installed CLI reads releases from
+`A3S-Lab/a3s`. Homebrew upgrades are unaffected.
 
 Box retains its complete runtime bundle during installation and update. Bench
 downloads into a staging area, verifies the release checksum, component

--- a/docs/cli-repository-migration.md
+++ b/docs/cli-repository-migration.md
@@ -26,3 +26,18 @@ and Homebrew formula from a tag reachable from `A3S-Lab/a3s` `main`.
 Standalone installers, matching Web downloads, and self-update all resolve
 published stable CLI releases from `A3S-Lab/a3s`. They deliberately ignore
 component release tags such as `a3s-code-vX.Y.Z`.
+
+## Legacy Update Endpoint
+
+A3S 0.9.9 through 0.10.10 hard-code `A3S-Lab/CLI` as their release endpoint and
+require a `support/managed-srt` tree before replacing the executable. Starting
+with 0.11.1, canonical binary archives include a four-file, inert compatibility
+marker that satisfies that retired package check and exits with failure if it
+is ever invoked. It does not contain the Anthropic sandbox runtime.
+
+The exact canonical archives are relayed to the former repository after their
+asset set, GitHub digests, checksum manifests, and marker contract pass
+verification. The relay publishes GitHub assets only; it has no crates.io or
+Homebrew authority. `A3S-Lab/CLI` must remain readable as an archived
+compatibility endpoint so an old installation can perform its one migration to
+the canonical release channel.


### PR DESCRIPTION
## Summary

- bump the root-owned CLI package and lockfile to 0.11.1
- publish the legacy self-update compatibility fix in the changelog
- document the retained `A3S-Lab/CLI` one-time migration endpoint
- remove obsolete SRT runtime/setup claims from current TUI and security docs and describe the shipped Rust host-command guardrail

## Validation

- `cargo test --locked --test legacy_self_update_bridge`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `cargo package --locked --allow-dirty --list` (archive-only bridge and repository-only test absent)
- `bash .github/scripts/test-check-release-state.sh`
- `bash .github/scripts/check-release-state.sh 0.11.1 6.5.2 0.1.14 2.1.0`
- `bash .github/scripts/check-cli-integration.sh`