### PR TITLE
chore: update Cloud compatibility lock

### DIFF
--- a/apps/docs/cloud-releases/cloud-0.1.0.json
+++ b/apps/docs/cloud-releases/cloud-0.1.0.json
@@ -4,7 +4,7 @@
   "releaseKind": "integration-snapshot",
   "milestone": "E0",
   "milestoneStatus": "verified",
-  "cloudRevision": "b5aae34b374eb7d64f2c0784568e6b7d92a466c2",
+  "cloudRevision": "d46873b2c2911b039dc480a980699285cfe5dd6a",
   "compatibilityLock": "compat/cloud-stack.acl",
   "documents": {
     "en": "/en/docs/cloud/v0.1.0",
@@ -14,7 +14,7 @@
     "acl": { "version": "0.3.0", "revision": "5317e166222495585909d81f2caffdca90273c99" },
     "boot": { "version": "0.1.3", "revision": "3119d61f1ae9b995913e34abd467ceaadc378a5f" },
     "box": { "version": "3.2.0", "revision": "9ee75351ed1c5b5648639476e664c97825879f89" },
-    "cloud": { "version": "0.1.0", "revision": "b5aae34b374eb7d64f2c0784568e6b7d92a466c2" },
+    "cloud": { "version": "0.1.0", "revision": "d46873b2c2911b039dc480a980699285cfe5dd6a" },
     "event": { "version": "0.3.0", "revision": "6df3d6551a2a3ab68b2f8271d33a87b078fc8151" },
     "flow": { "version": "0.4.3", "revision": "1675376dbced0a65afce2141e799dcdceb8e475d" },
     "gateway": { "version": "1.0.13", "revision": "d49ee2b324345104cc28d68b637d7e47bd110b44" },

--- a/apps/docs/docs/en/docs/cloud/v0.1.0/index.mdx
+++ b/apps/docs/docs/en/docs/cloud/v0.1.0/index.mdx
@@ -12,7 +12,7 @@ Snapshot: `cloud-0.1.0`
 This is versioned documentation for the E0 integration snapshot. It is not a
 production support declaration and no matching GitHub release has been
 published. The evidence boundary is the clean-host E0 gate described in the
-[pinned Cloud development plan](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/docs/development-plan.md).
+[pinned Cloud development plan](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/docs/development-plan.md).
 
 ## Capability status
 
@@ -34,7 +34,7 @@ drifts from that lock.
 | ACL | `0.3.0` | `5317e166222495585909d81f2caffdca90273c99` |
 | Boot | `0.1.3` | `3119d61f1ae9b995913e34abd467ceaadc378a5f` |
 | Box | `3.2.0` | `9ee75351ed1c5b5648639476e664c97825879f89` |
-| Cloud | `0.1.0` | `b5aae34b374eb7d64f2c0784568e6b7d92a466c2` |
+| Cloud | `0.1.0` | `d46873b2c2911b039dc480a980699285cfe5dd6a` |
 | Event | `0.3.0` | `6df3d6551a2a3ab68b2f8271d33a87b078fc8151` |
 | Flow | `0.4.3` | `1675376dbced0a65afce2141e799dcdceb8e475d` |
 | Gateway | `1.0.13` | `d49ee2b324345104cc28d68b637d7e47bd110b44` |

--- a/apps/docs/docs/en/docs/cloud/v0.1.0/install-upgrade.mdx
+++ b/apps/docs/docs/en/docs/cloud/v0.1.0/install-upgrade.mdx
@@ -45,9 +45,9 @@ apps/cloud/target/release/a3s-cloud-control-plane apps/cloud/config/cloud.acl
 ```
 
 Startup applies the checked-in migrations. Keep the complete
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/cloud.acl)
 and
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/node.example.acl)
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/node.example.acl)
 as the starting point; both are parsed by the docs gate and by Cloud's typed
 configuration tests.
 

--- a/apps/docs/docs/en/docs/cloud/v0.1.0/interfaces.mdx
+++ b/apps/docs/docs/en/docs/cloud/v0.1.0/interfaces.mdx
@@ -33,7 +33,7 @@ tenant routes require an API token with the declared scope.
 
 Do not copy a generated schema into source documentation. Start the exact
 binary and retrieve `/api/v1/openapi.json`. Its registration is tied to the
-[pinned API contract source](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/crates/control-plane/src/presentation/api_contract/route.rs),
+[pinned API contract source](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/crates/control-plane/src/presentation/api_contract/route.rs),
 and the docs gate fails if that source marker changes.
 
 ## Events and node protocols
@@ -41,19 +41,19 @@ and the docs gate fails if that source marker changes.
 Event keys are lowercase dot-separated names. The envelope carries event ID,
 key, schema version, organization, aggregate identity/version, timestamps,
 correlation/causation IDs, and JSON payload; see the
-[pinned contract](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/crates/contracts/src/event.rs).
+[pinned contract](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/crates/contracts/src/event.rs).
 NATS is a relay of the PostgreSQL outbox, not a second business authority.
 
 Node request/response schemas live in the
-[pinned contracts directory](https://github.com/A3S-Lab/Cloud/tree/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/crates/contracts/src/node).
+[pinned contracts directory](https://github.com/A3S-Lab/Cloud/tree/d46873b2c2911b039dc480a980699285cfe5dd6a/crates/contracts/src/node).
 They are private infrastructure contracts authenticated by node identity; they
 must not be exposed as unauthenticated public REST.
 
 ## ACL
 
 ACL means A3S Agent Configuration Language, not HCL. The complete shipped
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/cloud.acl)
 and
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/node.example.acl)
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/node.example.acl)
 are the versioned references. Unknown blocks and fields fail closed. Secrets
 are referenced by environment-variable name; values do not belong in ACL.

--- a/apps/docs/docs/zh/docs/cloud/v0.1.0/index.mdx
+++ b/apps/docs/docs/zh/docs/cloud/v0.1.0/index.mdx
@@ -11,7 +11,7 @@ Snapshot: `cloud-0.1.0`
 
 这是 E0 集成快照的版本化文档，不是生产支持声明，目前也没有发布对应的 GitHub
 release。证据边界是固定 Cloud revision 的
-[开发计划](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/docs/development-plan.md)
+[开发计划](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/docs/development-plan.md)
 中定义的 clean-host E0 gate。
 
 ## 能力状态
@@ -33,7 +33,7 @@ release manifest 或兼容锁发生漂移时失败。
 | ACL | `0.3.0` | `5317e166222495585909d81f2caffdca90273c99` |
 | Boot | `0.1.3` | `3119d61f1ae9b995913e34abd467ceaadc378a5f` |
 | Box | `3.2.0` | `9ee75351ed1c5b5648639476e664c97825879f89` |
-| Cloud | `0.1.0` | `b5aae34b374eb7d64f2c0784568e6b7d92a466c2` |
+| Cloud | `0.1.0` | `d46873b2c2911b039dc480a980699285cfe5dd6a` |
 | Event | `0.3.0` | `6df3d6551a2a3ab68b2f8271d33a87b078fc8151` |
 | Flow | `0.4.3` | `1675376dbced0a65afce2141e799dcdceb8e475d` |
 | Gateway | `1.0.13` | `d49ee2b324345104cc28d68b637d7e47bd110b44` |

--- a/apps/docs/docs/zh/docs/cloud/v0.1.0/install-upgrade.mdx
+++ b/apps/docs/docs/zh/docs/cloud/v0.1.0/install-upgrade.mdx
@@ -42,9 +42,9 @@ apps/cloud/target/release/a3s-cloud-control-plane apps/cloud/config/cloud.acl
 ```
 
 启动时会应用已检入 migration。应以完整的
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/cloud.acl)
 和
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/node.example.acl)
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/node.example.acl)
 为起点。文档 gate 使用锁定的 `a3s-acl` 解析它们，Cloud 类型化配置测试也会验证它们。
 
 接入流量前验证进程与依赖健康：

