### PR TITLE
docs: add Code core optimization roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ its owning repository before advancing its gitlink here, and read
   [review](docs/retrieval-platform-architecture-review.md), and
   [roadmap](docs/retrieval-platform-roadmap.md)
 - [Scientific discovery platform roadmap](docs/scientific-discovery-platform-roadmap.md)
+- [A3S Code Core optimization roadmap](docs/a3s-code-core-optimization-roadmap.md)
 - [CLI releases](https://github.com/A3S-Lab/CLI/releases)
 - [Discord](https://discord.gg/XVg6Hu6H)
 

--- a/docs/a3s-code-core-optimization-roadmap.md
+++ b/docs/a3s-code-core-optimization-roadmap.md
@@ -1,0 +1,344 @@
+# A3S Code Core Optimization Roadmap
+
+- Status: accepted engineering plan
+- Decision date: 2026-09-05
+- Owner: A3S Code, with A3S Use and A3S Desktop integration gates
+- Baseline: Code `main` at `bfd79f4c` and the repository integration at
+  `b40626bf`
+- Scope: simplify and strengthen the Code execution kernel; do not add a
+  foreign Harness runtime
+
+This document turns the first-principles architecture review into an ordered
+implementation plan. It supplements the
+[scientific discovery platform roadmap](scientific-discovery-platform-roadmap.md)
+and the Code-owned [roadmap](../crates/code/ROADMAP.md).
+
+## 1. Decision summary
+
+A3S Code already has the required capability breadth: governed Agent
+execution, exact capability generations, scoped cancellation, workspace and
+semantic retrieval, durable memory, workflows, evaluation, checkpoints,
+replay, and cross-language SDKs. The next performance and reliability gains
+come from reducing parallel authorities and duplicated lifecycle machinery.
+
+The target is one small execution kernel with typed host adapters:
+
+```text
+Host API / SDK / Harness
+          │
+          ▼
+ExecutionCoordinator
+  Run · Turn · Tool · Model · Workflow
+          │
+          ├── CapabilitySnapshot + AuthorityCeiling
+          ├── CoreEventLog + EvidenceCursor
+          ├── WorkspaceSourceSnapshot
+          └── Artifact/CAS + Checkpoint
+          │
+          ▼
+Typed adapters: Use · MCP · Flow · Memory · Search · Sandbox · Cloud
+```
+
+Code remains the execution and evidence authority. A3S Use remains the
+package, grant, environment, and generation authority. Desktop remains the
+project and human-decision projection. No component may create a second
+session/run store or silently reinterpret Code evidence.
+
+## 2. First-principles invariants
+
+Every change in this roadmap must preserve these invariants:
+
+1. **One fact, one authority.** A fact is appended once and projected into
+   Agent, evaluation, research, graph, and SDK views.
+2. **Authority is temporal.** A Run can only use the exact capability,
+   workspace, policy, and provider generation admitted for that Run.
+3. **Evidence precedes synthesis.** Missing, stale, conflicting, or redacted
+   evidence is explicit; it never becomes an implicit success.
+4. **Boundedness is a contract.** Bytes, tokens, tasks, queues, descriptors,
+   files, sockets, retries, and shutdown time are bounded before work starts.
+5. **Cancellation follows ownership.** Every spawned future belongs to a
+   Session, Run, Turn, or Subtask and settles before that owner releases its
+   leases.
+6. **Reproducibility is identity.** Source, workflow, code, environment,
+   model, parameters, seed, provider, and output are content-addressed.
+7. **Trust is explicit.** Model, tool, web, package, host, secret, and derived
+   artifact data have different trust and egress rules.
+8. **Adapters do not become authorities.** Search, memory, Flow, MCP, and
+   remote providers implement typed ports and cannot rewrite Code history.
+
+## 3. Baseline observations
+
+The current architecture is strong but has measurable consolidation pressure:
+
+- Runtime facts are represented by `AgentEvent`, `RunEventRecord`,
+  `EventEnvelopeV1`, `harness_evidence`, the evaluation fact journal,
+  research contracts, and State Graph events.
+- Lifecycle state is coordinated by `AgentSession`, `AgentLoop`, Run stores,
+  capability supervisors, evaluation supervisors, queues, the task scheduler,
+  and the protocol Harness/Host.
+- `SessionStore` still exposes aggregate snapshots and legacy fragment APIs.
+- The capability projection is correct and generation-exact, but compatibility
+  registries remain beside the projected registry until `CAP-GA1`.
+- Workspace manifest, LSP documents, retrieval chunks, semantic indexes, and
+  zvec indexes each maintain related source/revision state. The persistent
+  zvec-grep work is a derived-cache integration and is not a new source of
+  truth.
+- Large implementation units remain in `tools/task.rs`, `run.rs`,
+  `workspace/local.rs`, and `evaluation/evidence.rs`; the Core Cargo manifest
+  also couples model, browser, search, memory, Flow, sandbox, zvec, S3, and
+  QuickJS concerns.
+- The native research contracts are now strict Rust values, but still need an
+  adapter into the existing Run, Event, Store, Evaluation, and SDK planes.
+
+These observations are architecture risks, not reasons to remove working
+capabilities. Refactors must be incremental and behavior-preserving.
+
+## 4. Optimization tracks
+
+### KRN-1 — Unified identity, clock, and event fabric
+
+Introduce a small `CoreIdentity` layer containing typed `OperationId`,
+`SourceRevision`, `CapabilityStamp`, `EvidenceCursor`, `ArtifactRef`, and an
+injectable logical clock. Add one append-only `CoreEventLog` with canonical
+encoding, domain-separated digests, causality, retention gaps, and bounded
+payload references.
+
+The existing Agent, evaluation, research, and State Graph values become
+validated projections. Do not create another audit database. Preserve the
+current wire envelopes as compatibility projections until the migration gate
+is complete.
+
+**Exit gate:** replaying any retained log twice is idempotent; duplicate,
+reordered, stale-generation, and cursor-skipping writes fail closed; all
+projections expose the same operation, source, capability, and evidence
+identity.
+
+### KRN-2 — One execution coordinator
+
+Create an internal `ExecutionCoordinator` that owns Run admission, Turn
+creation, cancellation, task registration, Tool/Model/Workflow invocation,
+event append, checkpoint acknowledgement, and close. Existing facades remain
+public API adapters.
+
+Detached work must use an explicit durable/external-run contract. A dropped
+`JoinHandle` must never be the accidental way to outlive a Run. Close must
+settle child Tasks, evaluation work, refresh jobs, stream bridges, and
+capability effects before releasing the Use lease.
+
+**Exit gate:** one state machine covers normal, streaming, direct-tool,
+delegated, protocol, and recovery paths; no unowned task or lease remains in
+the lifecycle qualification matrix.
+
+### KRN-3 — Capability plane convergence
+
+Finish the migration from compatibility registries to the immutable
+`CapabilityProjection` path. Keep `CapabilitySet` as the identity plane and
+separate three concerns currently close together:
+
+- `AuthorityCeiling` — what may be accessed;
+- `ResourceBudget` — how much work may be done; and
+- `ReadinessStamp` — whether a dependency is usable.
+
+Use exact generation leases for all Use-backed surfaces. Use lazy runtime
+handles for expensive MCP, Flow, UI, and Knowledge values while retaining
+generation-exact identity and atomic publication.
+
+**Exit gate:** one catalog, one admission transaction, no shadowing or
+piecemeal reconciliation, bounded cutover/retirement, and unchanged old-Run
+behavior across an N → N+1 publication.
+
+### KRN-4 — Source snapshot and derived data plane
+
+Define `WorkspaceSourceSnapshot` as the single revision authority for local,
+remote, and S3 content. It binds repository revision, file content digest,
+document/LSP revision, eligibility policy, chunk revision, and index
+generation.
+
+Manifest scanning, LSP, BM25, zvec, semantic vectors, context selection, and
+research evidence must consume this snapshot. Indexes are rebuildable derived
+caches published by atomic generation/CAS; stale results cannot cross a
+source snapshot boundary.
+
+**Exit gate:** a search hit, symbol result, model context item, and evidence
+fact can be traced to the same source snapshot; concurrent edits never yield a
+false current result; zvec startup, crash recovery, and platform loading pass
+the locked qualification matrix.
+
+### KRN-5 — Model and Tool middleware
+
+Normalize blocking, streaming, structured, repair, compaction, and auxiliary
+model calls through one `ModelCallMiddleware`:
+
+```text
+admission → budget → cancellation → capability/evidence bind
+→ provider call → usage/cost → retry/repair → event append
+```
+
+Normalize every Tool, MCP, Flow, and Use Runtime Task through one
+`ToolInvocation` state machine. Add typed trust/taint labels so redaction and
+egress checks are applied at the value boundary instead of repeated in each
+adapter.
+
+**Exit gate:** every provider and Tool path produces the same admission,
+cancellation, usage, error, and evidence semantics; model output cannot
+change authority; untrusted content cannot become an instruction without an
+explicit host policy.
+
+### KRN-6 — Durable log, CAS, and artifact lifecycle
+
+Extend `SessionStoreCapabilities` to advertise aggregate CAS, append-only log,
+lease fencing, encryption, watch, and artifact-GC guarantees. Move the file
+adapter toward WAL plus periodic immutable snapshots while retaining the
+current API during migration.
+
+Make artifact retention reference-aware: a provenance receipt, review finding,
+checkpoint, or publication keeps its referenced content alive. Garbage
+collection must never remove an object reachable from a retained identity.
+
+**Exit gate:** crash/restart/replay tests prove atomic visibility, no partial
+generation, no lost event, no duplicate side effect, and no premature artifact
+deletion under concurrent writers.
+
+### KRN-7 — Research and evaluation convergence
+
+Adapt `ResearchRunV1`, `ResearchEvidenceFactV1`,
+`ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and
+`ResearchEventV1` onto KRN-1 rather than adding a Research Store. Add a typed
+reproducibility manifest for provider parameters, model revision, environment
+lock, code/workflow digests, seeds, tolerances, and output artifacts.
+
+Reviewer execution uses the generic Evaluation Substrate for isolation,
+cancellation, bounded evidence, and immutable results. Research review is a
+typed projection with host-owned rubric, threshold, human approval, and
+publication decisions.
+
+**Exit gate:** one research run survives restart and fork; every published
+claim, number, figure, table, and report has source/evidence/provenance links;
+review findings cannot imply approval; Rust/Node/Python/Go receive the same
+strict schema.
+
+### KRN-8 — Workflow and scheduler convergence
+
+Unify Planning, orchestration, Dynamic Workflow, Flow, and State Graph around
+one internal `ExecutionPlan`/Step model. Keep their public formats as
+adapters. Unify `a3s-lane`, Session queues, and the task scheduler around one
+admission scheduler with priority, fairness, per-Run quotas, provider quotas,
+and starvation protection.
+
+Checkpoint and idempotency identity must be shared by model calls, Tool calls,
+workflow steps, and evaluator dispatches.
+
+**Exit gate:** sequential, parallel, resumable, delegated, and Flow-backed
+plans use one cancellation and checkpoint semantics; no orphan work remains
+after parent cancellation or process restart.
+
+### KRN-9 — SDK and host contract generation
+
+Generate Event, Capability, Evaluation, Research, Run Control, and error
+schemas from one catalog. Add research capability discovery and exact schema
+version negotiation to Node, Python, and Go. Replace FFI runtime `.expect()`
+paths with fallible initialization and stable error codes.
+
+**Exit gate:** generated declarations and negative fixtures pass parity checks;
+all SDKs agree on cancellation, backpressure, replay, unknown-field, and error
+semantics.
+
+### KRN-10 — Kernel modularization and release profiles
+
+Keep `a3s-code-core` as a compatibility facade, but split internal ownership
+into these dependency layers:
+
+```text
+a3s-code-kernel       identity · clock · events · capabilities · scopes
+a3s-code-engine       run · turn · model · tool · workflow
+a3s-code-data         workspace · retrieval · memory · artifacts · CAS
+a3s-code-evaluation   evidence · evaluator · research projections
+a3s-code-host         MCP · Use · Flow · SDK · Serve · Cloud adapters
+```
+
+Publish explicit feature profiles (`minimal`, `local-code`, `scientific`,
+`server`, `full`). Native zvec, browser, S3, QuickJS, and telemetry must be
+selected by a product profile rather than silently increasing every embedder's
+build and supply-chain surface.
+
+**Exit gate:** kernel builds without browser/S3/zvec dependencies; release
+profiles have documented size, startup, memory, and feature behavior; public
+API compatibility tests remain green.
+
+## 5. Delivery phases
+
+| Phase | Focus | Required deliverables | Exit gate |
+| --- | --- | --- | --- |
+| **P0 — Freeze and measure** | Establish one baseline before refactoring | Machine-readable capability inventory; schema/owner map; event/identity inventory; lifecycle leak matrix; source/index consistency matrix; compile/startup/RSS/latency measurements | Architecture review approves owners and budgets; no behavior change is hidden in a refactor |
+| **P1 — Kernel convergence** | KRN-1, KRN-2, KRN-3 | Core identities, logical clock, event-log adapter, ExecutionCoordinator skeleton, separated ceiling/budget/readiness, compatibility-path telemetry | Existing full Core tests pass; replay/cancellation/lease tests pass through both old and new adapters |
+| **P2 — Data and durability** | KRN-4, KRN-6 | WorkspaceSourceSnapshot, derived-index generation/CAS, unified artifact refs, store capability expansion, WAL/CAS prototype | Concurrent edit/index/restart fixtures prove current-source results and atomic persistence |
+| **P3 — Execution simplification** | KRN-5, KRN-8 | Model middleware, ToolInvocation FSM, shared plan/step model, unified scheduler and idempotency | Provider/tool/workflow matrix has identical budget, cancellation, evidence, and retry semantics |
+| **P4 — Scientific vertical slice** | KRN-7, KRN-9 | Research-to-Run adapters, reproducibility manifest, reviewer projection, artifact/provenance graph, generated SDK contracts | Local literature-plus-data fixture supports restart, fork, deterministic analysis, reviewer fault detection, explicit approval, and export |
+| **P5 — Modularization and scale** | KRN-10 plus remaining KRN-9 | Internal crate split, feature profiles, remote provider recovery, FFI hardening, operational dashboards | Linux/macOS/Windows, offline/remote, memory/disk, security, and release qualification pass without API drift |
+
+## 6. Dependency order
+
+```text
+P0
+ └─> P1 Kernel convergence
+       ├─> P2 Source + durability
+       │     └─> P4 Scientific vertical slice
+       ├─> P3 Model/Tool/workflow convergence
+       │     └─> P4 Scientific vertical slice
+       └─> P3 + P2 ──> P5 Modularization and scale
+```
+
+Do not start broad domain packages, remote compute, or Desktop graph features
+before P2 establishes source and artifact identity. Do not claim scientific
+reproducibility before P4's fixture and reviewer gates pass.
+
+## 7. Measurement and rollback policy
+
+Every phase records before/after values for:
+
+- admission-to-first-token and Tool round-trip latency;
+- event append and replay throughput;
+- peak RSS, open files/sockets, queue depth, and retained bytes;
+- cancellation-to-settlement and shutdown deadlines;
+- index rebuild/publication time and stale-result rate;
+- duplicate side effects, replay conflicts, and orphan-task count; and
+- SDK wire parity and schema rejection behavior.
+
+The proposed default performance guard is no more than 10% regression in a
+qualified local profile unless the change removes a documented correctness or
+security risk. A phase rolls back to its previous adapter when any invariant,
+resource ceiling, or cross-platform gate fails. Compatibility adapters may
+remain during one migration period, but they must emit usage metrics and cannot
+become a new authority.
+
+## 8. Explicit non-goals
+
+- Embedding DeepSeek Harness, Cordis, or another foreign runtime.
+- Turning Code into a package manager, general dependency-injection framework,
+  or scientific policy authority.
+- Adding a second event journal, research store, Cloud audit store, or Desktop
+  session store.
+- Making a specific model, browser, vector database, Cloud deployment, or HPC
+  provider mandatory for local Code.
+- Treating similarity, model confidence, reviewer tokens, or successful
+  execution as scientific truth without evidence and human/domain policy.
+- Removing a working compatibility surface before its migration and rollback
+  gates are recorded.
+
+## 9. Immediate next slice
+
+The next Code-side implementation slice is **P1.1 Core identity and event
+adapter**:
+
+1. inventory the existing event/evidence digests and assign one owner per
+   identity;
+2. introduce `OperationId`, `SourceRevision`, `CapabilityStamp`, and
+   `EvidenceCursor` adapters without changing public envelopes;
+3. route one Run's Agent, evaluation, and research projections through the
+   adapter and prove replay/idempotency;
+4. add the first `ExecutionCoordinator` boundary around one blocking and one
+   streaming provider path; and
+5. publish measurements and a rollback note before expanding the migration.
+
+This slice is intentionally smaller than a new feature. It reduces future
+complexity while preserving the native Code + Use + Desktop ownership model.

--- a/docs/scientific-discovery-platform-roadmap.md
+++ b/docs/scientific-discovery-platform-roadmap.md
@@ -3,6 +3,7 @@
 - Status: accepted product direction; implementation is staged
 - Decision date: 2026-09-05
 - Owners: A3S Code, A3S Use, and A3S Desktop
+- Code architecture follow-up: [A3S Code Core Optimization Roadmap](a3s-code-core-optimization-roadmap.md)
 - Related: [Native Code/Use boundary](https://github.com/A3S-Lab/Use/blob/main/docs/adr-003-native-code-harness-boundary.md), [Code evaluation substrate](https://github.com/A3S-Lab/Code/blob/main/manual/EVALUATION_SUBSTRATE.md), [Desktop product contract](../apps/desktop/DESIGN.md), [Science catalog](../packages/science/README.md)
 
 ## Product outcome


### PR DESCRIPTION
## Summary
- add a first-principles optimization roadmap for the A3S Code execution kernel
- define KRN-1 through KRN-10, phased delivery gates, measurements, rollback policy, and non-goals
- link the Code roadmap from the scientific discovery roadmap and repository README

## Scope
Documentation only. This change does not modify the Code submodule or the in-progress zvec-grep/persistent-index worktree.

## Verification
- `git diff --check`
- local link targets for the new roadmap and parent roadmap exist
