### PR TITLE
chore(cloud): sync MCP profile lifecycle stack

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "d46873b2c2911b039dc480a980699285cfe5dd6a"
+  revision = "9cd849fa4fdebf6461b81079930821d323e1883c"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- advance the Cloud gitlink to A3S-Lab/Cloud@9cd849fa4fdebf6461b81079930821d323e1883c
- update the canonical ACL compatibility lock in the same commit
- preserve all other component and protocol revisions

## Verification
- node --test scripts/verify-cloud-stack.test.mjs (9/9)
- node scripts/verify-cloud-stack.mjs
- cargo metadata --manifest-path apps/cloud/Cargo.toml --locked --format-version 1
- Cloud PR #123: all CI and real A3S Box Provider checks passed