--- a/apps/docs/docs/zh/docs/cloud/v0.1.0/interfaces.mdx
+++ b/apps/docs/docs/zh/docs/cloud/v0.1.0/interfaces.mdx
@@ -31,24 +31,24 @@ Snapshot: `cloud-0.1.0`
 
 不要把生成 schema 手工复制进源码文档。启动精确二进制并读取
 `/api/v1/openapi.json`。注册位置固定在
-[API contract source](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/crates/control-plane/src/presentation/api_contract/route.rs)；
+[API contract source](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/crates/control-plane/src/presentation/api_contract/route.rs)；
 该 source marker 改变时文档 gate 会失败。
 
 ## 事件与节点协议
 
 Event key 使用小写点分格式。envelope 携带 event ID、key、schema version、organization、
 aggregate identity/version、timestamp、correlation/causation ID 与 JSON payload；参见
-[固定 contract](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/crates/contracts/src/event.rs)。
+[固定 contract](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/crates/contracts/src/event.rs)。
 NATS 是 PostgreSQL outbox 的 relay，不是第二个业务权威来源。
 
 Node request/response schema 位于
-[固定 contracts 目录](https://github.com/A3S-Lab/Cloud/tree/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/crates/contracts/src/node)。
+[固定 contracts 目录](https://github.com/A3S-Lab/Cloud/tree/d46873b2c2911b039dc480a980699285cfe5dd6a/crates/contracts/src/node)。
 它们是由节点 identity 认证的私有基础设施 contract，不得作为未认证公共 REST 暴露。
 
 ## ACL
 
 ACL 指 A3S Agent Configuration Language，不是 HCL。完整发布参考是
-[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/cloud.acl)
+[`cloud.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/cloud.acl)
 和
-[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/b5aae34b374eb7d64f2c0784568e6b7d92a466c2/config/node.example.acl)。
+[`node.example.acl`](https://github.com/A3S-Lab/Cloud/blob/d46873b2c2911b039dc480a980699285cfe5dd6a/config/node.example.acl)。
 未知 block 与字段会 fail closed。ACL 只引用环境变量名，不能包含 secret value。

--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "b5aae34b374eb7d64f2c0784568e6b7d92a466c2"
+  revision = "d46873b2c2911b039dc480a980699285cfe5dd6a"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- advance the Cloud submodule to the merged node-wide MCP Gateway aggregation implementation
- update the canonical Cloud compatibility lock to the same exact revision

## Validation
- `node --test scripts/verify-cloud-stack.test.mjs` (9 passed)
- `node scripts/verify-cloud-stack.mjs`
- `cargo metadata --manifest-path apps/cloud/Cargo.toml --locked --format-version 1 --no-deps`
- Cloud PR A3S-Lab/Cloud#120 required CI and real PostgreSQL C0.1/C0.2 gates passed