### PR TITLE
chore: sync atomic Use graph upgrades

### DIFF
--- a/tests/web_plugin_marketplace/real_e2e.rs
+++ b/tests/web_plugin_marketplace/real_e2e.rs
@@ -52,7 +52,13 @@ fn real_marketplace_installs_uses_and_removes_packaged_science_extension() {
     fs::write(&config, test_config()).expect("write config fixture");
 
     let version = run_use_json(&temp, &use_binary, &["--version", "--json"]);
-    assert_eq!(version["data"]["version"], manifest.version);
+    assert_eq!(version["schemaVersion"], 1);
+    assert_eq!(version["ok"], true);
+    let engine_version = version["data"]["version"]
+        .as_str()
+        .filter(|version| !version.is_empty())
+        .expect("A3S Use engine version");
+    assert_eq!(version["version"], engine_version);
     replace_registry(
         &temp,
         &config,


### PR DESCRIPTION
## Summary

- advance the crates/use gitlink from the website baseline to Use main at merge commit 7f1964a
- bring in dependency-graph Add/Replace/Retain upgrade, automatic pre-cutover rollback, reverse prior retirement, and crash replay
- stop conflating the A3S Use engine version with the independently versioned Science cognitive package in Web Marketplace E2E

## Verification

- cargo fmt --all -- --check
- just use-hotplug-e2e
  - real Use install, upgrade, rebuild, disable, and enable
  - Code TUI first-use release installation
- just marketplace-science-e2e
  - signed Registry install/use/uninstall
  - release-bundled install/use/uninstall
- just marketplace-science-browser-e2e
  - A3S Test ACL install, activity projection, iframe content, disable/enable, uninstall
  - empty browser console and page-error evidence

The first browser attempt stopped before product startup because Bun failed to extract two cached tarballs. A locked dependency-install retry succeeded and the unchanged ACL then passed.