### PR TITLE
fix(compat): pin bounded CLI startup warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ release cadence, and detailed documentation.
 
 - The standalone [`A3S-Lab/CLI`](https://github.com/A3S-Lab/CLI) repository
   owns CLI source, CI, tags, releases, and product documentation. This root
-  pins a reviewed post-v0.12.5 integration revision that adds Runtime Service
-  provider-process rebinding qualification. The gitlink is newer than the
-  v0.12.5 tag and does not represent a newer public release. This root retains
+  pins a reviewed v0.12.5 maintenance revision with Runtime Service
+  provider-process rebinding and unambiguous bounded-startup warnings. CLI
+  v0.13.0 is not pinned until its in-process Use dependency and the external
+  Use process share one frozen capability protocol revision. This root retains
   an asset-only relay for legacy 0.11.x clients that briefly used the monorepo
   release endpoint.
 - The pinned [Code](crates/code/) revision includes a capability ledger and


### PR DESCRIPTION
## Summary
- advance the standalone CLI gitlink to the reviewed v0.12.5 maintenance revision from A3S-Lab/CLI#126
- preserve Runtime Service provider-process rebinding while making bounded startup warning boundaries unambiguous
- document why CLI v0.13.0 remains unpinned until its in-process and external Use implementations share one frozen capability protocol revision

## Validation
- CLI CI run 33172173248: Linux, Linux ARM64, macOS, Windows, Clippy, all targets, and real offline local-CPU inference passed
- root scripts/test-use-hotplug-e2e.sh: all three real-process scenarios passed locally
- .github/scripts/check-cli-integration.sh passed at 650ccaf9b3f37f1f7e227a12ae269ced29b51d31
- cargo metadata --locked --no-deps passed