### PR TITLE
chore: add A3S UI submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -97,3 +97,6 @@
 [submodule "crates/ash"]
 	path = crates/ash
 	url = git@github.com:A3S-Lab/ash.git
+[submodule "packages/ui"]
+	path = packages/ui
+	url = git@github.com:A3S-Lab/UI.git


### PR DESCRIPTION
Add the A3S UI repository under packages/ui and lock the gitlink to the published design system and versioned documentation release.