### PR TITLE
refactor(docs): simplify desktop download page

### DIFF
--- a/apps/docs/components/desktop-download-page.tsx
+++ b/apps/docs/components/desktop-download-page.tsx
@@ -2,22 +2,16 @@ import {
   AppleLogo,
   ArrowRight,
   DownloadSimple,
-  GithubLogo,
   LinuxLogo,
-  ShieldCheck,
-  TerminalWindow,
   WindowsLogo,
 } from '@phosphor-icons/react/dist/ssr';
-import { withBase } from '@rspress/core/runtime';
 import {
   desktopChecksumsUrl,
   desktopDownloadContent,
   desktopLatestReleaseUrl,
   desktopReleaseAssets,
-  desktopReleasesUrl,
   desktopRepositoryUrl,
 } from '@/components/download/download-content';
-import { A3SMark } from '@/components/home/a3s-mark';
 import { HomeNav } from '@/components/home/home-nav';
 import type { Lang } from '@/components/home/home-content';
 
@@ -35,72 +29,46 @@ export default function DesktopDownloadPage({ lang = 'cn' }: { lang?: Lang }) {
       <a className="a3s-skip-link" href="#desktop-downloads">{tr.skip}</a>
       <HomeNav lang={lang} page="download" />
 
-      <section className="a3s-download-hero" aria-labelledby="a3s-download-title">
-        <div className="a3s-download-hero__inner">
-          <div className="a3s-download-hero__copy">
-            <div className="a3s-download-hero__product" aria-hidden="true">
-              <A3SMark />
-              <span>A3S</span>
-              <small>DESKTOP</small>
-            </div>
+      <section
+        className="a3s-download"
+        id="desktop-downloads"
+        aria-labelledby="a3s-download-title"
+      >
+        <div className="a3s-download__inner">
+          <header className="a3s-download__header">
             <h1 id="a3s-download-title">{tr.title}</h1>
             <p>{tr.description}</p>
-            <div className="a3s-download-hero__actions">
-              <a
-                className="a3s-button a3s-button--primary"
-                href={desktopLatestReleaseUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {tr.releaseAction}<ArrowRight aria-hidden="true" weight="bold" />
-              </a>
-              <a
-                className="a3s-button a3s-button--secondary"
-                href={desktopRepositoryUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <GithubLogo aria-hidden="true" weight="fill" />{tr.sourceAction}
-              </a>
-            </div>
-            <p className="a3s-download-hero__availability">{tr.availability}</p>
-          </div>
+          </header>
 
           <div
-            className="a3s-release-panel"
-            id="desktop-downloads"
-            aria-labelledby="a3s-release-panel-title"
+            className="a3s-download__platforms"
+            aria-label={lang === 'cn' ? '选择下载平台' : 'Choose a download platform'}
           >
-            <header>
-              <div>
-                <h2 id="a3s-release-panel-title">{tr.downloadHeading}</h2>
-                <p>{tr.downloadDescription}</p>
-              </div>
-              <DownloadSimple aria-hidden="true" weight="duotone" />
-            </header>
-
-            <div className="a3s-release-panel__platforms">
-              {desktopReleaseAssets.map((asset) => {
-                const Icon = platformIcons[asset.id];
-                return (
-                  <a
-                    href={asset.href}
-                    key={asset.id}
-                    aria-label={`${tr.downloadAction} A3S ${asset.name}`}
-                  >
-                    <Icon aria-hidden="true" weight="duotone" />
-                    <span>
-                      <strong>{asset.name}</strong>
-                      <small>{asset.fileName}</small>
-                    </span>
-                    <b>{asset.format}</b>
+            {desktopReleaseAssets.map((asset) => {
+              const Icon = platformIcons[asset.id];
+              return (
+                <a
+                  href={asset.href}
+                  key={asset.id}
+                  aria-label={`${tr.downloadAction} A3S ${asset.name}`}
+                >
+                  <Icon aria-hidden="true" weight="duotone" />
+                  <span>
+                    <strong>{asset.name}</strong>
+                    <small>{asset.fileName} · {asset.format}</small>
+                  </span>
+                  <b>
+                    {tr.downloadAction}
                     <DownloadSimple aria-hidden="true" weight="bold" />
-                  </a>
-                );
-              })}
-            </div>
+                  </b>
+                </a>
+              );
+            })}
+          </div>
 
-            <footer>
+          <div className="a3s-download__meta">
+            <p>{tr.previewNote}</p>
+            <nav aria-label={lang === 'cn' ? '下载资源' : 'Download resources'}>
               <a href={desktopChecksumsUrl}>{tr.checksumAction}</a>
               <a
                 href={desktopLatestReleaseUrl}
@@ -109,74 +77,32 @@ export default function DesktopDownloadPage({ lang = 'cn' }: { lang?: Lang }) {
               >
                 {tr.releaseNotesAction}
               </a>
-            </footer>
+              <a
+                href={desktopRepositoryUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {tr.sourceAction}
+              </a>
+            </nav>
           </div>
+
+          <aside className="a3s-download__cli">
+            <div>
+              <strong>{tr.cliTitle}</strong>
+              <p>{tr.cliDescription}</p>
+            </div>
+            <a
+              href="https://github.com/A3S-Lab/a3s#quick-start"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {tr.installCli}
+              <ArrowRight aria-hidden="true" weight="bold" />
+            </a>
+          </aside>
         </div>
       </section>
-
-      <section
-        className="a3s-download-setup a3s-section"
-        aria-labelledby="a3s-download-setup-title"
-      >
-        <header>
-          <h2 id="a3s-download-setup-title">{tr.requirementsTitle}</h2>
-          <p>{tr.requirementsDescription}</p>
-        </header>
-        <ol>
-          {tr.requirements.map(([title, description], index) => (
-            <li key={title}>
-              <span>{String(index + 1).padStart(2, '0')}</span>
-              <div>
-                <h3>{title}</h3>
-                <p>{description}</p>
-              </div>
-            </li>
-          ))}
-        </ol>
-        <a
-          className="a3s-download-setup__link"
-          href="https://github.com/A3S-Lab/a3s#quick-start"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <TerminalWindow aria-hidden="true" weight="duotone" />
-          {tr.installCli}
-          <ArrowRight aria-hidden="true" />
-        </a>
-      </section>
-
-      <section className="a3s-download-trust" aria-labelledby="a3s-download-trust-title">
-        <div className="a3s-download-trust__inner">
-          <ShieldCheck aria-hidden="true" weight="duotone" />
-          <div>
-            <h2 id="a3s-download-trust-title">{tr.trustTitle}</h2>
-            <p>{tr.trustDescription}</p>
-          </div>
-          <ul>
-            {tr.trustPoints.map((point) => <li key={point}>{point}</li>)}
-          </ul>
-        </div>
-      </section>
-
-      <footer className="a3s-download-footer">
-        <div>
-          <a className="a3s-download-footer__brand" href={withBase('/')}>
-            <A3SMark />
-            <span>A3S</span>
-          </a>
-          <p>{tr.footerDescription}</p>
-        </div>
-        <nav aria-label={lang === 'cn' ? '下载页页脚' : 'Download page footer'}>
-          <a href={withBase('/')}>{tr.footerHome}</a>
-          <a href={desktopReleasesUrl} target="_blank" rel="noopener noreferrer">
-            {tr.footerReleases}
-          </a>
-          <a href={desktopRepositoryUrl} target="_blank" rel="noopener noreferrer">
-            {tr.footerSource}
-          </a>
-        </nav>
-        <small>© {new Date().getFullYear()} A3S Lab · MIT</small>
-      </footer>
     </main>
   );
 }

--- a/apps/docs/components/download/download-content.test.ts
+++ b/apps/docs/components/download/download-content.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   desktopChecksumsUrl,
+  desktopDownloadContent,
   desktopReleaseAssetBaseUrl,
   desktopReleaseAssets,
   desktopRepositoryUrl,
@@ -26,5 +27,31 @@ describe('Desktop release links', () => {
       desktopChecksumsUrl,
       'https://github.com/A3S-Lab/Desktop/releases/latest/download/SHA256SUMS.txt',
     );
+  });
+
+  test('keeps the download page copy focused on choosing a package', () => {
+    const expectedKeys = [
+      'checksumAction',
+      'cliDescription',
+      'cliTitle',
+      'description',
+      'downloadAction',
+      'installCli',
+      'previewNote',
+      'releaseNotesAction',
+      'skip',
+      'sourceAction',
+      'title',
+    ];
+
+    for (const locale of ['cn', 'en'] as const) {
+      const content = desktopDownloadContent[locale];
+      assert.deepEqual(Object.keys(content).sort(), expectedKeys);
+      assert.ok(content.description.length <= 64);
+      assert.ok(content.cliDescription.length <= 80);
+    }
+
+    assert.equal(desktopDownloadContent.cn.title, '下载 A3S Desktop');
+    assert.equal(desktopDownloadContent.en.title, 'Download A3S Desktop');
   });
 });

