### PR TITLE
chore(oci-runtime): update DeleteProcess replay contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,15 @@ release cadence, and detailed documentation.
   dispatch. Terminal exec SignalProcess performs an exact zero-timeout
   WaitProcess before replay, settles an already durable exit without a second
   signal, and preserves the existing replay path when the exec remains live.
+  DeleteProcess stores a separate task-identity- and generation-bound receipt
+  before removing an exec from main metadata, so a replacement shim can replay
+  the exact PID, status, and nanosecond exit time; a durable new incarnation of
+  the same exec ID consumes the old receipt.
   Three consecutive same-Host Ubuntu arm64/containerd 2.2.2 matrices retain
-  all eight replacement gates with zero matching live runtime residue. Native
-  Linux remains experimental; broader containerd-version, published-artifact,
-  and cross-driver release qualification remain open.
+  all nine replacement and response-replay gates with zero matching live
+  runtime residue. Native Linux remains experimental; broader containerd-version
+  and cross-driver qualification plus published-artifact compatibility remain
+  open.
 
 Component READMEs, releases, roadmaps, and the compatibility lock are the
 sources of truth for exact feature flags, platforms, versions, and remaining


### PR DESCRIPTION
## Summary

- advance the crates/oci-runtime gitlink to OCI Runtime merge commit 3e3af537d67ef4388338c2275b3dcd321e10c5b3
- update the root README to record the ninth containerd replacement/response-replay gate and its exact DeleteProcess receipt semantics

## Validation

- verified the new gitlink is a fast-forward descendant of the previous pin
- verified the gitlink equals A3S-Lab/OCI-Runtime main after PR #138 merged with full CI
- git diff --check
