### PR TITLE
feat(use): integrate OKF knowledge binding store

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ Tools, standard MCP servers, sandboxed UI, and non-executable Open Knowledge
 Format (OKF) bundles. Installation, authorization, Runtime binding, Knowledge
 promotion, and live capability projection remain separate evidence, so a
 downloaded package does not become an active capability by implication.
+The current Use integration snapshot includes the M0K-C-A byte-exact injected
+Knowledge port and durable generation store: failed candidates can retain only
+an exact promoted last-good record, while removal cannot resurrect an older
+generation. Production Knowledge indexing, cited retrieval, and parent-saga
+publication remain pending.
 The independent Browser and OCR repositories own their provider contracts,
 implementations, tests, and release assets. Office and Science remain external
 packages with native CLI, MCP, and/or `SKILL.md` surfaces rather than depending


### PR DESCRIPTION
## Summary

- advance `crates/use` to the merged M0K-C-A Knowledge binding implementation
- document the byte-exact injected Knowledge port and durable generation store
- preserve the roadmap boundary: production indexing, cited retrieval, and parent-saga publication remain pending

## Validation

- `cargo fmt --all -- --check` (Use)
- `cargo test --workspace --all-features` (Use)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (Use)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` (Use)
- Use CI across Linux, macOS, and Windows: https://github.com/A3S-Lab/Use/actions/runs/30736582076
- `just use-hotplug-e2e`
- `just marketplace-science-e2e`
- `CARGO_INCREMENTAL=0 just marketplace-science-browser-e2e`

The browser lifecycle covered install review, install, sandbox launch, disable, enable, relaunch, and uninstall with no console messages or page errors.