### PR TITLE
chore(cloud): advance Cloud compatibility pin

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "074a42f71e4f0dcafea375da016044b08c2c16ae"
+  revision = "292e418b6169f40b55d07952befc2070c6625c20"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- advance the root Cloud gitlink to the merged independent Code-pin CI fix
- keep `compat/cloud-stack.acl` exact with the gitlink

## Validation
- `git diff --check`
- Code and Cloud dependency/contract checks passed on the preceding pins
- Cloud Stack verification will validate the new exact revision in CI