### PR TITLE
chore: sync Power lossless tuning evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ main-repository release ownership.
 | --- | --- |
 | [A3S Boot](crates/boot/) | Adapter-first modular async service framework |
 | [A3S Gateway](crates/gateway/) | Local AI traffic and protocol data plane |
-| [A3S Power](crates/power/) | Model-neutral server and embedded inference with Colibri-inspired tiered weight residency, ordered current-layer staging, private routing hints, stable live adaptation, integrity, TEE privacy, and receipts |
+| [A3S Power](crates/power/) | Model-neutral server and embedded inference with Colibri-inspired tiered weight residency, ordered current-layer staging, digest-bound lossless tuning evidence, private routing hints, stable live adaptation, integrity, TEE privacy, and receipts |
 | [A3S AHP](crates/ahp/) | Transport-neutral Agent Harness Protocol supervision |
 | [A3S ACL](crates/acl/) | Parser and generator for the A3S Agent Configuration Language |
 | [A3S TUI](crates/tui/) | TEA-style terminal UI framework |


### PR DESCRIPTION
## Summary

- advance `crates/power` from `8375d88` to `16f18ec`
- include the digest-bound AB/BA lossless tuning evidence evaluator merged in A3S-Lab/Power#34
- update the root module description

## Boundaries

Power remains model-neutral. This does not add model assets, candidate configuration values, a calibration runner, persistence, a listener, ONNX Runtime, or an external inference service. TEE, attestation, receipts, admission, storage routing, cache, dtype, precision, and tensor semantics are unchanged.

## Upstream validation

- Power CI: 18/18 passed
- 254 embedded tests
- 1,437 default tests
- embedded/default all-target Clippy
- embedded dependency boundary
- strict embedded Rustdoc
- package verification

No Cloud component or protocol revision changed, so `compat/cloud-stack.acl` is unaffected.