### PR TITLE
chore: sync Use release conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ component-backed Box route, and the lifecycle and routing layer for external
 capability packages. Package sources are host-configured: release bundles and
 named TUF registries are parallel trust paths, and the default `a3s` registry
 identity is replaceable rather than a hardcoded network dependency.
+One immutable cognitive-plugin package may contribute named Skills, CLI or HTTP
+Tools, standard MCP servers, sandboxed UI, and non-executable Open Knowledge
+Format (OKF) bundles. Installation, authorization, Runtime binding, Knowledge
+promotion, and live capability projection remain separate evidence, so a
+downloaded package does not become an active capability by implication.
 The independent Browser and OCR repositories own their provider contracts,
 implementations, tests, and release assets. Office and Science remain external
 packages with native CLI, MCP, and/or `SKILL.md` surfaces rather than depending
@@ -187,6 +192,15 @@ Registry replacement never rewrites provenance. Installed package receipts bind
 the source name, URL, TUF root, channel, and target digest; an upgrade fails
 closed after source identity changes until the original source is restored or
 the package is explicitly migrated or reinstalled.
+
+Cloud-facing release identity is also immutable and surface-specific. An MCP
+release maps a digest-pinned OCI artifact and standard health/lifecycle contract
+to a Runtime Service; a Skill release maps a content-bound `SKILL.md` bundle to
+Agent input and has no executable or Runtime fields. Canonical fixtures bind
+cross-surface dependencies by their real descriptor digests. The Linux release
+gate pushes a non-root image to an ephemeral Registry, executes the returned
+manifest digest, exercises MCP initialize/list/request, verifies bounded
+SIGTERM shutdown, and starts a clean second generation.
 
 A3S Parser is a pre-alpha agentic document parser built on A3S Code. It combines
 A3S Office structure and source-layout rendering with A3S OCR through bounded,
@@ -284,7 +298,7 @@ type, or parsed configuration from being mistaken for a finished deployment.
 | Box | Requires a supported host and virtualization backend; platform-specific CRI, TEE, and Windows paths have separate gates |
 | Bench | The source and `a3s bench …` route exist, but a compatible component release is not yet published; local execution requires Docker and produces `local_unofficial` results |
 | Test | The deterministic Web runner, ACL admission, structured reports, and interrupt-safe browser cleanup are working; LLM planning, GUI/CUA, TUI/PTY, MCP, and Skill surfaces remain planned |
-| Use | Registry sources are replaceable host configuration and release bundles remain independent; domain readiness still depends on installed runtimes, model assets, and package-owned compatibility |
+| Use | Registry sources are replaceable host configuration and release bundles remain independent; MCP and Skill releases are immutable, while OKF publication requires promoted Knowledge evidence and executable readiness still depends on installed Runtime providers and package-owned compatibility |
 | Office | Pre-1.0; five browser-native surfaces, native CLI/MCP/Skill automation, OOXML semantics, and optional host-injected PDFium page rendering exist, while the first npm package release is still pending |
 | Parser | Pre-alpha runnable A3S Code parser; native OOXML structure, direct-image/exact-PPTX/native-PDF visual routes, canonical overlays, and durable resume are delivered, while richer formats and production-scale evidence remain gated |
 | Cloud | R0–E0 is the verified cumulative baseline; G0, C0, and H0 are in progress; P0, A0, S0, and I0 remain planned in the [locked Cloud compatibility manifest](compat/cloud-stack.acl) |
@@ -395,7 +409,7 @@ distribution assets.
 | [A3S Browser](crates/browser/) | Provider-oriented typed rendering plus the process-isolated automation driver, Skills, and Dashboard |
 | [A3S OCR](crates/ocr/) | Object-safe `OcrProvider` contract with bounded source evidence and PP-OCRv6 as the default local provider |
 | [A3S Parser](crates/parser/) | A3S Code-governed Office/OCR document parsing, resumable manifests, and MinerU-class source-locatable canonical geometry |
