### PR TITLE
Consolidate Form under UI

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - 'apps/docs/**'
       - '.github/workflows/site.yml'
+      - 'packages/ui'
   push:
     branches: [main]
     paths:
       - 'apps/docs/**'
       - '.github/workflows/site.yml'
+      - 'packages/ui'
   workflow_dispatch:
 
 permissions:
@@ -26,14 +28,18 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SITE_URL: https://a3s-lab.github.io/a3s/
-      FORM_REPOSITORY: https://github.com/A3S-Lab/Form.git
-      FORM_REVISION: b16990174f714af86727f49231553e8922216b52
+      UI_REPOSITORY: https://github.com/A3S-Lab/UI.git
+      UI_REVISION: b0446169548aacfcb95117de42728d6e273fc843
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - name: Install dependencies
         working-directory: apps/docs
@@ -53,24 +59,24 @@ jobs:
           sudo apt-get install --yes --no-install-recommends fonts-noto-cjk
           fc-cache --force
 
-      - name: Build pinned A3S Form preview
+      - name: Build pinned A3S Form preview from UI
         env:
           A3S_FORM_BASE: ./
         run: |
-          git init "$RUNNER_TEMP/a3s-form"
-          git -C "$RUNNER_TEMP/a3s-form" remote add origin "$FORM_REPOSITORY"
-          git -C "$RUNNER_TEMP/a3s-form" fetch --depth 1 origin "$FORM_REVISION"
-          git -C "$RUNNER_TEMP/a3s-form" switch --detach FETCH_HEAD
-          bun install --cwd "$RUNNER_TEMP/a3s-form" --frozen-lockfile
-          bun run --cwd "$RUNNER_TEMP/a3s-form" build
-          bun run --cwd "$RUNNER_TEMP/a3s-form" playground:build
+          git init "$RUNNER_TEMP/a3s-ui"
+          git -C "$RUNNER_TEMP/a3s-ui" remote add origin "$UI_REPOSITORY"
+          git -C "$RUNNER_TEMP/a3s-ui" fetch --depth 1 origin "$UI_REVISION"
+          git -C "$RUNNER_TEMP/a3s-ui" switch --detach FETCH_HEAD
+          npm --prefix "$RUNNER_TEMP/a3s-ui" ci
+          npm --prefix "$RUNNER_TEMP/a3s-ui" run build
+          npm --prefix "$RUNNER_TEMP/a3s-ui" run form:playground:build
 
       - name: Refresh project previews
         working-directory: apps/docs
         env:
           A3S_FORM_PREVIEW_URL: http://127.0.0.1:4176/
         run: |
-          bun "$RUNNER_TEMP/a3s-form/scripts/serve-playground.mjs" > "$RUNNER_TEMP/a3s-form-preview.log" 2>&1 &
+          node "$RUNNER_TEMP/a3s-ui/modules/form/scripts/serve-playground.mjs" > "$RUNNER_TEMP/a3s-form-preview.log" 2>&1 &
           form_preview_pid=$!
           trap 'kill "$form_preview_pid" 2>/dev/null || true' EXIT
           for attempt in {1..30}; do
@@ -88,8 +94,8 @@ jobs:
 
       - name: Publish A3S Form Playground
         run: |
-          test -f "$RUNNER_TEMP/a3s-form/playground-dist/index.html"
-          cp -R "$RUNNER_TEMP/a3s-form/playground-dist" apps/docs/out/form
+          test -f "$RUNNER_TEMP/a3s-ui/modules/form/playground-dist/index.html"
+          cp -R "$RUNNER_TEMP/a3s-ui/modules/form/playground-dist" apps/docs/out/form
 
       - name: Validate exported routes
         working-directory: apps/docs

--- a/.gitmodules
+++ b/.gitmodules
@@ -100,9 +100,6 @@
 [submodule "packages/ui"]
 	path = packages/ui
 	url = git@github.com:A3S-Lab/UI.git
-[submodule "packages/form"]
-	path = packages/form
-	url = git@github.com:A3S-Lab/Form.git
 [submodule "crates/moe"]
 	path = crates/moe
 	url = git@github.com:A3S-Lab/MoE.git

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ infrastructure dependency.
 | Layer | Contract | Owners |
 | --- | --- | --- |
 | **Host** | Invocation, policy, models, tools, permissions | [CLI](crates/cli/), [Code](crates/code/), [Cloud](apps/cloud/) |
-| **Extend** | Signed capabilities and typed content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](packages/form/), [Office](packages/office/), [Science](packages/science/) |
+| **Extend** | Signed capabilities and typed content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](packages/ui/modules/form/), [Office](packages/office/), [Science](packages/science/) |
 | **Coordinate** | Replay-safe workflows, events, queues, tests | [Flow](crates/flow/), [Event](crates/event/), [Lane](crates/lane/), [Bench](crates/bench/), [Test](crates/test/) |
 | **Execute** | Tasks, Services, isolation, model serving | [Runtime](crates/runtime/), [Box](crates/box/), [OCI Runtime](crates/oci-runtime/), [Power](crates/power/), [MoE](crates/moe/), [Boot](crates/boot/) |
 | **Scale** | Traffic, desired state, placement, reconciliation | [Gateway](crates/gateway/), [Cloud](apps/cloud/), [ORM](crates/orm/) |
