### PR TITLE
chore(use): advance dependency graph lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ that implements it.
 | **Top** | `a3s top` | Bundled view of agents, containers, sessions, and events |
 | **Box** | `a3s box ps` | Managed product for explicit local isolation and OCI workloads |
 | **Search** | `a3s search …` | Managed Browser-first search product with quality-gated fallbacks |
-| **Use** | `a3s use capabilities --json` | Managed package and capability facade; packages keep their own release boundaries |
+| **Use** | `a3s use capabilities --json` | Independently versioned AI-native package manager for signed dependency graphs and hot-pluggable Tool, MCP, OKF, A3S Flow, Skill, and UI surfaces |
 | **Bench** | `a3s bench …` | Managed evaluation product; [v0.1.2](https://github.com/A3S-Lab/Bench/releases/tag/v0.1.2) ships compatible components for Linux x86_64 and macOS arm64 |
 | **Cloud** | [`compat/cloud-stack.acl`](compat/cloud-stack.acl) | Self-hosted control plane governed by a revision and protocol compatibility lock |
 
@@ -175,7 +175,8 @@ integration snapshot pinned by `main`:
 | Area | Current boundary |
 | --- | --- |
 | Root CLI | Code, Web, Research, configuration, auth, models, diagnostics, component lifecycle, and self-management are root-owned |
-| Managed products | Box, Search, and Use install and run as independently versioned components; artifact availability is platform- and channel-specific |
+| Managed products | Box and Search install and run as independently versioned components; artifact availability is platform- and channel-specific |
+| Use | `main` pins the v0.3 cognitive-package line: replaceable TUF registries, exact SemVer dependency locks, atomic graph upgrade and removal, and one capability cutover across Tool, MCP, OKF, A3S Flow, Skill, and UI. Production Knowledge, Service/HTTP hosts, grant composition, distributed Flow, and complete cross-platform real-process E2E remain release gates. |
 | Bench | [v0.1.2](https://github.com/A3S-Lab/Bench/releases/tag/v0.1.2) is installable on Linux x86_64 and macOS arm64; local runs require Docker and remain `local_unofficial` by governance |
 | Cloud | R0–E0 is the verified cumulative baseline; later milestones remain tracked by the canonical [Cloud compatibility manifest](compat/cloud-stack.acl) |
 | Early projects | Ash is pre-release, Parser is pre-alpha, Office is pre-1.0, and OCI Runtime's native Linux path is experimental rather than the default launch claim |
@@ -263,6 +264,9 @@ just code
 just web
 just docs
 just windhole
+just use-hotplug-e2e
+just marketplace-science-e2e
+just marketplace-science-browser-e2e
 just cloud-stack-check
 ```
 


### PR DESCRIPTION
## Summary

- advance the pinned A3S Use revision to the dependency-graph garbage-collection baseline
- document the v0.3 cognitive-package boundary, six projected surfaces, and remaining release gates
- expose the three repository-level Use/Science integration commands in the root README

## Validation

- `cargo test --workspace --all-features --locked` in A3S Use
- `cargo test --workspace --all-features --locked -- --test-threads=1` in A3S Use
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` in A3S Use
- `cargo fmt --all -- --check` in A3S Use
- 17/17 remote A3S Use CLI process tests
- `just use-hotplug-e2e`: 2/2 focused real-process gates passed
- `just marketplace-science-e2e`: 2/2 release-bundle and signed-TUF lifecycle tests passed
- `just marketplace-science-browser-e2e`: deterministic A3S Test ACL passed; console errors 0, page errors 0, cleanup errors 0
- `git diff --check`

The root integration gates were also exercised in an isolated worktree against the exact pinned Code `1caabb9a` revision. This was necessary because `origin/main` already pins the unpublished `a3s-code-core = 6.8.0` while retaining a 6.5.2 lock entry, and its newly added Harness needs Axum's `IntoFuture` conversion before the root binary compiles. Neither baseline workaround is included in this scoped Use gitlink update.

## Existing remote-main failures

The current `origin/main` is red independently of this PR: A3S CLI cannot resolve unpublished Code Core 6.8.0, Cloud compatibility/docs locks do not match the latest synchronized gitlinks, and recursive workflows reference unavailable Desktop/Parser repositories. These failures predate this branch and are intentionally not hidden or broadened into this Use integration change.
