### PR TITLE
fix(ci): verify draft relay assets through API

### DIFF
--- a/.github/workflows/relay-cli-release.yml
+++ b/.github/workflows/relay-cli-release.yml
@@ -199,10 +199,29 @@ jobs:
           EOF
 
           verify_relay() {
+            local asset_id
+            local relay_id
+            local relay_json
+            relay_id="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" \
+              --json databaseId --jq .databaseId)"
+            if ! [[ "$relay_id" =~ ^[0-9]+$ ]]; then
+              echo "::error::Could not resolve the owned relay release ID"
+              exit 1
+            fi
+            relay_json="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/${relay_id}")"
+
             rm -rf relayed-assets
             mkdir relayed-assets
-            gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-              --dir relayed-assets --pattern "a3s-${tag}-*"
+            while IFS= read -r asset; do
+              asset_id="$(jq -er --arg asset "$asset" \
+                '[.assets[] | select(.name == $asset)]
+                 | if length == 1 then .[0].id else empty end' \
+                <<<"$relay_json")"
+              gh api -H "Accept: application/octet-stream" \
+                "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+                > "relayed-assets/${asset}"
+            done < expected-assets.txt
             find relayed-assets -mindepth 1 -maxdepth 1 -type f \
               -exec basename {} \; | sort > relayed-assets.txt
             diff -u expected-assets.txt relayed-assets.txt
@@ -214,7 +233,8 @@ jobs:
             done < expected-assets.txt
 
             for attempt in 1 2 3 4 5 6 7 8 9 10; do
-              relay_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}")"
+              relay_json="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/releases/${relay_id}")"
               ready=true
               while IFS= read -r asset; do
                 relay_digest="$(jq -r --arg asset "$asset" \


### PR DESCRIPTION
## Summary

- resolve the owned draft Release database ID
- download draft assets through the authenticated Release Asset API
- verify draft digests through the release-ID endpoint before publication

## Failure evidence

- failed recovery run: https://github.com/A3S-Lab/a3s/actions/runs/32262684419
- source asset verification and upload both succeeded
- `gh release download` returned 404 because the draft has no published tag URL yet
- the owned draft contains all 11 expected assets; the root tag remains absent

## Validation

- authenticated download of a current draft checksum asset matched its GitHub SHA-256 digest
- workflow YAML parse
- `git diff --check`
- `bash .github/scripts/check-cli-integration.sh`

No local build was run.