### PR TITLE
chore: sync a3s-bench v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Synced the Bench integration snapshot to v0.1.2 and documented its managed
+  Linux x86_64 and macOS arm64 component release boundary.
 - Stopped Code TUI startup from waiting for A3S Use discovery, verified
   first-use installation, and capability projection; they now continue in the
   background. Ready

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ that implements it.
 | **Box** | `a3s box ps` | Managed product for explicit local isolation and OCI workloads |
 | **Search** | `a3s search …` | Managed Browser-first search product with quality-gated fallbacks |
 | **Use** | `a3s use capabilities --json` | Managed package and capability facade; packages keep their own release boundaries |
-| **Bench** | `a3s bench …` | Managed evaluation product; source and route exist, but a compatible umbrella component release is still pending |
+| **Bench** | `a3s bench …` | Managed evaluation product; [v0.1.2](https://github.com/A3S-Lab/Bench/releases/tag/v0.1.2) ships compatible components for Linux x86_64 and macOS arm64 |
 | **Cloud** | [`compat/cloud-stack.acl`](compat/cloud-stack.acl) | Self-hosted control plane governed by a revision and protocol compatibility lock |
 
 Use the machine-readable commands before scripting an optional product:
@@ -159,7 +159,7 @@ integration snapshot pinned by `main`:
 | --- | --- |
 | Root CLI | Code, Web, Research, configuration, auth, models, diagnostics, component lifecycle, and self-management are root-owned |
 | Managed products | Box, Search, and Use install and run as independently versioned components; artifact availability is platform- and channel-specific |
-| Bench | Task, Candidate, Driver, Judge, result, and validation flows are implemented; local runs require Docker and remain `local_unofficial` until a compatible umbrella release is published |
+| Bench | [v0.1.2](https://github.com/A3S-Lab/Bench/releases/tag/v0.1.2) is installable on Linux x86_64 and macOS arm64; local runs require Docker and remain `local_unofficial` by governance |
 | Cloud | R0–E0 is the verified cumulative baseline; later milestones remain tracked by the canonical [Cloud compatibility manifest](compat/cloud-stack.acl) |
 | Early projects | Ash is pre-release, Parser is pre-alpha, Office is pre-1.0, and OCI Runtime's native Linux path is experimental rather than the default launch claim |
 


### PR DESCRIPTION
## Summary

- pin `crates/bench` to the published A3S Bench `v0.1.2` merge commit
- replace the obsolete compatible-release-pending README boundary with the actual Linux x86_64 and macOS arm64 availability
- record the integration snapshot update in the root Unreleased changelog

## Release evidence

- Bench tag `v0.1.2` resolves to `bcc14d5a00e4d3f2a8939e44494724932b06d383`
- Bench release workflow `30983819578` passed validation, tests, Clippy, Docker/runtime/imported smoke tests, both packages, and publish
- downloaded Linux and macOS archives match their published SHA-256 files
- both component manifests declare schema `a3s.component.v1`, protocol `a3s-bench-cli/v1`, version `0.1.2`, and the expected target/entrypoint
- archive names match the umbrella `BenchPackage` resolver

## Validation

- root README `beautify-github-readme` audit
- repository-local README link resolution
- GitHub GFM Markdown API render
- `git diff --check`

`compat/cloud-stack.acl` is unchanged because Bench is not part of the Cloud compatibility lock.
