### PR TITLE
chore: integrate task admission adapter

### DIFF
--- a/docs/a3s-code-core-optimization-roadmap.md
+++ b/docs/a3s-code-core-optimization-roadmap.md
@@ -348,6 +348,10 @@ The first P1 slices are now delivered on Code `main`:
   lifecycles use one cancellation-first `RunTerminalTransition`, with an
   atomic one-shot RunStore settlement. Lifecycle adapters retain only their
   mode-specific persistence, event-drain, and cleanup ordering.
+- **P1.2 task-admission convergence** (`d5c03fa5`): synchronous and
+  event-streaming direct-tool calls reuse the coordinator's canonical
+  TaskScheduler lease/error adapter while retaining their independent
+  control-plane lifetime (they do not acquire the transcript Run lease).
 
 The local qualification slice passed `cargo fmt --all -- --check`, focused
 identity/research/coordinator tests, blocking and streaming lifecycle tests,


### PR DESCRIPTION
## Summary
- advance `crates/code` to Code PR #83 (`d5c03fa5`)
- record direct-tool task admission convergence in the persistent optimization roadmap

## Scope
- one Code gitlink and one roadmap document
- direct tools retain their independent control-plane lifetime; no Run lease is added
- parallel persistent-index and research-contract worktrees are untouched

## Verification
- Code PR #83 merged
- direct-tool tests: 16 passed
- Core full library suite on the preceding coordinator state: 3103 passed, 0 failed, 13 ignored