@@ -198,7 +198,7 @@ root-owned.
 ```text
 a3s/
 ├── apps/       cloud control plane, docs, and Windhole
-├── packages/   Form, Office, Science, and UI
+├── packages/   Office, Science, and UI (including Form)
 ├── crates/     product hosts, capabilities, runtimes, services, and SDKs
 ├── compat/     exact cross-project revisions and protocol locks
 ├── assets/     repository-native README visuals
@@ -208,7 +208,7 @@ a3s/
 | Group | Projects |
 | --- | --- |
 | Product hosts | [CLI](crates/cli/), [Code](crates/code/), [Ash](crates/ash/), [Windhole](apps/windhole/), [Cloud](apps/cloud/) |
-| Capabilities and content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](packages/form/), [Office](packages/office/), [Science](packages/science/) |
+| Capabilities and content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](packages/ui/modules/form/), [Office](packages/office/), [Science](packages/science/) |
 | Runtime, inference, and coordination | [Runtime](crates/runtime/), [Box](crates/box/), [OCI Runtime](crates/oci-runtime/), [Power](crates/power/), [MoE](crates/moe/), [Flow](crates/flow/), [Event](crates/event/), [Lane](crates/lane/), [Memory](crates/memory/), [ORM](crates/orm/) |
 | Verification | [Bench](crates/bench/), [Test](crates/test/) |
 | Interfaces and services | [Boot](crates/boot/), [Gateway](crates/gateway/), [AHP](crates/ahp/), [ACL](crates/acl/), [Common](crates/common/), [TUI](crates/tui/), [GUI](crates/gui/), [UI](packages/ui/), [WebView](crates/webview/) |

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -82,7 +82,7 @@ Each project defines its own animation settle time in
 images, lets the hero reach that frame, then freezes CSS, SVG, video, and GIF
 motion before writing the PNG.
 
-The Form playground is built from a pinned revision and published with this
+The Form playground is built from a pinned UI revision and published with this
 site at `/form/`. Point the capture at a local build when refreshing its
 screenshot:
 
@@ -91,10 +91,11 @@ A3S_FORM_PREVIEW_URL=http://127.0.0.1:4173/ \
   bun run capture:sites --site=form
 ```
 
-The Pages workflow checks out a pinned Form revision, builds the playground,
-uses it for the screenshot step, and copies the same build to `out/form/` for
-deployment. Update `FORM_REVISION` in `.github/workflows/site.yml` when
-intentionally refreshing or publishing a newer Form commit.
+The Pages workflow checks out a pinned UI revision, builds the Form playground
+from `modules/form`, uses it for the screenshot step, and copies the same build
+to `out/form/` for deployment. Update `UI_REVISION` in
+`.github/workflows/site.yml` when intentionally refreshing or publishing a
+newer UI commit.
 
 The capture task keeps an existing committed image when a remote site is
 temporarily unavailable. Add or change destinations in

