### PR TITLE
chore(oci-runtime): update terminal exec signal contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,18 +171,21 @@ release cadence, and detailed documentation.
   accelerator backend, or speculative adapter is complete.
 - Ash and Parser are early-stage, and Office is pre-1.0.
 - The pinned OCI Runtime revision uses schema-v9 containerd metadata, recovers
-  committed init Start, exec Start, live init Kill, and terminal init Kill
-  effects from the Runtime's exact-generation state after shim replacement,
-  and replays pending Pause, Resume, and body-complete Update controls with
-  their original operation identities. Exec Start adopts the one existing
-  process and PID without redispatch. Live init Kill preserves init and exec
-  PIDs and proves `all=true` fanout plus `all=false` isolation; terminal init
-  Kill imports the Runtime's durable exit with one bounded Wait before signal
-  replay and therefore avoids a second Kill dispatch. Three consecutive
-  same-Host Ubuntu arm64/containerd 2.2.2 matrices retain all seven replacement
-  gates with zero matching live runtime residue. Native Linux remains
-  experimental; broader containerd-version, published-artifact, and
-  cross-driver release qualification remain open.
+  committed init Start, exec Start, live init Kill, terminal init Kill, and
+  terminal exec SignalProcess effects from the Runtime's exact-generation
+  state after shim replacement, and replays pending Pause, Resume, and
+  body-complete Update controls with their original operation identities. Exec
+  Start adopts the one existing process and PID without redispatch. Live init
+  Kill preserves init and exec PIDs and proves `all=true` fanout plus
+  `all=false` isolation; terminal init Kill imports the Runtime's durable exit
+  with one bounded Wait before signal replay and therefore avoids a second Kill
+  dispatch. Terminal exec SignalProcess performs an exact zero-timeout
+  WaitProcess before replay, settles an already durable exit without a second
+  signal, and preserves the existing replay path when the exec remains live.
+  Three consecutive same-Host Ubuntu arm64/containerd 2.2.2 matrices retain
+  all eight replacement gates with zero matching live runtime residue. Native
+  Linux remains experimental; broader containerd-version, published-artifact,
+  and cross-driver release qualification remain open.
 
 Component READMEs, releases, roadmaps, and the compatibility lock are the
 sources of truth for exact feature flags, platforms, versions, and remaining


### PR DESCRIPTION
## Summary

- advance `crates/oci-runtime` from `4f64090b` to merged OCI Runtime revision `07ae2bea`
- update the root README from seven to eight retained containerd replacement gates
- document terminal exec SignalProcess settlement from exact zero-timeout WaitProcess evidence

## Upstream evidence

- OCI Runtime PR A3S-Lab/OCI-Runtime#137 merged with all five CI checks passing
- three consecutive Ubuntu arm64/containerd 2.2.2 matrices passed in 68.837s, 63.125s, and 62.831s through one Host PID
- post-run audit and machine cleanup are recorded in the pinned component README, roadmap, changelog, and runtime-v2 documentation

## Validation

- `git diff --cached --check`
- verified OCI Runtime `main` resolves to `07ae2bea879fdc0b9addb292a1f12f4c3d9b3cda`
- root worktree was created clean from current `origin/main`; the existing dirty monorepo checkout was not modified