### PR TITLE
chore: sync event-driven Power staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ A3S Parser is a pre-alpha agentic document parser built on A3S Code. A3S Code
 owns planning and tool governance; A3S Office owns deterministic OOXML/PDF
 structure and source-layout rendering; A3S OCR owns model implementations and
 grounding; and model-neutral A3S Power owns embedded devices, weight integrity,
-admission, residency, bounded prefetch, ordered current-layer weight staging,
+admission, residency, bounded background loading, event-driven current-layer
+weight staging,
 attestation-bound accelerator batches, sealed warm-state transport, verified
 storage topology, privacy, TEE execution, and receipts.
 Parser binds those components through source-bound tools, persists resumable
@@ -237,14 +238,17 @@ A3S Power 0.7.0 keeps its HTTP server and embedded library paths separate. The
 embedded path deepens Colibri-inspired weight management with storage/host/
 device tiers, LFRU heat, atomic hot plans, stable hysteresis-bounded live tier
 adaptation, batched expert unions, private digest-bound cross-layer prefetch
-hints, bounded future-layer prefetch, ordered atomic current-layer staging,
+hints, bounded future-layer prefetch, event-driven atomic current-layer staging,
 exact indexed positional tensor reads, opt-in aligned direct I/O,
 integrity-checked complete or partial weighted replicas,
 validation-throughput source weighting, and usage-ranked verified
-partial-mirror staging. Current-layer staging exposes complete resident groups
-while exact misses use the existing bounded admission, cache, source router,
-per-key serialization, and cancellation path; final groups are restored in
-canonical input order for model-owned computation.
+partial-mirror staging. Prefetch and current-layer staging reuse one flight
+window bounded by both active workers and canonical bytes. Current-layer
+staging exposes complete resident groups immediately and wakes model-owned
+computation through `next_ready_group().await` without polling, while exact
+misses retain the existing task admission, cache, source router, per-key
+serialization, and cancellation path. Groups may become ready out of order,
+but final completion is restored in canonical input order.
 Accelerator declarations bind the active device-residency plan, weight and
 execution-policy digests, model-owned fused Candle kernel, exact fallback, and
 optional confidential-GPU claims. Fused batches acquire only complete
@@ -504,7 +508,7 @@ main-repository release ownership.
 | --- | --- |
 | [A3S Boot](crates/boot/) | Adapter-first modular async service framework |
 | [A3S Gateway](crates/gateway/) | Local AI traffic and protocol data plane |
-| [A3S Power](crates/power/) | Model-neutral server and embedded inference with Colibri-inspired tiered weight residency, ordered staging, attestation-bound fused accelerator batches, sealed warm-state recovery, lossless tuning and weight representations, private routing hints, stable live adaptation, integrity, TEE privacy, and receipts |
+| [A3S Power](crates/power/) | Model-neutral server and embedded inference with Colibri-inspired tiered weight residency, event-driven staging with shared worker/byte admission, attestation-bound fused accelerator batches, sealed warm-state recovery, lossless tuning and weight representations, private routing hints, stable live adaptation, integrity, TEE privacy, and receipts |
 | [A3S AHP](crates/ahp/) | Transport-neutral Agent Harness Protocol supervision |
 | [A3S ACL](crates/acl/) | Parser and generator for the A3S Agent Configuration Language |
 | [A3S TUI](crates/tui/) | TEA-style terminal UI framework |


### PR DESCRIPTION
## Summary

- advance the `crates/power` gitlink from `4115e67` to merged Power main commit `44dbe14`
- update the root README to describe event-driven atomic-group readiness and the shared worker/canonical-byte flight window
- retain the ownership boundary: Power remains model-neutral, OCR topology and artifacts remain in A3S OCR, and embedded inference opens no listener

## Upstream validation

- A3S-Lab/Power#41 passed the full Linux, macOS, Windows, cross-target, feature, Clippy, dependency-boundary, and test matrices
- local Power validation passed 1,437 default library tests and 301 embedded-inference tests

Upstream: A3S-Lab/Power#41