--- a/apps/docs/components/home/project-links.test.ts
+++ b/apps/docs/components/home/project-links.test.ts
@@ -3,9 +3,9 @@ import { describe, test } from 'node:test';
 import { getProjectPrimaryHref, getProjectRepositoryHref } from './project-links';
 
 describe('project links', () => {
-  test('opens the published Form playground while keeping GitHub separate', () => {
+  test('opens the published Form playground and links source to UI', () => {
     assert.equal(getProjectPrimaryHref('form'), '/form/');
-    assert.equal(getProjectRepositoryHref('form'), 'https://github.com/A3S-Lab/Form');
+    assert.equal(getProjectRepositoryHref('form'), 'https://github.com/A3S-Lab/UI');
   });
 
   test('opens the Site project at the ecosystem homepage', () => {

--- a/apps/docs/components/home/project-links.ts
+++ b/apps/docs/components/home/project-links.ts
@@ -32,7 +32,7 @@ export const projectLinks = {
     website: 'https://a3s-lab.github.io/Cloud/',
   },
   form: {
-    repository: 'https://github.com/A3S-Lab/Form',
+    repository: 'https://github.com/A3S-Lab/UI',
     website: '/form/',
   },
   site: {

--- a/apps/docs/components/home/project-sites.test.ts
+++ b/apps/docs/components/home/project-sites.test.ts
@@ -66,22 +66,25 @@ describe('featured project site previews', () => {
       new URL('../../../../.github/workflows/site.yml', import.meta.url),
       'utf8',
     );
-    const formRevision = workflow.indexOf('FORM_REVISION:');
+    const uiRepository = workflow.indexOf('UI_REPOSITORY: https://github.com/A3S-Lab/UI.git');
+    const uiRevision = workflow.indexOf('UI_REVISION:');
     const formBase = workflow.indexOf('A3S_FORM_BASE: ./');
-    const formBuild = workflow.indexOf('playground:build');
+    const formBuild = workflow.indexOf('form:playground:build');
     const formPreviewUrl = workflow.indexOf('A3S_FORM_PREVIEW_URL: http://127.0.0.1:4176/');
     const screenshotCapture = workflow.indexOf('bun run capture:sites');
     const siteBuild = workflow.indexOf('run: bun run build');
-    const formPublish = workflow.indexOf('cp -R "$RUNNER_TEMP/a3s-form/playground-dist" apps/docs/out/form');
+    const formPublish = workflow.indexOf('cp -R "$RUNNER_TEMP/a3s-ui/modules/form/playground-dist" apps/docs/out/form');
     const formValidation = workflow.indexOf("REQUIRE_FORM_PREVIEW: '1'");
 
-    assert.notEqual(formRevision, -1, 'Form preview source must be pinned');
+    assert.notEqual(uiRepository, -1, 'Form preview source must be the UI repository');
+    assert.notEqual(uiRevision, -1, 'UI preview source must be pinned');
     assert.notEqual(formBase, -1, 'Form playground assets must use relative paths');
     assert.notEqual(formBuild, -1, 'Form playground must be built');
     assert.notEqual(formPreviewUrl, -1, 'Capture must use the local Form build');
     assert.notEqual(formPublish, -1, 'Form playground must be included in the Pages artifact');
     assert.notEqual(formValidation, -1, 'Pages validation must require the Form playground');
-    assert.equal(formRevision < formBuild, true);
+    assert.equal(uiRepository < formBuild, true);
+    assert.equal(uiRevision < formBuild, true);
     assert.equal(formBase < formBuild, true);
     assert.equal(formBuild < screenshotCapture, true);
     assert.equal(formPreviewUrl < screenshotCapture, true);

--- a/apps/docs/scripts/check-built-site.mjs
+++ b/apps/docs/scripts/check-built-site.mjs
@@ -84,12 +84,13 @@ for (const marker of [
 for (const [homepage, locale] of [[chineseHome, 'Chinese'], [englishHome, 'English']]) {
   const projectStages = homepage.match(/class="a3s-project-delivery"/g) ?? [];
   const formLinkCount = homepage.split(`href="${formHref}"`).length - 1;
+  const uiRepositoryLinkCount = homepage.split('href="https://github.com/A3S-Lab/UI"').length - 1;
   assert(projectStages.length === 35, `${locale} homepage has ${projectStages.length} project stages instead of 35`);
   assert(!homepage.includes('a3s-project-progress'), `${locale} homepage still uses progress UI for categorical delivery stages`);
   assert(!homepage.includes('role="progressbar"'), `${locale} homepage still presents delivery stages as completion percentages`);
   assert(homepage.includes('/brand/a3s-os-logo.png'), `${locale} homepage does not use the A3S OS logo`);
   assert(formLinkCount >= 2, `${locale} homepage does not route both A3S Form entries to the published playground`);
-  assert(homepage.includes('https://github.com/A3S-Lab/Form'), `${locale} homepage is missing the separate A3S Form repository link`);
+  assert(uiRepositoryLinkCount >= 2, `${locale} homepage does not route both UI and Form source links to A3S-Lab/UI`);
   assert(homepage.includes('a3s-lab.github.io/Box'), `${locale} homepage does not feature the A3S Box site`);
   assert(!homepage.includes('id="architecture"'), `${locale} homepage still renders the architecture diagram`);
   assert(!homepage.includes('href="#architecture"'), `${locale} homepage still links to the architecture diagram`);

--- a/scripts/verify-cloud-stack.test.mjs
+++ b/scripts/verify-cloud-stack.test.mjs
@@ -90,6 +90,9 @@ test('the Form component resolves the native core package from its nested manife
   );
   assert.ok(form);
   assert.equal(form.manifest, 'modules/form/crates/a3s-form-core/Cargo.toml');
+  assert.equal(form.owner, 'A3S-Lab/UI');
+  assert.equal(form.path, 'packages/ui');
+  assert.equal(form.repository, 'git@github.com:A3S-Lab/UI.git');
   assert.equal(form.package, 'a3s-form-core');
   assert.equal(form.version, '0.1.0');
 });


### PR DESCRIPTION
## Summary

- remove the standalone `packages/form` submodule and advance `packages/ui` to the consolidated Form revision
- advance Cloud to its merged UI-backed Form Core dependency
- move the Cloud compatibility lock, protocol ownership, and conformance fixtures to `packages/ui/modules/form`
- build the mirrored Form Playground from the pinned UI repository in the Pages workflow
- update root and site documentation links to the UI-owned Form source

## Validation

- `just cloud-stack-check`
- `node --test scripts/verify-cloud-stack.test.mjs` (18/18)
- `bun run test` in `apps/docs` (21/21)
- `bun run typecheck` in `apps/docs`
- `SITE_URL=https://a3s-lab.github.io/a3s/ bun run build` in `apps/docs`
- `npm run build` and `A3S_FORM_BASE=./ npm run form:playground:build` at UI revision `b044616`
- exported Pages artifact validation with `REQUIRE_FORM_PREVIEW=1`