### PR TITLE
Point Form links to the UI module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ infrastructure dependency.
 | Layer | Contract | Owners |
 | --- | --- | --- |
 | **Host** | Invocation, policy, models, tools, permissions | [CLI](crates/cli/), [Code](crates/code/), [Cloud](apps/cloud/) |
-| **Extend** | Signed capabilities and typed content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](packages/ui/modules/form/), [Office](packages/office/), [Science](packages/science/) |
+| **Extend** | Signed capabilities and typed content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](https://github.com/A3S-Lab/UI/tree/main/modules/form), [Office](packages/office/), [Science](packages/science/) |
 | **Coordinate** | Replay-safe workflows, events, queues, tests | [Flow](crates/flow/), [Event](crates/event/), [Lane](crates/lane/), [Bench](crates/bench/), [Test](crates/test/) |
 | **Execute** | Tasks, Services, isolation, model serving | [Runtime](crates/runtime/), [Box](crates/box/), [OCI Runtime](crates/oci-runtime/), [Power](crates/power/), [MoE](crates/moe/), [Boot](crates/boot/) |
 | **Scale** | Traffic, desired state, placement, reconciliation | [Gateway](crates/gateway/), [Cloud](apps/cloud/), [ORM](crates/orm/) |
@@ -208,7 +208,7 @@ a3s/
 | Group | Projects |
 | --- | --- |
 | Product hosts | [CLI](crates/cli/), [Code](crates/code/), [Ash](crates/ash/), [Windhole](apps/windhole/), [Cloud](apps/cloud/) |
-| Capabilities and content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](packages/ui/modules/form/), [Office](packages/office/), [Science](packages/science/) |
+| Capabilities and content | [Use](crates/use/), [Browser](crates/browser/), [Search](crates/search/), [OCR](crates/ocr/), [Parser](crates/parser/), [Form](https://github.com/A3S-Lab/UI/tree/main/modules/form), [Office](packages/office/), [Science](packages/science/) |
 | Runtime, inference, and coordination | [Runtime](crates/runtime/), [Box](crates/box/), [OCI Runtime](crates/oci-runtime/), [Power](crates/power/), [MoE](crates/moe/), [Flow](crates/flow/), [Event](crates/event/), [Lane](crates/lane/), [Memory](crates/memory/), [ORM](crates/orm/) |
 | Verification | [Bench](crates/bench/), [Test](crates/test/) |
 | Interfaces and services | [Boot](crates/boot/), [Gateway](crates/gateway/), [AHP](crates/ahp/), [ACL](crates/acl/), [Common](crates/common/), [TUI](crates/tui/), [GUI](crates/gui/), [UI](packages/ui/), [WebView](crates/webview/) |

--- a/apps/docs/components/home/project-links.test.ts
+++ b/apps/docs/components/home/project-links.test.ts
@@ -5,7 +5,10 @@ import { getProjectPrimaryHref, getProjectRepositoryHref } from './project-links
 describe('project links', () => {
   test('opens the published Form playground and links source to UI', () => {
     assert.equal(getProjectPrimaryHref('form'), '/form/');
-    assert.equal(getProjectRepositoryHref('form'), 'https://github.com/A3S-Lab/UI');
+    assert.equal(
+      getProjectRepositoryHref('form'),
+      'https://github.com/A3S-Lab/UI/tree/main/modules/form',
+    );
   });
 
   test('opens the Site project at the ecosystem homepage', () => {

--- a/apps/docs/components/home/project-links.ts
+++ b/apps/docs/components/home/project-links.ts
@@ -32,7 +32,7 @@ export const projectLinks = {
     website: 'https://a3s-lab.github.io/Cloud/',
   },
   form: {
-    repository: 'https://github.com/A3S-Lab/UI',
+    repository: 'https://github.com/A3S-Lab/UI/tree/main/modules/form',
     website: '/form/',
   },
   site: {

--- a/apps/docs/scripts/check-built-site.mjs
+++ b/apps/docs/scripts/check-built-site.mjs
@@ -84,13 +84,15 @@ for (const marker of [
 for (const [homepage, locale] of [[chineseHome, 'Chinese'], [englishHome, 'English']]) {
   const projectStages = homepage.match(/class="a3s-project-delivery"/g) ?? [];
   const formLinkCount = homepage.split(`href="${formHref}"`).length - 1;
-  const uiRepositoryLinkCount = homepage.split('href="https://github.com/A3S-Lab/UI"').length - 1;
   assert(projectStages.length === 35, `${locale} homepage has ${projectStages.length} project stages instead of 35`);
   assert(!homepage.includes('a3s-project-progress'), `${locale} homepage still uses progress UI for categorical delivery stages`);
   assert(!homepage.includes('role="progressbar"'), `${locale} homepage still presents delivery stages as completion percentages`);
   assert(homepage.includes('/brand/a3s-os-logo.png'), `${locale} homepage does not use the A3S OS logo`);
   assert(formLinkCount >= 2, `${locale} homepage does not route both A3S Form entries to the published playground`);
-  assert(uiRepositoryLinkCount >= 2, `${locale} homepage does not route both UI and Form source links to A3S-Lab/UI`);
+  assert(
+    homepage.includes('href="https://github.com/A3S-Lab/UI/tree/main/modules/form"'),
+    `${locale} homepage does not route Form source to the UI module`,
+  );
   assert(homepage.includes('a3s-lab.github.io/Box'), `${locale} homepage does not feature the A3S Box site`);
   assert(!homepage.includes('id="architecture"'), `${locale} homepage still renders the architecture diagram`);
   assert(!homepage.includes('href="#architecture"'), `${locale} homepage still links to the architecture diagram`);


### PR DESCRIPTION
## Summary

- point README Form references directly to `A3S-Lab/UI/tree/main/modules/form`
- update the website Form source action to the consolidated UI module
- make the exported-site gate reject stale or generic Form source links

## Validation

- `bun run test` (21/21)
- `bun run typecheck`
- `SITE_URL=https://a3s-lab.github.io/a3s/ bun run build`
- `SITE_URL=https://a3s-lab.github.io/a3s/ bun run check:site`