### PR TITLE
chore: sync agentic-parser repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,7 +90,7 @@
 	url = git@github.com:A3S-Lab/OCR.git
 [submodule "crates/parser"]
 	path = crates/parser
-	url = git@github.com:A3S-Lab/Parser.git
+	url = git@github.com:contra-sense/agentic-parser.git
 [submodule "crates/test"]
 	path = crates/test
 	url = git@github.com:A3S-Lab/Test.git


### PR DESCRIPTION
## Summary

- migrate the crates/parser submodule URL to git@github.com:contra-sense/agentic-parser.git
- advance the parser gitlink to contra-sense/agentic-parser main at 422496741489e7621c717b18143dfd432daeec20

## Verification

- root branch is based on the latest A3S-Lab/a3s main
- .gitmodules resolves the new canonical SSH URL
- the initialized parser submodule origin uses the new repository
- the gitlink exactly matches the merged agentic-parser PR #20 commit
- parser submodule working tree is clean