### PR TITLE
fix(ci): make CLI relay checksum check portable

### DIFF
--- a/.github/workflows/relay-cli-release.yml
+++ b/.github/workflows/relay-cli-release.yml
@@ -124,8 +124,7 @@ jobs:
             fi
             for archive in "${archives[@]}"; do
               expected="$(awk -v asset="$archive" \
-                '($2 == asset || $2 == "*" asset) && length($1) == 64
-                 && $1 !~ /[^0-9a-f]/ { digest = $1; count += 1 }
+                '($2 == asset || $2 == "*" asset) && length($1) == 64 && $1 !~ /[^0-9a-f]/ { digest = $1; count += 1 }
                  END { if (count == 1) print digest }' "$checksum")"
               actual="$(sha256sum "source-assets/${archive}" | awk '{ print $1 }')"
               if [[ -z "$expected" || "$actual" != "$expected" ]]; then


### PR DESCRIPTION
## Summary

- keep the checksum predicate on one portable awk source line
- unblock the verified legacy CLI release relay on Ubuntu runners

## Failure evidence

- failed relay run: https://github.com/A3S-Lab/a3s/actions/runs/32262244136
- the source release and all canonical assets were public and intact
- the job stopped before creating a root tag or release

## Validation

- portable checksum fixture accepts plain and binary-marker asset names
- invalid hexadecimal digests remain rejected
- `git diff --check`
- `bash .github/scripts/check-cli-integration.sh`

No local build was run.