-| [A3S Use](crates/use/) | Cross-platform AI Native Package Manager with replaceable TUF registries, release bundles, native routes, and cognitive plugin lifecycle |
+| [A3S Use](crates/use/) | Cross-platform AI Native Package Manager with replaceable TUF registries and immutable Skill, Tool, MCP, UI, and OKF cognitive-plugin lifecycle |
 | [A3S Office](packages/office/) | Pre-1.0 Office package with five browser-native surfaces, native automation, OOXML semantics, and optional host-injected PDFium pages |
 | [A3S Science](packages/science/) | TUF-signed 472-entry catalog with 35 A3S-native Skills, 25 A3S-native MCP resources, and scientific research tooling |
 | [A3S Cloud](apps/cloud/) | Self-hosted control plane with durable tenant-scoped finite Executions, Runtime placement, cancellation, and cleanup |

--- a/justfile
+++ b/justfile
@@ -25,6 +25,11 @@ marketplace-e2e-submodules:
     sh scripts/ensure-dev-submodules.sh crates/use:crates/science/Cargo.toml
 
 [private]
+marketplace-browser-e2e-submodules: marketplace-e2e-submodules
+    sh scripts/ensure-dev-submodules.sh \
+        crates/code:sdk/node/examples/configs/test_config.acl
+
+[private]
 webview-submodule:
     sh scripts/ensure-dev-submodules.sh crates/webview:Cargo.toml
 
@@ -95,7 +100,7 @@ marketplace-science-e2e: marketplace-e2e-submodules
     A3S_USE_E2E_TARGET='{{ use_e2e_target }}' bash scripts/test-web-plugin-marketplace-e2e.sh
 
 # Test the release-bundled Science lifecycle through the real Web UI
-marketplace-science-browser-e2e: marketplace-e2e-submodules
+marketplace-science-browser-e2e: marketplace-browser-e2e-submodules
     A3S_USE_E2E_TARGET='{{ use_e2e_target }}' bash scripts/test-web-plugin-marketplace-browser-e2e.sh
 
 # Build and start the A3S Web application

--- a/justfile
+++ b/justfile
@@ -25,11 +25,6 @@ marketplace-e2e-submodules:
     sh scripts/ensure-dev-submodules.sh crates/use:crates/science/Cargo.toml
 
 [private]
-marketplace-browser-e2e-submodules: marketplace-e2e-submodules
-    sh scripts/ensure-dev-submodules.sh \
-        crates/code:sdk/node/examples/configs/test_config.acl
-
-[private]
 webview-submodule:
     sh scripts/ensure-dev-submodules.sh crates/webview:Cargo.toml
 
@@ -100,7 +95,7 @@ marketplace-science-e2e: marketplace-e2e-submodules
     A3S_USE_E2E_TARGET='{{ use_e2e_target }}' bash scripts/test-web-plugin-marketplace-e2e.sh
 
 # Test the release-bundled Science lifecycle through the real Web UI
-marketplace-science-browser-e2e: marketplace-browser-e2e-submodules
+marketplace-science-browser-e2e: marketplace-e2e-submodules
     A3S_USE_E2E_TARGET='{{ use_e2e_target }}' bash scripts/test-web-plugin-marketplace-browser-e2e.sh
 
 # Build and start the A3S Web application

--- a/scripts/test-web-plugin-marketplace-browser-e2e.sh
+++ b/scripts/test-web-plugin-marketplace-browser-e2e.sh
@@ -82,6 +82,8 @@ mkdir -p \
   "${workspace}" \
   "$(dirname "${config}")" \
   "${web_state}"
+bash "${repository_root}/scripts/ensure-dev-submodules.sh" \
+  crates/code:sdk/node/examples/configs/test_config.acl
 cp "${repository_root}/crates/code/sdk/node/examples/configs/test_config.acl" "${config}"
 
 CARGO_TARGET_DIR="${use_target}" cargo build \


### PR DESCRIPTION
## Summary

- advance the A3S Use gitlink to the merged immutable MCP/Skill release conformance baseline
- document replaceable named registries, multi-surface cognitive packages, OKF boundaries, and digest-pinned OCI lifecycle evidence
- make the Marketplace browser E2E initialize its Code fixture dependency in a fresh checkout

## Verification

- cargo fmt --all -- --check
- cargo test --all-targets --locked
- cargo clippy --all-targets --locked -- -D warnings
- just use-hotplug-e2e
- just marketplace-science-e2e
- just marketplace-science-browser-e2e
- A3S-Lab/Use main CI run 30734290497