### PR TITLE
chore: update Use registry source baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ operator-selected ACL source under a normalized digest lock. An automatically
 discovered workspace ACL cannot authorize plugin mutation, and an existing Web
 process is reused only when its policy digest and offline mode match exactly.
 
+The standalone Use host now persists a bounded named Registry set in canonical
+ACL with an enabled/default selection and a content-derived configuration
+revision. Install and upgrade accept only an optional source name, resolve
+dependencies across the complete enabled set, and report the exact source
+revision used. Each source identity binds its name, canonical URL, and pinned
+bootstrap-root digest to an isolated TUF/cache datastore. Reviewed replacement,
+default selection, enablement, disablement, and removal use revision-bound
+confirmation; they do not rewrite installed provenance or delete prior source
+evidence.
+
 The pinned Runtime/Use/CLI line now shares one managed execution lifecycle.
 Running Services publish generation-bound typed loopback endpoints; retirement
 drains the Gateway route, stops Runtime, removes the route, removes Runtime,
@@ -259,7 +269,7 @@ describe the integration snapshot pinned by this repository's `main` branch:
 | --- | --- |
 | Standalone CLI | Code, Web, Research, configuration, auth, models, diagnostics, reviewed plugin plan/apply, shared TUI/Web Plugin Manager policy, shared Use managed lifecycle composition, component lifecycle, CI, tags, and releases are owned by `A3S-Lab/CLI`; this repository pins one reviewed gitlink |
 | Managed products | Box and Search install and run as independently versioned components; artifact availability is platform- and channel-specific |
-| Use | `main` pins the single current preview baseline: manifest/catalog/receipt v3, plan/host v4, manager tools v3, exact SemVer dependency locks, replaceable TUF Registries, in-process reviewed Grants and graph apply, shared dependency ownership, restart-safe hot-plug across Tool, MCP, OKF, A3S Flow, Skill, and UI, typed Runtime Service endpoint consumption with Gateway drain → Runtime stop → route removal → Runtime removal, explicit standalone Flow preflight with exact replay, a scope-aware local SQLite/FTS5 OKF Knowledge carrier with cited TUI/Web search and exact published-generation query leases, receipt-accounted scope quota, bounded generations/tombstones, physical cleanup, usage diagnostics, scope-bound integrity audit, derived-index repair, versioned backup/offline verification, and a Windows x86_64 signed Registry/graph/Grant/Flow/OKF CLI lifecycle plus killed-process cutover-recovery gate. Managed Knowledge rollback, coordinated restore and authority recovery, backup rotation, distributed Knowledge placement, managed UI delivery, production Runtime provider selection and Gateway injection for Tool Service/HTTP MCP, distributed Flow recovery/retention, production Registry operations, and the complete cross-platform CLI/TUI/Web real-process matrix remain release gates. Use is not a released product. |
+| Use | `main` pins the single current preview baseline: manifest/catalog/receipt v3, plan/host v4, manager tools v3, exact SemVer dependency locks, revision-addressed canonical-ACL Registry sources with identity-isolated TUF/cache state, in-process reviewed Grants and graph apply, shared dependency ownership, restart-safe hot-plug across Tool, MCP, OKF, A3S Flow, Skill, and UI, typed Runtime Service endpoint consumption with Gateway drain → Runtime stop → route removal → Runtime removal, explicit standalone Flow preflight with exact replay, a scope-aware local SQLite/FTS5 OKF Knowledge carrier with cited TUI/Web search and exact published-generation query leases, receipt-accounted scope quota, bounded generations/tombstones, physical cleanup, usage diagnostics, scope-bound integrity audit, derived-index repair, versioned backup/offline verification, and a Windows x86_64 signed Registry/graph/Grant/Flow/OKF CLI lifecycle plus killed-process cutover-recovery gate. Managed Knowledge rollback, coordinated restore and authority recovery, backup rotation, distributed Knowledge placement, managed UI delivery, production Runtime provider selection and Gateway injection for Tool Service/HTTP MCP, distributed Flow recovery/retention, production Registry operations, and the complete cross-platform CLI/TUI/Web real-process matrix remain release gates. Use is not a released product. |
 | Bench | [v0.1.2](https://github.com/A3S-Lab/Bench/releases/tag/v0.1.2) is installable on Linux x86_64 and macOS arm64; local runs require Docker and remain `local_unofficial` by governance |
 | Cloud | R0–E0 is the verified cumulative baseline; later milestones remain tracked by the canonical [Cloud compatibility manifest](compat/cloud-stack.acl) |
 | Early projects | Ash is pre-release, Parser is pre-alpha, Office is pre-1.0, and OCI Runtime's native Linux path is experimental rather than the default launch claim |


### PR DESCRIPTION
## Summary

- advance only crates/use from 1d00d3f to the merged Use PR #76 baseline 74e35fc
- document durable canonical-ACL Registry source configuration, revision binding, enabled dependency sources, and identity-isolated TUF/cache state
- leave packages/science uninitialized and pinned at 225642b60be5494698a0cf8803994f44f9959d9e

## Verification

- Use PR #76 passed Linux/Core, macOS, Windows real-process cognitive-package lifecycle, installer, supply-chain, and Docs gates
- root git diff --check
- fresh-clone gitlink inspection confirms only crates/use changed

A3S Use remains a development preview and is not production-ready.