### PR TITLE
chore(cloud): sync allocation evidence lock

### DIFF
--- a/apps/docs/cloud-releases/cloud-0.1.0.json
+++ b/apps/docs/cloud-releases/cloud-0.1.0.json
@@ -4,7 +4,7 @@
   "releaseKind": "integration-snapshot",
   "milestone": "E0",
   "milestoneStatus": "verified",
-  "cloudRevision": "f83071714f1e0a34cf3e1b27604780441046d6b4",
+  "cloudRevision": "094bddd2a805aabb28c7ea23938176e87dea40e1",
   "compatibilityLock": "compat/cloud-stack.acl",
   "documents": {
     "en": "/en/docs/cloud/v0.1.0",
@@ -14,7 +14,7 @@
     "acl": { "version": "0.3.0", "revision": "5317e166222495585909d81f2caffdca90273c99" },
     "boot": { "version": "0.1.3", "revision": "3119d61f1ae9b995913e34abd467ceaadc378a5f" },
     "box": { "version": "3.2.0", "revision": "4756ad60278aa8d8d21450ea6ed046ccff29306f" },
-    "cloud": { "version": "0.1.0", "revision": "f83071714f1e0a34cf3e1b27604780441046d6b4" },
+    "cloud": { "version": "0.1.0", "revision": "094bddd2a805aabb28c7ea23938176e87dea40e1" },
     "event": { "version": "0.3.0", "revision": "6df3d6551a2a3ab68b2f8271d33a87b078fc8151" },
     "flow": { "version": "0.4.3", "revision": "1675376dbced0a65afce2141e799dcdceb8e475d" },
     "gateway": { "version": "1.0.12", "revision": "f8500b89284e75342dd0286a0200b3a6e3f51e32" },

--- a/apps/docs/content/docs/cn/cloud/v0.1.0/index.mdx
+++ b/apps/docs/content/docs/cn/cloud/v0.1.0/index.mdx
@@ -11,7 +11,7 @@ Snapshot: `cloud-0.1.0`
 
 这是 E0 集成快照的版本化文档，不是生产支持声明，目前也没有发布对应的 GitHub
 release。证据边界是固定 Cloud revision 的
-[开发计划](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/docs/development-plan.md)
+[开发计划](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/docs/development-plan.md)
 中定义的 clean-host E0 gate。
 
 ## 能力状态
@@ -33,7 +33,7 @@ release manifest 或兼容锁发生漂移时失败。
 | ACL | `0.3.0` | `5317e166222495585909d81f2caffdca90273c99` |
 | Boot | `0.1.3` | `3119d61f1ae9b995913e34abd467ceaadc378a5f` |
 | Box | `3.2.0` | `4756ad60278aa8d8d21450ea6ed046ccff29306f` |
-| Cloud | `0.1.0` | `f83071714f1e0a34cf3e1b27604780441046d6b4` |
+| Cloud | `0.1.0` | `094bddd2a805aabb28c7ea23938176e87dea40e1` |
 | Event | `0.3.0` | `6df3d6551a2a3ab68b2f8271d33a87b078fc8151` |
 | Flow | `0.4.3` | `1675376dbced0a65afce2141e799dcdceb8e475d` |
 | Gateway | `1.0.12` | `f8500b89284e75342dd0286a0200b3a6e3f51e32` |

--- a/apps/docs/content/docs/cn/cloud/v0.1.0/install-upgrade.mdx
+++ b/apps/docs/content/docs/cn/cloud/v0.1.0/install-upgrade.mdx
@@ -42,9 +42,9 @@ apps/cloud/target/release/a3s-cloud-control-plane apps/cloud/config/cloud.acl
 ```
 
 启动时会应用已检入 migration。应以完整的
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/cloud.acl)
 和
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/node.example.acl)
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/node.example.acl)
 为起点。文档 gate 使用锁定的 `a3s-acl` 解析它们，Cloud 类型化配置测试也会验证它们。
 
 接入流量前验证进程与依赖健康：

--- a/apps/docs/content/docs/cn/cloud/v0.1.0/interfaces.mdx
+++ b/apps/docs/content/docs/cn/cloud/v0.1.0/interfaces.mdx
@@ -31,24 +31,24 @@ Snapshot: `cloud-0.1.0`
 
 不要把生成 schema 手工复制进源码文档。启动精确二进制并读取
 `/api/v1/openapi.json`。注册位置固定在
-[API contract source](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/crates/control-plane/src/presentation/api_contract/route.rs)；
+[API contract source](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/crates/control-plane/src/presentation/api_contract/route.rs)；
 该 source marker 改变时文档 gate 会失败。
 
 ## 事件与节点协议
 
 Event key 使用小写点分格式。envelope 携带 event ID、key、schema version、organization、
 aggregate identity/version、timestamp、correlation/causation ID 与 JSON payload；参见
-[固定 contract](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/crates/contracts/src/event.rs)。
+[固定 contract](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/crates/contracts/src/event.rs)。
 NATS 是 PostgreSQL outbox 的 relay，不是第二个业务权威来源。
 
 Node request/response schema 位于
-[固定 contracts 目录](https://github.com/A3S-Lab/Cloud/tree/f83071714f1e0a34cf3e1b27604780441046d6b4/crates/contracts/src/node)。
+[固定 contracts 目录](https://github.com/A3S-Lab/Cloud/tree/094bddd2a805aabb28c7ea23938176e87dea40e1/crates/contracts/src/node)。
 它们是由节点 identity 认证的私有基础设施 contract，不得作为未认证公共 REST 暴露。
 
 ## ACL
 
 ACL 指 A3S Agent Configuration Language，不是 HCL。完整发布参考是
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/cloud.acl)
 和
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/node.example.acl)。
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/node.example.acl)。
 未知 block 与字段会 fail closed。ACL 只引用环境变量名，不能包含 secret value。

--- a/apps/docs/content/docs/en/cloud/v0.1.0/index.mdx
+++ b/apps/docs/content/docs/en/cloud/v0.1.0/index.mdx
@@ -12,7 +12,7 @@ Snapshot: `cloud-0.1.0`
 This is versioned documentation for the E0 integration snapshot. It is not a
 production support declaration and no matching GitHub release has been
 published. The evidence boundary is the clean-host E0 gate described in the
-[pinned Cloud development plan](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/docs/development-plan.md).
+[pinned Cloud development plan](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/docs/development-plan.md).
 
 ## Capability status
 
@@ -34,7 +34,7 @@ drifts from that lock.
 | ACL | `0.3.0` | `5317e166222495585909d81f2caffdca90273c99` |
 | Boot | `0.1.3` | `3119d61f1ae9b995913e34abd467ceaadc378a5f` |
 | Box | `3.2.0` | `4756ad60278aa8d8d21450ea6ed046ccff29306f` |
-| Cloud | `0.1.0` | `f83071714f1e0a34cf3e1b27604780441046d6b4` |
+| Cloud | `0.1.0` | `094bddd2a805aabb28c7ea23938176e87dea40e1` |
 | Event | `0.3.0` | `6df3d6551a2a3ab68b2f8271d33a87b078fc8151` |
 | Flow | `0.4.3` | `1675376dbced0a65afce2141e799dcdceb8e475d` |
 | Gateway | `1.0.12` | `f8500b89284e75342dd0286a0200b3a6e3f51e32` |

--- a/apps/docs/content/docs/en/cloud/v0.1.0/install-upgrade.mdx
+++ b/apps/docs/content/docs/en/cloud/v0.1.0/install-upgrade.mdx
@@ -45,9 +45,9 @@ apps/cloud/target/release/a3s-cloud-control-plane apps/cloud/config/cloud.acl
 ```
 
 Startup applies the checked-in migrations. Keep the complete
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/cloud.acl)
 and
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/node.example.acl)
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/node.example.acl)
 as the starting point; both are parsed by the docs gate and by Cloud's typed
 configuration tests.
 

