### PR TITLE
chore(oci-runtime): update control replay contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,13 @@ release cadence, and detailed documentation.
 - MoE owns model-specific equations and validation; Power owns model-neutral
   execution. Model support evidence does not imply that every optimized kernel,
   accelerator backend, or speculative adapter is complete.
-- Ash and Parser are early-stage, Office is pre-1.0, and OCI Runtime's native
-  Linux path remains experimental rather than the default launch claim.
+- Ash and Parser are early-stage, and Office is pre-1.0.
+- The pinned OCI Runtime revision uses schema-v9 containerd metadata and
+  automatically replays pending Pause, Resume, and body-complete Update
+  controls with their original operation identities during shim recovery.
+  Native Linux remains experimental; the new real-containerd replacement gate
+  still needs fresh-host evidence, and broader cross-driver release
+  qualification remains open.
 
 Component READMEs, releases, roadmaps, and the compatibility lock are the
 sources of truth for exact feature flags, platforms, versions, and remaining


### PR DESCRIPTION
## Summary

- advance `crates/oci-runtime` from `0d61dfb7` to `0c3d1649`
- document schema-v9 containerd control replay and the remaining fresh-host and cross-driver qualification boundaries in the root README

Upstream: A3S-Lab/OCI-Runtime#132

## Validation

- upstream OCI Runtime CI passed 5/5 on merge commit `0c3d1649`
- `git diff --cached --check`
- verified this commit changes only `README.md` and the `crates/oci-runtime` gitlink
- verified the target gitlink equals OCI Runtime `origin/main`