### PR TITLE
feat(site): publish Power within A3S Pages

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'apps/docs/**'
+      - 'crates/power'
       - '.github/workflows/site.yml'
   push:
     branches: [main]
     paths:
       - 'apps/docs/**'
+      - 'crates/power'
       - '.github/workflows/site.yml'
   workflow_dispatch:
 
@@ -29,13 +31,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Initialize pinned Power site
+        run: >-
+          git -c url.https://github.com/.insteadOf=git@github.com:
+          submodule update --init --depth 1 crates/power
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: crates/power/site/package-lock.json
+
       - name: Install dependencies
         working-directory: apps/docs
         run: bun install --frozen-lockfile
+
+      - name: Install pinned Power site dependencies
+        run: npm ci --prefix crates/power/site
 
       - name: Test site data
         working-directory: apps/docs
@@ -44,6 +60,10 @@ jobs:
       - name: Typecheck site
         working-directory: apps/docs
         run: bun run typecheck
+
+      - name: Typecheck pinned Power site
+        working-directory: apps/docs
+        run: bun run typecheck:power
 
       - name: Install project preview fonts
         run: |

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,7 +1,8 @@
 # A3S Site
 
-This application builds the bilingual A3S ecosystem homepage with Rspress. It
-does not publish product documentation, tutorials, or articles.
+This application builds the bilingual A3S ecosystem homepage and publishes the
+pinned A3S Power website in the same Rspress-based Pages artifact. Other
+product documentation, tutorials, and articles remain with their owners.
 
 ## Routes
 
@@ -9,9 +10,13 @@ does not publish product documentation, tutorials, or articles.
 | --- | --- |
 | `/` | Chinese ecosystem homepage |
 | `/en/` | English ecosystem homepage |
+| `/power/` | Chinese A3S Power website and current documentation |
+| `/power/en/` | English A3S Power website and current documentation |
+| `/power/v0.9.0/` | Versioned A3S Power documentation |
 
-The production build runs Rspress once per language and assembles both outputs
-under `out/`. Chinese remains the unprefixed default language.
+The production build runs the ecosystem Rspress app once per language, builds
+the exact Power site locked by the `crates/power` gitlink, and assembles every
+route under `out/`. Chinese remains the unprefixed default language.
 
 ## Project layout
 
@@ -27,10 +32,15 @@ apps/docs/
 └── rspress.config.ts
 ```
 
+Power pages stay owned by `crates/power/site`; the main site consumes that
+locked source directly instead of copying its Markdown or theme.
+
 ## Development
 
 ```bash
+git -C ../.. submodule update --init crates/power
 bun install
+npm ci --prefix ../../crates/power/site
 bun run dev
 ```
 
@@ -52,6 +62,7 @@ Individual commands are also available:
 ```bash
 bun run test
 bun run typecheck
