### PR TITLE
chore: pin Windows cognitive lifecycle gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ The standalone Use lifecycle composes real `a3s-flow` Native TypeScript
 preflight only when `A3S_FLOW_NATIVE_TS_COMPILER` identifies an explicit
 absolute compiler path. Failed preflight keeps the candidate installed-disabled
 with no active named-surface projection; retry after provider repair resumes the
-same durable plan and generation. Signed Unix real-process tests cover
-install, restart observation, exact upgrade, uninstall, failure, and replay.
+same durable plan and generation. Signed Unix and Windows x86_64 real-process
+tests cover install, restart observation, exact upgrade, uninstall, failure,
+and replay.
 
 Install, upgrade, and uninstall accept only verified catalog-v3 evidence with
 complete Use-owned dependency locks. Reviewed apply runs through Use in the
@@ -216,7 +217,7 @@ describe the integration snapshot pinned by this repository's `main` branch:
 | --- | --- |
 | Standalone CLI | Code, Web, Research, configuration, auth, models, diagnostics, reviewed plugin plan/apply, component lifecycle, CI, tags, and releases are owned by `A3S-Lab/CLI`; this repository pins one reviewed gitlink |
 | Managed products | Box and Search install and run as independently versioned components; artifact availability is platform- and channel-specific |
-| Use | `main` pins the single current preview baseline: manifest/catalog/receipt v3, plan/host v4, manager tools v3, exact SemVer dependency locks, replaceable TUF Registries, in-process reviewed Grants and graph apply, shared dependency ownership, restart-safe hot-plug across Tool, MCP, OKF, A3S Flow, Skill, and UI, and explicit standalone Flow preflight with exact replay. Managed Knowledge/UI carriers, Runtime Service, HTTP MCP/Gateway, distributed Flow recovery/retention, production Registry operations, and real-process cross-platform CLI/TUI/Web E2E remain release gates. Use is not a released product. |
+| Use | `main` pins the single current preview baseline: manifest/catalog/receipt v3, plan/host v4, manager tools v3, exact SemVer dependency locks, replaceable TUF Registries, in-process reviewed Grants and graph apply, shared dependency ownership, restart-safe hot-plug across Tool, MCP, OKF, A3S Flow, Skill, and UI, explicit standalone Flow preflight with exact replay, and a Windows x86_64 signed Registry/graph/Grant/Flow/OKF CLI lifecycle gate. Managed Knowledge/UI carriers, Runtime Service, HTTP MCP/Gateway, distributed Flow recovery/retention, production Registry operations, and the complete cross-platform CLI/TUI/Web real-process matrix remain release gates. Use is not a released product. |
 | Bench | [v0.1.2](https://github.com/A3S-Lab/Bench/releases/tag/v0.1.2) is installable on Linux x86_64 and macOS arm64; local runs require Docker and remain `local_unofficial` by governance |
 | Cloud | R0–E0 is the verified cumulative baseline; later milestones remain tracked by the canonical [Cloud compatibility manifest](compat/cloud-stack.acl) |
 | Early projects | Ash is pre-release, Parser is pre-alpha, Office is pre-1.0, and OCI Runtime's native Linux path is experimental rather than the default launch claim |


### PR DESCRIPTION
## Summary

- pin A3S Use merge 70b953a with the Windows signed cognitive-package lifecycle gate
- update the root README with the verified Windows preview coverage and remaining release blockers

## Validation

- just use-hotplug-e2e
  - signed install, upgrade, Code session rebuild, and uninstall
  - Code TUI first-use installation through a real A3S Use process

Science-specific development and E2E remain out of scope.