### PR TITLE
test: cover and isolate A3S Use setup

### DIFF
--- a/src/api/serve/background.rs
+++ b/src/api/serve/background.rs
@@ -9,7 +9,9 @@ use fs2::FileExt;
 use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System, UpdateKind};
+use sysinfo::{
+    Pid, ProcessRefreshKind, ProcessStatus, ProcessesToUpdate, Signal, System, UpdateKind,
+};
 use tokio::time::{sleep, Instant};
 
 use super::options::ServeOptions;
@@ -242,6 +244,12 @@ pub(super) async fn replace_managed(workspace: &Path) -> anyhow::Result<Option<W
 }
 
 async fn stop_owned_instance(path: &Path, instance: &WebInstanceRecord) -> anyhow::Result<()> {
+    let identity = process_identity(instance.pid).await?.with_context(|| {
+        format!(
+            "managed A3S Web process {} is no longer running",
+            instance.pid
+        )
+    })?;
     let url = control_url(instance, "stop");
     let response = control_client()?
         .post(url)
@@ -251,15 +259,9 @@ async fn stop_owned_instance(path: &Path, instance: &WebInstanceRecord) -> anyho
     if !response.status().is_success() {
         bail!("A3S Web rejected the authenticated shutdown request");
     }
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while Instant::now() < deadline {
-        if !probe_instance(instance).await {
-            remove_instance_if_owned(path, &instance.nonce);
-            return Ok(());
-        }
-        sleep(POLL_INTERVAL).await;
-    }
-    bail!("A3S Web did not stop within 10 seconds; no force signal was sent")
+    wait_until_process_stopped(instance.pid, identity, OBSERVED_SHUTDOWN_TIMEOUT).await?;
+    remove_instance_if_owned(path, &instance.nonce);
+    Ok(())
 }
 
 pub(super) async fn replace_observed_instance(
@@ -309,7 +311,11 @@ pub(super) async fn replace_observed_instance(
     }
 
     signal_observed_process(pid, expected_executable, expected_port, identity).await?;
-    wait_until_port_released(existing.address).await
+    tokio::try_join!(
+        wait_until_port_released(existing.address),
+        wait_until_process_stopped(pid, identity, OBSERVED_SHUTDOWN_TIMEOUT),
+    )?;
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -325,6 +331,52 @@ async fn inspect_observed_process(
     tokio::task::spawn_blocking(move || inspect_observed_process_sync(pid, &executable, port))
         .await
         .context("A3S Web process inspection task failed")?
+}
+
+async fn process_identity(pid: u32) -> anyhow::Result<Option<ObservedProcessIdentity>> {
+    tokio::task::spawn_blocking(move || {
+        let system = process_snapshot(pid);
+        system
+            .process(Pid::from_u32(pid))
+            .map(|process| ObservedProcessIdentity {
+                start_time: process.start_time(),
+            })
+    })
+    .await
+    .context("A3S Web process identity task failed")
+}
+
+async fn wait_until_process_stopped(
+    pid: u32,
+    identity: ObservedProcessIdentity,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let stopped = tokio::task::spawn_blocking(move || {
+            let system = process_snapshot(pid);
+            match system.process(Pid::from_u32(pid)) {
+                None => true,
+                Some(process) if process.start_time() != identity.start_time => true,
+                Some(process) => matches!(
+                    process.status(),
+                    ProcessStatus::Dead | ProcessStatus::Zombie
+                ),
+            }
+        })
+        .await
+        .context("A3S Web process exit task failed")?;
+        if stopped {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "A3S Web process {pid} did not exit within {} seconds; no force signal was sent",
+                timeout.as_secs()
+            );
+        }
+        sleep(POLL_INTERVAL).await;
+    }
 }
 
 fn inspect_observed_process_sync(

--- a/src/use_registry/tests.rs
+++ b/src/use_registry/tests.rs
@@ -23,6 +23,46 @@ async fn registry_slot_waits_without_blocking_and_settles_when_setup_finishes() 
 }
 
 #[tokio::test]
