### PR TITLE
chore: sync Power lossless weight representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ main-repository release ownership.
 | --- | --- |
 | [A3S Boot](crates/boot/) | Adapter-first modular async service framework |
 | [A3S Gateway](crates/gateway/) | Local AI traffic and protocol data plane |
-| [A3S Power](crates/power/) | Model-neutral server and embedded inference with Colibri-inspired tiered weight residency, ordered current-layer staging, digest-bound lossless tuning evidence, private routing hints, stable live adaptation, integrity, TEE privacy, and receipts |
+| [A3S Power](crates/power/) | Model-neutral server and embedded inference with Colibri-inspired tiered weight residency, ordered current-layer staging, digest-bound lossless tuning evidence, verified lossless weight representations, private routing hints, stable live adaptation, integrity, TEE privacy, and receipts |
 | [A3S AHP](crates/ahp/) | Transport-neutral Agent Harness Protocol supervision |
 | [A3S ACL](crates/acl/) | Parser and generator for the A3S Agent Configuration Language |
 | [A3S TUI](crates/tui/) | TEA-style terminal UI framework |


### PR DESCRIPTION
## Summary

- advance the Power submodule to A3S-Lab/Power#36
- document verified lossless weight representations in the root module catalog
- retain model-neutral ownership and existing TEE privacy guarantees

## Validation

- Power PR #36 passed all 18 CI jobs
- root diff checked with `git diff --check`