--- a/apps/docs/content/docs/en/cloud/v0.1.0/interfaces.mdx
+++ b/apps/docs/content/docs/en/cloud/v0.1.0/interfaces.mdx
@@ -33,7 +33,7 @@ tenant routes require an API token with the declared scope.
 
 Do not copy a generated schema into source documentation. Start the exact
 binary and retrieve `/api/v1/openapi.json`. Its registration is tied to the
-[pinned API contract source](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/crates/control-plane/src/presentation/api_contract/route.rs),
+[pinned API contract source](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/crates/control-plane/src/presentation/api_contract/route.rs),
 and the docs gate fails if that source marker changes.
 
 ## Events and node protocols
@@ -41,19 +41,19 @@ and the docs gate fails if that source marker changes.
 Event keys are lowercase dot-separated names. The envelope carries event ID,
 key, schema version, organization, aggregate identity/version, timestamps,
 correlation/causation IDs, and JSON payload; see the
-[pinned contract](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/crates/contracts/src/event.rs).
+[pinned contract](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/crates/contracts/src/event.rs).
 NATS is a relay of the PostgreSQL outbox, not a second business authority.
 
 Node request/response schemas live in the
-[pinned contracts directory](https://github.com/A3S-Lab/Cloud/tree/f83071714f1e0a34cf3e1b27604780441046d6b4/crates/contracts/src/node).
+[pinned contracts directory](https://github.com/A3S-Lab/Cloud/tree/094bddd2a805aabb28c7ea23938176e87dea40e1/crates/contracts/src/node).
 They are private infrastructure contracts authenticated by node identity; they
 must not be exposed as unauthenticated public REST.
 
 ## ACL
 
 ACL means A3S Agent Configuration Language, not HCL. The complete shipped
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/cloud.acl)
 and
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/f83071714f1e0a34cf3e1b27604780441046d6b4/config/node.example.acl)
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/094bddd2a805aabb28c7ea23938176e87dea40e1/config/node.example.acl)
 are the versioned references. Unknown blocks and fields fail closed. Secrets
 are referenced by environment-variable name; values do not belong in ACL.

--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "f83071714f1e0a34cf3e1b27604780441046d6b4"
+  revision = "094bddd2a805aabb28c7ea23938176e87dea40e1"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary

- advance the Cloud gitlink to 094bddd2a805aabb28c7ea23938176e87dea40e1, which includes the merged BX0.3 allocation-evidence gate
- update the canonical Cloud compatibility lock and bilingual versioned documentation snapshot
- retain the exact Box, Runtime, Gateway, ORM, and protocol revisions

## Evidence

- Cloud compatibility lock: sha256:bce6a97d31d1b74e021024578f96f25e24141b5f0705010c494a24f775d3a534
- Cloud real Box allocation gate: https://github.com/A3S-Lab/Cloud/actions/runs/30603209089
- just cloud-stack-check
- bun run check:cloud
- bun run check in apps/docs: 17 tests, TypeScript, production build, 693 static pages, and 6726 exported files