--- a/apps/docs/components/download/download-content.ts
+++ b/apps/docs/components/download/download-content.ts
@@ -41,78 +41,28 @@ export const desktopReleaseAssets: readonly DesktopReleaseAsset[] = [
 export const desktopDownloadContent = {
   en: {
     skip: 'Skip to downloads',
-    title: 'A3S Code, built for your desktop.',
-    description:
-      'A native workbench for office, coding, and design workflows, powered by the same local A3S Code kernel. Start with Office today; Code and Design arrive as verified contracts are completed.',
-    releaseAction: 'View release history',
-    sourceAction: 'View source',
-    availability: 'macOS · Windows · Linux',
-    downloadHeading: 'Download the latest release',
-    downloadDescription:
-      'Choose your platform. Every package is produced by the tagged Desktop release workflow. Current preview packages are unsigned.',
+    title: 'Download A3S Desktop',
+    description: 'Choose your system and download the latest desktop build.',
     downloadAction: 'Download',
-    checksumAction: 'Verify SHA-256 checksums',
+    previewNote: 'Preview builds are currently unsigned.',
+    checksumAction: 'SHA-256 checksums',
     releaseNotesAction: 'Release notes',
-    requirementsTitle: 'Before you open A3S',
-    requirementsDescription:
-      'Desktop discovers A3S Code locally and keeps execution policy with the installed CLI.',
-    requirements: [
-      [
-        'Install A3S Code',
-        'Install the A3S CLI and configure a supported model provider before starting work.',
-      ],
-      [
-        'Open a workspace',
-        'A3S validates the local workspace, ACL path, model, mode, and tool policy before execution.',
-      ],
-      [
-        'Keep authority explicit',
-        'Office, Code, and Design never elevate permissions when you switch work modes.',
-      ],
-    ],
-    installCli: 'Install the A3S CLI',
-    trustTitle: 'Local-first by construction.',
-    trustDescription:
-      'The React interface talks to an authenticated loopback Host. The Host launches shell-free A3S Code commands and awaits every child process after completion, failure, or cancellation.',
-    trustPoints: [
-      'Authenticated loopback API',
-      'Typed A3S Code contracts',
-      'Versioned GitHub releases',
-    ],
-    footerDescription: 'The native workbench for A3S Code.',
-    footerHome: 'A3S ecosystem',
-    footerReleases: 'All releases',
-    footerSource: 'Source',
+    sourceAction: 'Source',
+    cliTitle: 'First time using A3S?',
+    cliDescription: 'Install and configure the A3S CLI before opening a workspace.',
+    installCli: 'Install A3S CLI',
   },
   cn: {
     skip: '跳到下载区域',
-    title: '把 A3S Code 带到桌面。',
-    description:
-      '由同一个本地 A3S Code 内核驱动的原生工作台，覆盖办公、编码与设计三种工作方式。办公模式现已可用，编码和设计会在真实协议完成后开放。',
-    releaseAction: '查看发布记录',
-    sourceAction: '查看源码',
-    availability: 'macOS · Windows · Linux',
-    downloadHeading: '下载最新版本',
-    downloadDescription:
-      '选择你的平台。每个安装包都由带标签的 Desktop 发布工作流生成。当前预览包尚未签名。',
+    title: '下载 A3S Desktop',
+    description: '选择你的系统，下载最新版桌面应用。',
     downloadAction: '下载',
-    checksumAction: '校验 SHA-256',
+    previewNote: '当前预览包尚未签名。',
+    checksumAction: 'SHA-256 校验',
     releaseNotesAction: '版本说明',
-    requirementsTitle: '打开 A3S 前',
-    requirementsDescription: 'Desktop 在本机发现 A3S Code，执行策略始终由已安装的 CLI 管理。',
-    requirements: [
-      ['安装 A3S Code', '先安装 A3S CLI，并配置受支持的模型 Provider。'],
-      ['打开工作区', '执行前会校验本地工作区、ACL 路径、模型、运行模式和工具策略。'],
-      ['权限保持明确', '切换办公、编码或设计模式时，A3S 不会自动提高权限。'],
-    ],
+    sourceAction: '源码',
+    cliTitle: '第一次使用 A3S？',
+    cliDescription: '打开工作区前，请先安装并配置 A3S CLI。',
     installCli: '安装 A3S CLI',
-    trustTitle: '从底层开始坚持本地优先。',
-    trustDescription:
-      'React 界面只连接带认证的本机 Host。Host 以无 Shell 参数启动 A3S Code，并在完成、失败或取消后等待每个子进程退出。',
-    trustPoints: ['带认证的本机 API', '类型化 A3S Code 协议', '版本化 GitHub Releases'],
-    footerDescription: 'A3S Code 的原生桌面工作台。',
-    footerHome: 'A3S 生态',
-    footerReleases: '全部版本',
-    footerSource: '源代码',
   },
 } as const;

--- a/apps/docs/components/home/styles/desktop-download-responsive.css
+++ b/apps/docs/components/home/styles/desktop-download-responsive.css
@@ -1,114 +1,56 @@
-@media (max-width: 1080px) {
-  .a3s-download-hero__inner {
+@media (max-width: 760px) {
+  .a3s-download {
     min-height: auto;
-    padding-top: 92px;
-    padding-bottom: 110px;
-    grid-template-columns: 1fr;
+    align-items: start;
   }
 
-  .a3s-download-hero__copy {
-    max-width: 820px;
+  .a3s-download__inner {
+    padding: 56px 20px 72px;
   }
 
-  .a3s-release-panel {
-    width: min(100%, 820px);
-    justify-self: end;
+  .a3s-download__header {
+    margin-bottom: 34px;
   }
 
-  .a3s-download-trust__inner {
-    grid-template-columns: auto 1fr;
+  .a3s-download__header h1 {
+    font-size: clamp(40px, 12vw, 54px);
+    letter-spacing: -0.035em;
   }
 
-  .a3s-download-trust ul {
+  .a3s-download__header p {
+    margin-top: 16px;
+    font-size: 15px;
+  }
+
+  .a3s-download__platforms > a {
+    min-height: 104px;
+    padding: 18px 20px;
+    gap: 14px;
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .a3s-download__platforms b {
+    min-height: auto;
     grid-column: 2;
   }
-}
 
-@media (max-width: 760px) {
-  .a3s-download-hero__inner,
-  .a3s-download-trust__inner,
-  .a3s-download-footer {
-    padding-right: 20px;
-    padding-left: 20px;
-  }
-
-  .a3s-download-hero__inner {
-    padding-top: 70px;
-    padding-bottom: 82px;
-    border-right: 0;
-    border-left: 0;
-    gap: 52px;
-  }
-
-  .a3s-download-hero h1 {
-    margin-top: 28px;
-    font-size: clamp(44px, 13vw, 64px);
-  }
-
-  .a3s-release-panel > header,
-  .a3s-release-panel__platforms > a,
-  .a3s-release-panel > footer {
-    padding-right: 20px;
-    padding-left: 20px;
-  }
-
-  .a3s-release-panel__platforms > a {
-    min-height: 88px;
-  }
-
-  .a3s-release-panel__platforms b {
-    display: none;
-  }
-
-  .a3s-download-setup > header {
-    align-items: start;
-    gap: 24px;
-    grid-template-columns: 1fr;
-  }
-
-  .a3s-download-setup > header p {
-    justify-self: start;
-  }
-
-  .a3s-download-setup ol {
-    margin-top: 48px;
-    grid-template-columns: 1fr;
-  }
-
-  .a3s-download-setup li,
-  .a3s-download-setup li:first-child,
-  .a3s-download-setup li:last-child {
-    min-height: auto;
-    padding: 25px 0 30px;
-    border-right: 0;
-    border-bottom: 1px solid var(--a3s-line);
-  }
-
-  .a3s-download-setup li h3 {
-    margin-top: 32px;
-  }
-
-  .a3s-download-trust__inner {
-    min-height: auto;
-    padding-top: 82px;
-    padding-bottom: 88px;
-    gap: 28px;
-    grid-template-columns: 1fr;
-  }
-
-  .a3s-download-trust ul {
-    grid-column: 1;
-  }
-
-  .a3s-download-footer {
-    min-height: 300px;
-    grid-template-columns: 1fr;
-  }
-
-  .a3s-download-footer nav {
+  .a3s-download__meta,
+  .a3s-download__cli {
     align-items: flex-start;
     flex-direction: column;
-    gap: 15px;
+  }
+
+  .a3s-download__meta {
+    gap: 14px;
+  }
+
+  .a3s-download__meta nav {
+    gap: 12px 18px;
+  }
+
+  .a3s-download__cli {
+    margin-top: 42px;
+    gap: 14px;
   }
 }
 
@@ -117,6 +59,6 @@
   .a3s-download-site *::before,
   .a3s-download-site *::after {
     scroll-behavior: auto !important;
-    transition-duration: 0.01ms !important;
+    transition-duration: 0.001ms !important;
   }
 }

--- a/apps/docs/components/home/styles/desktop-download.css
+++ b/apps/docs/components/home/styles/desktop-download.css
@@ -4,442 +4,202 @@
 }
 
 .a3s-download-site {
+  min-height: 100dvh;
   background: #f7f9fc;
 }
 
-.a3s-download-hero {
-  position: relative;
-  overflow: hidden;
-  border-bottom: 1px solid var(--a3s-line);
-  background: #f7f9fc;
-}
-
-.a3s-download-hero::before {
-  position: absolute;
-  top: -340px;
-  right: -220px;
-  width: 760px;
-  height: 760px;
-  border: 1px solid rgba(18, 100, 255, 0.12);
-  border-radius: 50%;
-  box-shadow: inset 0 0 0 120px rgba(255, 255, 255, 0.38);
-  content: '';
-  pointer-events: none;
-}
-
-.a3s-download-hero__inner {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  width: min(100%, var(--a3s-max));
+.a3s-download {
+  display: flex;
   min-height: calc(100dvh - 72px);
+  align-items: center;
+}
+
+.a3s-download__inner {
+  width: min(100%, 980px);
   margin: 0 auto;
-  padding: clamp(72px, 8vw, 122px) clamp(28px, 5vw, 72px);
-  border-right: 1px solid var(--a3s-line);
-  border-left: 1px solid var(--a3s-line);
-  align-items: center;
-  gap: clamp(56px, 8vw, 132px);
-  grid-template-columns: minmax(380px, 0.88fr) minmax(520px, 1.12fr);
+  padding: clamp(64px, 8vw, 104px) 28px clamp(72px, 9vw, 120px);
 }
 
-.a3s-download-hero__copy {
-  max-width: 650px;
+.a3s-download__header {
+  max-width: 680px;
+  margin-bottom: 42px;
 }
 
-.a3s-download-hero__product {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.a3s-download__header h1 {
+  margin: 0;
   color: var(--a3s-text);
-  font-size: 18px;
+  font-size: clamp(44px, 6vw, 72px);
   font-weight: 760;
-  letter-spacing: -0.025em;
-}
-
-.a3s-download-hero__product svg {
-  width: 36px;
-  height: 36px;
-  color: var(--a3s-blue);
-}
-
-.a3s-download-hero__product small {
-  padding-left: 10px;
-  border-left: 1px solid var(--a3s-line-strong);
-  color: var(--a3s-faint);
-  font-family: var(--a3s-mono);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-}
-
-.a3s-download-hero h1 {
-  max-width: 700px;
-  margin: 34px 0 25px;
-  color: var(--a3s-text);
-  font-size: clamp(48px, 5.2vw, 78px);
-  font-weight: 760;
-  letter-spacing: -0.04em;
-  line-height: 0.98;
-  text-wrap: balance;
-}
-
-.a3s-download-hero__copy > p:not(.a3s-download-hero__availability) {
-  max-width: 650px;
-  margin: 0;
-  color: var(--a3s-muted);
-  font-size: 16px;
-  line-height: 1.72;
-  text-wrap: pretty;
-}
-
-.a3s-download-hero__actions {
-  display: flex;
-  margin-top: 34px;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.a3s-button--secondary {
-  border: 1px solid var(--a3s-line-strong);
-  background: #ffffff;
-  color: var(--a3s-text);
-}
-
-.a3s-button--secondary:hover {
-  border-color: #9bb5da;
-  background: var(--a3s-paper-blue);
-  color: var(--a3s-blue);
-}
-
-.a3s-download-hero__availability {
-  margin: 22px 0 0 !important;
-  color: var(--a3s-faint);
-  font-family: var(--a3s-mono);
-  font-size: 9px;
-  font-weight: 650;
-  letter-spacing: 0.08em;
-}
-
-.a3s-release-panel {
-  overflow: hidden;
-  border: 1px solid var(--a3s-line-strong);
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 30px 80px rgba(31, 65, 116, 0.16);
-}
-
-.a3s-release-panel > header {
-  display: grid;
-  min-height: 156px;
-  padding: 30px;
-  border-bottom: 1px solid var(--a3s-line);
-  align-items: start;
-  gap: 24px;
-  grid-template-columns: 1fr auto;
-}
-
-.a3s-release-panel > header h2 {
-  margin: 0;
-  color: var(--a3s-text);
-  font-size: clamp(25px, 2.2vw, 34px);
-  font-weight: 720;
-  letter-spacing: -0.035em;
-  line-height: 1.08;
-}
-
-.a3s-release-panel > header p {
-  max-width: 500px;
-  margin: 14px 0 0;
-  color: var(--a3s-muted);
-  font-size: 12px;
-  line-height: 1.65;
-}
-
-.a3s-release-panel > header > svg {
-  width: 32px;
-  height: 32px;
-  color: var(--a3s-blue);
-}
-
-.a3s-release-panel__platforms > a {
-  display: grid;
-  min-height: 92px;
-  padding: 0 30px;
-  border-bottom: 1px solid var(--a3s-line);
-  align-items: center;
-  gap: 17px;
-  grid-template-columns: auto 1fr auto auto;
-  transition: background 160ms ease, color 160ms ease;
-}
-
-.a3s-release-panel__platforms > a:hover {
-  background: var(--a3s-paper-blue);
-  color: var(--a3s-blue);
-}
-
-.a3s-release-panel__platforms > a > svg:first-child {
-  width: 30px;
-  height: 30px;
-  color: var(--a3s-blue);
-}
-
-.a3s-release-panel__platforms span {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.a3s-release-panel__platforms strong {
-  color: var(--a3s-text);
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.a3s-release-panel__platforms small,
-.a3s-release-panel__platforms b {
-  color: var(--a3s-faint);
-  font-family: var(--a3s-mono);
-  font-size: 8px;
-  font-weight: 650;
-  letter-spacing: 0.04em;
-}
-
-.a3s-release-panel__platforms small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.a3s-release-panel__platforms > a > svg:last-child {
-  width: 17px;
-  height: 17px;
-}
-
-.a3s-release-panel > footer {
-  display: flex;
-  min-height: 58px;
-  padding: 0 30px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  color: var(--a3s-muted);
-  font-size: 10px;
-  font-weight: 650;
-}
-
-.a3s-release-panel > footer a:hover {
-  color: var(--a3s-blue);
-}
-
-.a3s-download-setup {
-  padding-top: clamp(112px, 10vw, 164px);
-  padding-bottom: clamp(112px, 10vw, 164px);
-  background: #ffffff;
-}
-
-.a3s-download-setup > header {
-  display: grid;
-  align-items: end;
-  gap: 48px;
-  grid-template-columns: minmax(320px, 0.8fr) minmax(360px, 1.2fr);
-}
-
-.a3s-download-setup h2,
-.a3s-download-trust h2 {
-  margin: 0;
-  color: var(--a3s-text);
-  font-size: clamp(38px, 4vw, 58px);
-  font-weight: 740;
   letter-spacing: -0.04em;
   line-height: 1;
   text-wrap: balance;
 }
 
-.a3s-download-setup > header p {
-  max-width: 600px;
-  margin: 0;
-  justify-self: end;
+.a3s-download__header p {
+  max-width: 620px;
+  margin: 20px 0 0;
   color: var(--a3s-muted);
-  font-size: 15px;
-  line-height: 1.7;
+  font-size: 16px;
+  line-height: 1.6;
 }
 
-.a3s-download-setup ol {
+.a3s-download__platforms {
+  overflow: hidden;
+  border: 1px solid var(--a3s-line-strong);
+  border-radius: 16px;
+  background: #ffffff;
+}
+
+.a3s-download__platforms > a {
   display: grid;
-  margin: 68px 0 0;
-  padding: 0;
-  border-top: 1px solid var(--a3s-line-strong);
-  list-style: none;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.a3s-download-setup li {
-  min-height: 240px;
-  padding: 28px 28px 32px;
-  border-right: 1px solid var(--a3s-line);
-}
-
-.a3s-download-setup li:first-child {
-  padding-left: 0;
-}
-
-.a3s-download-setup li:last-child {
-  padding-right: 0;
-  border-right: 0;
-}
-
-.a3s-download-setup li > span {
-  color: var(--a3s-blue);
-  font-family: var(--a3s-mono);
-  font-size: 9px;
-  font-weight: 700;
-}
-
-.a3s-download-setup li h3 {
-  margin: 76px 0 13px;
-  color: var(--a3s-text);
-  font-size: 19px;
-  font-weight: 690;
-  letter-spacing: -0.025em;
-}
-
-.a3s-download-setup li p {
-  max-width: 370px;
-  margin: 0;
-  color: var(--a3s-muted);
-  font-size: 12px;
-  line-height: 1.68;
-}
-
-.a3s-download-setup__link {
-  display: inline-flex;
-  min-height: 42px;
-  margin-top: 42px;
+  min-height: 96px;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--a3s-line);
   align-items: center;
-  gap: 9px;
+  gap: 18px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.a3s-download__platforms > a:last-child {
+  border-bottom: 0;
+}
+
+.a3s-download__platforms > a:hover {
+  background: var(--a3s-paper-blue);
+}
+
+.a3s-download__platforms > a:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--a3s-blue);
+  outline-offset: -2px;
+}
+
+.a3s-download__platforms > a > svg {
+  width: 30px;
+  height: 30px;
+  color: var(--a3s-blue);
+}
+
+.a3s-download__platforms span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.a3s-download__platforms strong {
+  color: var(--a3s-text);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.a3s-download__platforms small {
+  overflow: hidden;
+  color: var(--a3s-faint);
+  font-family: var(--a3s-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a3s-download__platforms b {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 8px;
   color: var(--a3s-blue);
   font-size: 12px;
   font-weight: 700;
 }
 
-.a3s-download-setup__link svg {
+.a3s-download__platforms b svg {
   width: 17px;
   height: 17px;
-}
-
-.a3s-download-setup__link svg:last-child {
   transition: transform 160ms ease;
 }
 
-.a3s-download-setup__link:hover svg:last-child {
-  transform: translateX(3px);
+.a3s-download__platforms > a:hover b svg {
+  transform: translateY(2px);
 }
 
-.a3s-download-trust {
-  border-top: 1px solid #263954;
-  border-bottom: 1px solid #263954;
-  background: #0e1b35;
-  color: #ffffff;
+.a3s-download__meta {
+  display: flex;
+  margin-top: 18px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
 }
 
-.a3s-download-trust__inner {
-  display: grid;
-  width: min(100%, var(--a3s-max));
-  min-height: 520px;
-  margin: 0 auto;
-  padding: clamp(82px, 8vw, 124px) clamp(28px, 5vw, 72px);
-  align-items: start;
-  gap: clamp(36px, 5vw, 80px);
-  grid-template-columns: auto minmax(380px, 1fr) minmax(240px, 0.55fr);
+.a3s-download__meta p {
+  margin: 0;
+  color: var(--a3s-faint);
+  font-size: 12px;
+  line-height: 1.6;
 }
 
-.a3s-download-trust__inner > svg {
-  width: 54px;
-  height: 54px;
-  color: #77aaff;
-}
-
-.a3s-download-trust h2 {
-  max-width: 700px;
-  color: #ffffff;
-}
-
-.a3s-download-trust p {
-  max-width: 730px;
-  margin: 28px 0 0;
-  color: #b9c7dc;
-  font-size: 14px;
-  line-height: 1.75;
-}
-
-.a3s-download-trust ul {
-  margin: 4px 0 0;
-  padding: 0;
-  border-top: 1px solid rgba(185, 199, 220, 0.26);
-  list-style: none;
-}
-
-.a3s-download-trust li {
-  padding: 18px 0;
-  border-bottom: 1px solid rgba(185, 199, 220, 0.18);
-  color: #d8e2f0;
-  font-family: var(--a3s-mono);
-  font-size: 9px;
-  letter-spacing: 0.04em;
-}
-
-.a3s-download-footer {
-  display: grid;
-  width: min(100%, var(--a3s-max));
-  min-height: 250px;
-  margin: 0 auto;
-  padding: 64px clamp(28px, 5vw, 72px) 34px;
-  align-items: start;
-  gap: 32px 48px;
-  grid-template-columns: 1fr auto;
-}
-
-.a3s-download-footer__brand {
-  display: inline-flex;
+.a3s-download__meta nav {
+  display: flex;
   align-items: center;
-  gap: 10px;
-  color: var(--a3s-text);
-  font-size: 18px;
-  font-weight: 760;
+  flex-wrap: wrap;
+  gap: 10px 20px;
 }
 
-.a3s-download-footer__brand svg {
-  width: 32px;
-  height: 32px;
-  color: var(--a3s-blue);
-}
-
-.a3s-download-footer p {
-  margin: 16px 0 0;
+.a3s-download__meta a,
+.a3s-download__cli a {
   color: var(--a3s-muted);
   font-size: 12px;
-}
-
-.a3s-download-footer nav {
-  display: flex;
-  gap: 28px;
-  color: var(--a3s-muted);
-  font-size: 11px;
   font-weight: 650;
+  transition: color 160ms ease;
 }
 
-.a3s-download-footer nav a:hover {
+.a3s-download__meta a:hover,
+.a3s-download__meta a:focus-visible,
+.a3s-download__cli a:hover,
+.a3s-download__cli a:focus-visible {
   color: var(--a3s-blue);
 }
 
-.a3s-download-footer > small {
-  padding-top: 24px;
+.a3s-download__cli {
+  display: flex;
+  margin-top: 50px;
+  padding-top: 26px;
   border-top: 1px solid var(--a3s-line);
-  grid-column: 1 / -1;
-  color: var(--a3s-faint);
-  font-family: var(--a3s-mono);
-  font-size: 8px;
-  letter-spacing: 0.05em;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+}
+
+.a3s-download__cli strong {
+  color: var(--a3s-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.a3s-download__cli p {
+  margin: 6px 0 0;
+  color: var(--a3s-muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.a3s-download__cli a {
+  display: inline-flex;
+  min-height: 44px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.a3s-download__cli a svg {
+  width: 16px;
+  height: 16px;
+  transition: transform 160ms ease;
+}
+
+.a3s-download__cli a:hover svg {
+  transform: translateX(3px);
 }

--- a/apps/docs/theme/components/HomeLayout.tsx
+++ b/apps/docs/theme/components/HomeLayout.tsx
@@ -1,5 +1,6 @@
 import HomePage from '@/components/home-page';
 import DesktopDownloadPage from '@/components/desktop-download-page';
+import { desktopDownloadContent } from '@/components/download/download-content';
 import type { Lang } from '@/components/home/home-content';
 import { usePageData } from '@rspress/core/runtime';
 
@@ -23,14 +24,12 @@ function MarkdownHome({ lang }: { lang: Lang }) {
 }
 
 function MarkdownDownload({ lang }: { lang: Lang }) {
+  const tr = desktopDownloadContent[lang];
+
   return (
     <main>
-      <h1>{lang === 'cn' ? '下载 A3S Desktop' : 'Download A3S Desktop'}</h1>
-      <p>
-        {lang === 'cn'
-          ? '获取适用于 macOS、Windows 和 Linux 的原生 A3S Code 工作台。'
-          : 'Get the native A3S Code workbench for macOS, Windows, and Linux.'}
-      </p>
+      <h1>{tr.title}</h1>
+      <p>{tr.description}</p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- reduce the Desktop download page to one focused package-selection flow
- keep platform downloads, checksums, release notes, source, and CLI setup links
- remove duplicated product, setup, trust, and footer sections
- keep the static fallback copy in the same localized source of truth

## Validation

- bun run test
- bun run typecheck
- bun run build
- bun run check:site
- A3S Test at 1440x900 and 390x844
- Impeccable detector