+bun run typecheck:power
 bun run build
 bun run check:site
 ```

--- a/apps/docs/components/home/ecosystem-directory.tsx
+++ b/apps/docs/components/home/ecosystem-directory.tsx
@@ -26,7 +26,11 @@ import {
 } from '@/components/home/ecosystem-status';
 import type { Lang } from '@/components/home/home-content';
 import { getProjectRepositoryHref } from '@/components/home/project-links';
-import { featuredProjectSites, type FeaturedProjectSite } from '@/components/home/project-sites';
+import {
+  featuredProjectSites,
+  getFeaturedProjectSiteHref,
+  type FeaturedProjectSite,
+} from '@/components/home/project-sites';
 
 type DirectoryFilter = 'all' | ArchitectureCategory;
 
@@ -151,7 +155,7 @@ function ProjectSitePreview({ project, site }: { project: ArchitectureProject; s
 
 function FeaturedSiteCard({ project, site, lang }: { project: ArchitectureProject; site: FeaturedProjectSite; lang: Lang }) {
   const tr = copy[lang];
-  const href = sharedSiteHref(site.href, lang);
+  const href = sharedSiteHref(getFeaturedProjectSiteHref(site, lang), lang);
 
   return (
     <article className="a3s-site-card" data-preview-mode={site.mode} data-site={project.id}>
@@ -182,7 +186,7 @@ function ProjectCard({ project, index, lang }: { project: ArchitectureProject; i
     site.id === project.id && site.destination === 'site'
   ));
   const projectHref = featuredSite
-    ? sharedSiteHref(featuredSite.href, lang)
+    ? sharedSiteHref(getFeaturedProjectSiteHref(featuredSite, lang), lang)
     : localizedHref(project.href, lang);
   const repositoryHref = getProjectRepositoryHref(project.id);
   const hasDistinctRepository = repositoryHref !== projectHref;

--- a/apps/docs/components/home/home-content.ts
+++ b/apps/docs/components/home/home-content.ts
@@ -10,6 +10,7 @@ export const homeContent = {
   en: {
     nav: {
       ecosystem: 'Ecosystem',
+      power: 'Power',
       principles: 'Principles',
       language: '中文',
       menu: 'Open navigation',
@@ -90,6 +91,7 @@ export const homeContent = {
   cn: {
     nav: {
       ecosystem: '生态',
+      power: 'Power',
       principles: '原则',
       language: 'EN',
       menu: '打开导航',

--- a/apps/docs/components/home/home-nav.tsx
+++ b/apps/docs/components/home/home-nav.tsx
@@ -8,9 +8,11 @@ export function HomeNav({ lang }: { lang: Lang }) {
   const homeHref = withBase('/');
   const rootHref = lang === 'en' ? homeHref.replace(/en\/$/, '') : homeHref;
   const languageHref = lang === 'cn' ? `${rootHref}en/` : rootHref;
+  const powerHref = lang === 'cn' ? `${rootHref}power/` : `${rootHref}power/en/`;
 
   const anchorLinks = [
     { label: tr.ecosystem, href: '#ecosystem' },
+    { label: tr.power, href: powerHref },
     { label: tr.principles, href: '#principles' },
   ];
 

--- a/apps/docs/components/home/project-links.test.ts
+++ b/apps/docs/components/home/project-links.test.ts
@@ -4,7 +4,7 @@ import { getProjectPrimaryHref, getProjectRepositoryHref } from './project-links
 
 describe('project links', () => {
   test('opens the Power website and links its source repository', () => {
-    assert.equal(getProjectPrimaryHref('power'), 'https://a3s-lab.github.io/Power/');
+    assert.equal(getProjectPrimaryHref('power'), '/power/');
     assert.equal(getProjectRepositoryHref('power'), 'https://github.com/A3S-Lab/Power');
   });
 

--- a/apps/docs/components/home/project-links.ts
+++ b/apps/docs/components/home/project-links.ts
@@ -50,7 +50,7 @@ export const projectLinks = {
   },
   power: {
     repository: 'https://github.com/A3S-Lab/Power',
-    website: 'https://a3s-lab.github.io/Power/',
+    website: '/power/',
   },
   ahp: { repository: 'https://github.com/A3S-Lab/AgentHarnessProtocol' },
   acl: { repository: 'https://github.com/A3S-Lab/ACL' },

--- a/apps/docs/components/home/project-sites.test.ts
+++ b/apps/docs/components/home/project-sites.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, test } from 'node:test';
 import { architectureProjects } from './architecture';
-import { featuredProjectSites } from './project-sites';
+import { featuredProjectSites, getFeaturedProjectSiteHref } from './project-sites';
 
 describe('featured project site previews', () => {
   test('point to known projects and committed screenshots', () => {
@@ -33,8 +33,10 @@ describe('featured project site previews', () => {
 
     assert.equal(box?.href, 'https://a3s-lab.github.io/Box/');
     assert.equal(box?.mode, 'live');
-    assert.equal(power?.captureUrl, 'https://a3s-lab.github.io/Power/');
-    assert.equal(power?.href, 'https://a3s-lab.github.io/Power/');
+    assert.equal(power?.captureUrl, 'https://a3s-lab.github.io/a3s/power/');
+    assert.equal(power?.href, '/power/');
+    assert.equal(power && getFeaturedProjectSiteHref(power, 'cn'), '/power/');
+    assert.equal(power && getFeaturedProjectSiteHref(power, 'en'), '/power/en/');
     assert.equal(power?.mode, 'live');
     assert.equal(power?.destination, 'site');
     assert.equal(featuredProjectSites.map((site) => String(site.id)).includes('site'), false);
@@ -62,16 +64,25 @@ describe('featured project site previews', () => {
     assert.equal(fontInstall < screenshotCapture, true, 'CJK fonts must be installed before screenshots are captured');
   });
 
-  test('captures live project sites without publishing a nested Form playground', () => {
+  test('builds the pinned Power site without publishing a nested Form playground', () => {
     const workflow = readFileSync(
       new URL('../../../../.github/workflows/site.yml', import.meta.url),
       'utf8',
     );
     const screenshotCapture = workflow.indexOf('bun run capture:sites');
     const siteBuild = workflow.indexOf('run: bun run build');
+    const powerSubmodule = workflow.indexOf('submodule update --init --depth 1 crates/power');
+    const powerInstall = workflow.indexOf('npm ci --prefix crates/power/site');
+    const powerTypecheck = workflow.indexOf('bun run typecheck:power');
 
     assert.notEqual(screenshotCapture, -1, 'Pages must refresh project screenshots');
     assert.notEqual(siteBuild, -1, 'Pages must build the Rspress site');
+    assert.notEqual(powerSubmodule, -1, 'Pages must initialize the pinned Power source');
+    assert.notEqual(powerInstall, -1, 'Pages must install the pinned Power site dependencies');
+    assert.notEqual(powerTypecheck, -1, 'Pages must typecheck the pinned Power site');
+    assert.equal(powerSubmodule < powerInstall, true);
+    assert.equal(powerInstall < powerTypecheck, true);
+    assert.equal(powerTypecheck < siteBuild, true);
     assert.equal(screenshotCapture < siteBuild, true);
     assert.equal(workflow.includes('UI_REPOSITORY'), false);
     assert.equal(workflow.includes('UI_REVISION'), false);

--- a/apps/docs/components/home/project-sites.ts
+++ b/apps/docs/components/home/project-sites.ts
@@ -1,8 +1,10 @@
 import type { ProjectId } from './project-links';
+import type { Lang } from './home-content';
 
 export interface FeaturedProjectSite {
   id: ProjectId;
   href: string;
+  hrefByLang?: Partial<Record<Lang, string>>;
   captureUrl: string;
   displayUrl: string;
   screenshot: string;
@@ -44,9 +46,10 @@ export const featuredProjectSites = [
   },
   {
     id: 'power',
-    href: 'https://a3s-lab.github.io/Power/',
-    captureUrl: 'https://a3s-lab.github.io/Power/',
-    displayUrl: 'a3s-lab.github.io/Power',
+    href: '/power/',
+    hrefByLang: { en: '/power/en/' },
+    captureUrl: 'https://a3s-lab.github.io/a3s/power/',
+    displayUrl: 'a3s-lab.github.io/a3s/power',
     screenshot: '/ecosystem-sites/power.png',
     settleMs: 5_000,
     mode: 'live',
@@ -93,3 +96,7 @@ export const featuredProjectSites = [
     destination: 'site',
   },
 ] as const satisfies readonly FeaturedProjectSite[];
+
+export function getFeaturedProjectSiteHref(site: FeaturedProjectSite, lang: Lang): string {
+  return site.hrefByLang?.[lang] ?? site.href;
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,10 +8,11 @@
     "dev:en": "bun scripts/dev-site.mjs en",
     "build": "bun scripts/build-site.mjs",
     "capture:sites": "bun scripts/capture-project-sites.ts",
-    "check": "bun run test && bun run typecheck && bun run build && bun run check:site",
+    "check": "bun run test && bun run typecheck && bun run typecheck:power && bun run build && bun run check:site",
     "check:site": "node scripts/check-built-site.mjs",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:power": "node scripts/run-power-site-script.mjs typecheck"
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.3.0",

--- a/apps/docs/rspress.config.ts
+++ b/apps/docs/rspress.config.ts
@@ -9,18 +9,21 @@ const deploymentPath = publicSite.pathname.replace(/\/+$/, '');
 const rootBase = `${deploymentPath || ''}/`.replace(/\/+/g, '/');
 const base = locale === 'en' ? `${rootBase}en/` : rootBase;
 const alternateBase = locale === 'en' ? rootBase : `${rootBase}en/`;
+const powerBase = locale === 'en' ? `${rootBase}power/en/` : `${rootBase}power/`;
 
 const copy = {
   cn: {
     title: 'A3S — 为AI Native组织构建的AI操作系统生态',
     description: 'A3S 项目索引。查看 34 个项目的职责、交付阶段、当前版本或通道和代码入口。',
     ecosystem: '生态',
+    power: 'Power',
     alternate: 'EN',
   },
   en: {
     title: 'A3S — The AI operating system ecosystem for AI Native organizations',
     description: 'The A3S project index. Browse 34 projects, their delivery stages, current versions or channels, sites, and source.',
     ecosystem: 'Ecosystem',
+    power: 'Power',
     alternate: '中文',
   },
 } as const;
@@ -84,6 +87,7 @@ export default defineConfig({
     lastUpdated: true,
     nav: [
       { text: copy[locale].ecosystem, link: '/' },
+      { text: copy[locale].power, link: powerBase },
       {
         text: copy[locale].alternate,
         link: `${publicSite.origin}${alternateBase}`,

--- a/apps/docs/scripts/build-site.mjs
+++ b/apps/docs/scripts/build-site.mjs
@@ -1,20 +1,26 @@
 import { spawn } from 'node:child_process';
-import { cp, mkdir, rm } from 'node:fs/promises';
+import { access, cp, mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 const root = process.cwd();
+const repositoryRoot = path.resolve(root, '../..');
 const buildRoot = path.join(root, 'site_build');
 const output = path.join(root, 'out');
+const powerSiteRoot = path.join(repositoryRoot, 'crates', 'power', 'site');
+const powerPackage = path.join(powerSiteRoot, 'package.json');
+const powerBuildRoot = path.join(powerSiteRoot, 'doc_build');
+const publicSite = new URL(process.env.SITE_URL ?? 'https://a3s.dev/');
+const deploymentPath = publicSite.pathname.replace(/\/+$/, '');
+const powerBase = `${deploymentPath}/power/`.replace(/\/+/g, '/');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
-function runRspress(locale) {
+function run(command, args, { cwd = root, env = {}, label }) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ['x', 'rspress', 'build'], {
-      cwd: root,
+    const child = spawn(command, args, {
+      cwd,
       env: {
         ...process.env,
-        PUBLIC_SITE_LOCALE: locale,
-        SITE_LOCALE: locale,
-        SITE_OUT_DIR: path.join('site_build', locale),
+        ...env,
       },
       stdio: 'inherit',
     });
@@ -22,8 +28,42 @@ function runRspress(locale) {
     child.on('error', reject);
     child.on('exit', (code) => {
       if (code === 0) resolve();
-      else reject(new Error(`Rspress ${locale} build exited with code ${code}`));
+      else reject(new Error(`${label} exited with code ${code}`));
     });
+  });
+}
+
+function runRspress(locale) {
+  return run(process.execPath, ['x', 'rspress', 'build'], {
+    env: {
+      PUBLIC_SITE_LOCALE: locale,
+      SITE_LOCALE: locale,
+      SITE_OUT_DIR: path.join('site_build', locale),
+    },
+    label: `Rspress ${locale} build`,
+  });
+}
+
+async function buildPowerSite() {
+  try {
+    await access(powerPackage);
+  } catch {
+    throw new Error(
+      'Pinned Power site is missing. Run `git submodule update --init crates/power` before building.',
+    );
+  }
+
+  await run(npmCommand, ['run', 'build'], {
+    cwd: powerSiteRoot,
+    env: {
+      DOCS_BASE: powerBase,
+      DOCS_ORIGIN: publicSite.origin,
+    },
+    label: 'Power site build',
+  });
+  await run(npmCommand, ['run', 'check:site'], {
+    cwd: powerSiteRoot,
+    label: 'Power site validation',
   });
 }
 
@@ -32,9 +72,12 @@ await rm(output, { force: true, recursive: true });
 
 await runRspress('cn');
 await runRspress('en');
+await buildPowerSite();
 
 await cp(path.join(buildRoot, 'cn'), output, { recursive: true });
 await mkdir(path.join(output, 'en'), { recursive: true });
 await cp(path.join(buildRoot, 'en'), path.join(output, 'en'), { recursive: true });
+await mkdir(path.join(output, 'power'), { recursive: true });
+await cp(powerBuildRoot, path.join(output, 'power'), { recursive: true });
 
-console.log('Assembled Chinese and English Rspress builds in out/.');
+console.log('Assembled the A3S ecosystem and pinned Power sites in out/.');

--- a/apps/docs/scripts/check-built-site.mjs
+++ b/apps/docs/scripts/check-built-site.mjs
@@ -3,7 +3,11 @@ import path from 'node:path';
 
 const root = process.cwd();
 const output = path.join(root, 'out');
-const powerHref = 'https://a3s-lab.github.io/Power/';
+const publicSite = new URL(process.env.SITE_URL ?? 'https://a3s.dev/');
+const deploymentPath = publicSite.pathname.replace(/\/+$/, '');
+const powerHref = `${deploymentPath}/power/`.replace(/\/+/g, '/');
+const powerEnglishHref = `${deploymentPath}/power/en/`.replace(/\/+/g, '/');
+const standalonePowerHref = 'https://a3s-lab.github.io/Power/';
 const requiredImages = [
   'brand/a3s-os-logo.png',
   'ecosystem-sites/cloud.png',
@@ -48,9 +52,42 @@ const routeEntries = await Promise.all(
 const routeHtml = new Map(routeEntries);
 const chineseHome = routeHtml.get('index.html');
 const englishHome = routeHtml.get('en/index.html');
+const powerRouteChecks = [
+  {
+    file: 'power/index.html',
+    lang: 'zh',
+    copy: ['Rust 模型推理', '运行时。', 'MTP 推测解码', '176.6109'],
+  },
+  {
+    file: 'power/en/index.html',
+    lang: 'en',
+    copy: ['A Rust runtime', 'for model inference.', 'MTP speculative decoding', '176.6109'],
+  },
+  {
+    file: 'power/v0.9.0/index.html',
+    lang: 'zh',
+    copy: ['Rust 模型推理', '运行时。', 'v0.9.0'],
+  },
+  {
+    file: 'power/v0.9.0/en/index.html',
+    lang: 'en',
+    copy: ['A Rust runtime', 'for model inference.', 'v0.9.0'],
+  },
+];
+const powerRouteEntries = await Promise.all(
+  powerRouteChecks.map(async (route) => ({ ...route, html: await read(route.file) })),
+);
 
 assert(chineseHome, 'Chinese homepage is missing');
 assert(englishHome, 'English homepage is missing');
+
+for (const route of powerRouteEntries) {
+  assert(route.html.includes(`<html lang="${route.lang}">`), `Power route has the wrong language: ${route.file}`);
+  assert(route.html.includes('a3s-os-logo.png'), `Power route is missing the A3S OS logo: ${route.file}`);
+  for (const marker of route.copy) {
+    assert(route.html.includes(marker), `Power route ${route.file} is missing: ${marker}`);
+  }
+}
 
 for (const marker of [
   '为AI Native组织构建的AI操作系统生态',
@@ -78,14 +115,18 @@ for (const marker of [
   assert(englishHome.includes(marker), `English homepage is missing: ${marker}`);
 }
 
-for (const [homepage, locale] of [[chineseHome, 'Chinese'], [englishHome, 'English']]) {
+for (const [homepage, locale, localizedPowerHref] of [
+  [chineseHome, 'Chinese', powerHref],
+  [englishHome, 'English', powerEnglishHref],
+]) {
   const projectStages = homepage.match(/class="a3s-project-delivery"/g) ?? [];
-  const powerLinkCount = homepage.split(`href="${powerHref}"`).length - 1;
+  const powerLinkCount = homepage.split(`href="${localizedPowerHref}"`).length - 1;
   assert(projectStages.length === 34, `${locale} homepage has ${projectStages.length} project stages instead of 34`);
   assert(!homepage.includes('a3s-project-progress'), `${locale} homepage still uses progress UI for categorical delivery stages`);
   assert(!homepage.includes('role="progressbar"'), `${locale} homepage still presents delivery stages as completion percentages`);
   assert(homepage.includes('/brand/a3s-os-logo.png'), `${locale} homepage does not use the A3S OS logo`);
-  assert(powerLinkCount >= 2, `${locale} homepage does not route both A3S Power entries to its website`);
+  assert(powerLinkCount >= 2, `${locale} homepage does not route A3S Power entries inside the A3S site`);
+  assert(!homepage.includes(standalonePowerHref), `${locale} homepage still links to the standalone Power site`);
   assert(!homepage.includes('/form/'), `${locale} homepage still links to the removed Form site`);
   assert(!homepage.includes('A3S Form'), `${locale} homepage still includes the removed Form project`);
   assert(homepage.includes('a3s-lab.github.io/Box'), `${locale} homepage does not feature the A3S Box site`);
@@ -110,6 +151,7 @@ for (const [homepage, locale] of [[chineseHome, 'Chinese'], [englishHome, 'Engli
 
 const files = await collectFiles(output);
 const relativeFiles = files.map((file) => path.relative(output, file).split(path.sep).join('/'));
+const powerHtmlFiles = relativeFiles.filter((file) => file.startsWith('power/') && file.endsWith('.html'));
 
 assert(
   !relativeFiles.some((file) => /(^|\/)blog(\/|$)/.test(file)),
@@ -120,6 +162,10 @@ assert(
   !relativeFiles.some((file) => file.startsWith('form/')),
   'Static build still contains the removed Form site',
 );
+
+assert(powerHtmlFiles.length >= 33, `Static build contains only ${powerHtmlFiles.length} Power pages`);
+assert(relativeFiles.includes('power/a3s-os-logo.png'), 'Static build is missing the Power site logo');
+assert(relativeFiles.includes('power/social-card.svg'), 'Static build is missing the Power social card');
 
 for (const image of requiredImages) {
   assert(relativeFiles.includes(image), `Static build is missing image: ${image}`);
@@ -168,6 +214,14 @@ if (process.env.SITE_URL) {
   const canonicalSite = process.env.SITE_URL.replace(/\/$/, '');
   assert(chineseHome.includes(`href="${canonicalSite}/"`), 'Chinese canonical URL is incorrect');
   assert(englishHome.includes(`href="${canonicalSite}/en/"`), 'English canonical URL is incorrect');
+  assert(
+    powerRouteEntries[0].html.includes(`href="${canonicalSite}/power/"`),
+    'Chinese Power canonical URL is incorrect',
+  );
+  assert(
+    powerRouteEntries[1].html.includes(`href="${canonicalSite}/power/en/"`),
+    'English Power canonical URL is incorrect',
+  );
 }
 
-console.log(`Validated 2 homepages and ${files.length} exported files.`);
+console.log(`Validated 2 ecosystem homepages, ${powerHtmlFiles.length} Power pages, and ${files.length} exported files.`);

--- a/apps/docs/scripts/run-power-site-script.mjs
+++ b/apps/docs/scripts/run-power-site-script.mjs
@@ -1,0 +1,24 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+const supportedScripts = new Set(['typecheck']);
+const script = process.argv[2];
+
+if (!supportedScripts.has(script)) {
+  throw new Error(`Unsupported Power site script: ${script ?? '(missing)'}`);
+}
+
+const powerSiteRoot = path.resolve(process.cwd(), '../../crates/power/site');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const child = spawn(npmCommand, ['run', script], {
+  cwd: powerSiteRoot,
+  stdio: 'inherit',
+});
+
+child.on('error', (error) => {
+  throw error;
+});
+
+child.on('exit', (code) => {
+  process.exitCode = code ?? 1;
+});


### PR DESCRIPTION
## Summary
- build the pinned crates/power/site source as part of the A3S Pages artifact
- publish Power under /a3s/power/ with an English route under /a3s/power/en/
- route the homepage navigation, preview card, and project directory to the internal Power pages
- validate both ecosystem homepages and all 33 Power pages in one export

## Verification
- SITE_URL=https://a3s-lab.github.io/a3s/ bun run check
- local browser click-through for Chinese and English Power routes