### PR TITLE
chore(oci-runtime): update committed stdin cleanup contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,18 @@ release cadence, and detailed documentation.
   consecutive same-Host matrices retain all nine earlier replacement and
   response-replay gates with zero matching live runtime residue. Three
   additional source-build Ubuntu x86_64/containerd 2.2.3 matrices retained the
-  full suite plus exact task Delete response replay and also left zero matching
-  task, container, bundle, cgroup, mount, shim, or agent residue. That 2.2.3
-  regression evidence does not expand the contract-v1 compatibility claim.
-  Native Linux remains experimental; broader containerd-version and
-  cross-driver qualification plus published-artifact compatibility remain open.
+  full suite plus exact task Delete response replay and post-commit
+  `WriteStdin` forced cleanup. The new boundary commits the original
+  exec-scoped write while schema-v9 shim metadata still retains the pending
+  bytes, proves one input effect without changing the live init PID or
+  generation, and then removes only that generation after shim `SIGKILL`
+  without redispatching the write. Every pass left zero matching task,
+  container, bundle, live Runtime record, cgroup, mount, shim, agent or Host
+  child, zombie, or prepared operation. That 2.2.3 regression evidence does
+  not expand the contract-v1 compatibility claim. Native Linux remains
+  experimental; the `CloseStdin` and `ResizePty` forced-cleanup boundaries,
+  broader containerd-version and cross-driver qualification, and
+  published-artifact compatibility remain open.
 
 Component READMEs, releases, roadmaps, and the compatibility lock are the
 sources of truth for exact feature flags, platforms, versions, and remaining


### PR DESCRIPTION
## Summary

- advance the pinned OCI Runtime revision from `833847049591344fe01a376dfbc14210da026738` to `b3b75288ce348bcce8011fb9bd85f8ec8b314a7a`
- record the qualified post-commit containerd `WriteStdin` forced-cleanup boundary in the root README
- keep `CloseStdin`, `ResizePty`, broader containerd versions, cross-driver qualification, and published-artifact compatibility explicitly open

Component change: A3S-Lab/OCI-Runtime#140

## Validation

- `git diff origin/main...HEAD --check`
- OCI Runtime PR #140: all Ubuntu, macOS, Windows, aarch64 Native Linux, and static guest-agent CI checks passed
- real Ubuntu 24.04 x86_64/containerd 2.2.3 qualification: three consecutive passes with zero scoped residue and unchanged production containerd PID