### PR TITLE
chore(use): sync cognitive package lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,14 @@ Tools, standard MCP servers, sandboxed UI, and non-executable Open Knowledge
 Format (OKF) bundles. Installation, authorization, Runtime binding, Knowledge
 promotion, and live capability projection remain separate evidence, so a
 downloaded package does not become an active capability by implication.
-The current Use integration snapshot includes the M0K-C-A byte-exact injected
-Knowledge port and durable generation store: failed candidates can retain only
-an exact promoted last-good record, while removal cannot resurrect an older
-generation. Production Knowledge indexing, cited retrieval, and parent-saga
-publication remain pending.
+The current Use integration snapshot adds one canonical Tool/MCP/OKF/Skill/UI
+graph, a package-level lifecycle intent and crash-safe journal, forward
+dependency preparation, reverse receipt-owned removal, and typed Runtime,
+immutable Skill/UI, and OKF Knowledge adapters. The package remains the only
+install, upgrade, enable, disable, and uninstall unit. Production package and
+capability hosts, umbrella CLI/Web wiring, prior Runtime-generation retirement,
+Knowledge indexing, and cited retrieval remain pending, so this foundation does
+not yet make schema-v3 activation a finished product.
 The independent Browser and OCR repositories own their provider contracts,
 implementations, tests, and release assets. Office and Science remain external
 packages with native CLI, MCP, and/or `SKILL.md` surfaces rather than depending
@@ -368,7 +371,7 @@ type, or parsed configuration from being mistaken for a finished deployment.
 | Box | Requires a supported host and virtualization backend; platform-specific CRI, TEE, and Windows paths have separate gates |
 | Bench | The source and `a3s bench …` route exist, but a compatible component release is not yet published; local execution requires Docker and produces `local_unofficial` results |
 | Test | The deterministic Web runner, ACL admission, structured reports, and interrupt-safe browser cleanup are working; LLM planning, GUI/CUA, TUI/PTY, MCP, and Skill surfaces remain planned |
-| Use | Registry sources are replaceable host configuration and release bundles remain independent; MCP and Skill releases are immutable, while OKF publication requires promoted Knowledge evidence and executable readiness still depends on installed Runtime providers and package-owned compatibility |
+| Use | Registry sources are replaceable host configuration and release bundles remain independent; one package owns the Tool/MCP/OKF/Skill/UI lifecycle, while production host composition, prior-generation retirement, and promoted Knowledge evidence still gate schema-v3 publication |
 | Office | Pre-1.0; five browser-native surfaces, native CLI/MCP/Skill automation, OOXML semantics, and optional host-injected PDFium page rendering exist, while the first npm package release is still pending |
 | Parser | Pre-alpha runnable A3S Code parser; native OOXML structure, direct-image/exact-PPTX/native-PDF visual routes, canonical overlays, and durable resume are delivered, while richer formats and production-scale evidence remain gated |
 | Cloud | R0–E0 is the verified cumulative baseline; G0, C0, and H0 are in progress; P0, A0, S0, and I0 remain planned in the [locked Cloud compatibility manifest](compat/cloud-stack.acl) |
@@ -479,7 +482,7 @@ distribution assets.
 | [A3S Browser](crates/browser/) | Provider-oriented typed rendering plus the process-isolated automation driver, Skills, and Dashboard |
 | [A3S OCR](crates/ocr/) | Object-safe `OcrProvider` contract with bounded source evidence plus embedded Rust PP-OCRv6 and revision/inventory-bound Unlimited-OCR models executed through A3S Power |
 | [A3S Parser](crates/parser/) | A3S Code-governed Office/OCR orchestration, resumable manifests, evidence reconciliation, and MinerU-class source-locatable canonical geometry |
-| [A3S Use](crates/use/) | Cross-platform AI Native Package Manager with replaceable TUF registries and immutable Skill, Tool, MCP, UI, and OKF cognitive-plugin lifecycle |
+| [A3S Use](crates/use/) | Cross-platform AI Native Package Manager with replaceable TUF registries and one journaled package lifecycle for immutable Tool, MCP, OKF, Skill, and UI contributions |
 | [A3S Office](packages/office/) | Pre-1.0 Office package with five browser-native surfaces, native automation, OOXML semantics, and optional host-injected PDFium pages |
 | [A3S Science](packages/science/) | TUF-signed 472-entry catalog with 35 A3S-native Skills, 25 A3S-native MCP resources, and scientific research tooling |
 | [A3S Cloud](apps/cloud/) | Self-hosted control plane with durable tenant-scoped finite Executions, Runtime placement, cancellation, and cleanup |


### PR DESCRIPTION
## Summary
- sync A3S Use to the merged package-level cognitive lifecycle saga
- document Tool, MCP, OKF, Skill, and UI as package-owned contributions
- preserve replaceable TUF registry sources and explicit production integration gaps

## Validation
- just use-hotplug-e2e
- just marketplace-science-e2e
- just marketplace-science-browser-e2e
- git diff --check origin/main...HEAD

Use PR: A3S-Lab/Use#28