+async fn registry_slot_reports_setup_state_and_exposes_the_ready_handle() {
+    let temp = tempfile::tempdir().unwrap();
+    let agent = a3s_code_core::Agent::from_config(test_config())
+        .await
+        .unwrap();
+    let session = Arc::new(
+        agent
+            .session_async(temp.path().display().to_string(), None)
+            .await
+            .unwrap(),
+    );
+    let slot = UseRegistrySlot::preparing();
+
+    let preparing = slot.status_text(Arc::clone(&session), false).await;
+    assert!(preparing.contains("discovering or installing in the background"));
+
+    slot.set_unavailable("fixture setup failure");
+    let unavailable = slot.status_text(Arc::clone(&session), false).await;
+    assert!(unavailable.contains("binary  not discovered"));
+    assert!(unavailable.contains("setup   fixture setup failure"));
+
+    let cancellation = CancellationToken::new();
+    let (desired_tx, _) = watch::channel(Arc::new(DesiredCapabilities::default()));
+    let handle = UseRegistryHandle {
+        inner: Arc::new(UseRegistryInner {
+            executable: PathBuf::from("unused-a3s-use"),
+            directory: temp.path().to_path_buf(),
+            desired_tx,
+            cancellation,
+            projections: Mutex::new(BTreeMap::new()),
+            registry_task: Mutex::new(None),
+        }),
+    };
+    slot.set_ready(handle, Some("fixture setup warning".to_string()));
+    assert!(slot.ready_handle().is_some());
+
+    session.close().await;
+}
+
+#[tokio::test]
 async fn dropping_the_last_registry_handle_cancels_owned_background_work() {
     let cancellation = CancellationToken::new();
     let (desired_tx, _) = watch::channel(Arc::new(DesiredCapabilities::default()));

--- a/tests/web_asset_download.rs
+++ b/tests/web_asset_download.rs
@@ -270,6 +270,16 @@ impl CargoWebFixture {
         fs::create_dir_all(binary.parent().expect("Cargo-style binary parent"))
             .expect("create Cargo-style bin directory");
         fs::copy(a3s_bin(), &binary).expect("copy Cargo-style a3s binary");
+        // Keep Web asset download assertions isolated from Code Web's
+        // independent A3S Use first-use setup. The hard link is a native,
+        // version-probeable executable whose unsupported Use commands fail
+        // locally without contacting the fixture release server.
+        let use_binary = binary.with_file_name(if cfg!(windows) {
+            "a3s-use.exe"
+        } else {
+            "a3s-use"
+        });
+        fs::hard_link(&binary, &use_binary).expect("link fixture a3s-use executable");
         fs::write(&config, test_config()).expect("write Cargo-style Web config");
         Self {
             _temp: temp,
@@ -347,6 +357,10 @@ impl CargoWebFixture {
             .env(
                 "A3S_CODE_WEB_STATE_DIR",
                 self.root.join("code-web-state").join(workspace_name),
+            )
+            .env(
+                "A3S_USE_INSTALL_DIR",
+                self.binary.parent().expect("Cargo-style binary parent"),
             )
             .env_remove("A3S_CODE_WEB_DIR")
             .env_remove("A3S_NO_AUTO_INSTALL")


### PR DESCRIPTION
## Summary

- exercise the asynchronous A3S Use registry slot across preparing, unavailable, and ready states
- verify TUI setup status text includes the concrete failure reason
- exercise the ready handle path so production-only slot APIs remain live in the isolated library test graph
- isolate Web asset download fixtures from Code Web's independent Use first-use setup with a local, version-probeable executable
- wait for replaced managed and observed Web processes to fully exit by PID and start-time identity before returning
- fix the existing `cargo clippy --all-targets -- -D warnings` dead-code failure without suppressing lints
- keep Web asset request-count, offline, concurrent-download, process-replacement, and GitHub API rate-limit contracts deterministic

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `RUSTFLAGS='-D warnings' cargo check --locked --lib --tests`
- [x] focused registry slot lifecycle test: 1 passed
- [x] `web_cli` integration suite: 18 passed
- [x] `web_asset_download` integration suite: 7 passed
