### PR TITLE
chore: integrate tool invocation lifecycle

### DIFF
--- a/docs/a3s-code-core-optimization-roadmap.md
+++ b/docs/a3s-code-core-optimization-roadmap.md
@@ -373,13 +373,18 @@ The first P1 slices are now delivered on Code `main`:
   `LlmInvoker` lifecycle. Evidence classification and prompt estimation are
   shared, while the proxy receiver remains the owner of provider cancellation
   and usage completion.
+- **P3/KRN-5 ToolInvocation FSM** (`2c72c913`): built-ins, MCP, Flow, and
+  Use Runtime Task dispatch now cross one explicit lifecycle state machine
+  from admission through gate evaluation, execution, and a single terminal
+  outcome. Rejection, cancellation, success, failure, and budget denial are
+  typed without changing public Tool/ToolEnd protocol shapes.
 
 The local qualification slice passed `cargo fmt --all -- --check`, focused
 identity/research/coordinator tests, blocking and streaming lifecycle tests,
 protocol Host/Harness tests, and the complete Core test suite (3106 passed,
 0 failed, 13 ignored; 3119 total). The root integration PRs are #307, #308,
-#309, #310, #311, #312, #313, #314, and #315; coordinator integrations follow
-these Code changes.
+#309, #310, #311, #312, #313, #314, #315, and #316; coordinator integrations
+follow these Code changes.
 
 The middleware follow-up passed `cargo fmt --all -- --check`, Code compilation,
 and 13 focused `agent::llm_invoker` tests. The streaming follow-up passed the
@@ -387,14 +392,19 @@ same format/compile checks and 14 focused `agent::llm_invoker` tests. The
 intentionally filtered integration binaries were not rerun because the prior
 complete Core suite already covers their unchanged paths.
 
-The next Code-side slice is **P3/KRN-5 ToolInvocation FSM**:
+The ToolInvocation follow-up passed `cargo fmt --all -- --check` and focused
+FSM, executor-registry, and nested-governance tests (4 + 1 + 13 passed). The
+full suite was not repeated because this slice only adds an internal lifecycle
+guard around existing tool execution paths.
 
-1. add one `ToolInvocation` state machine for built-ins, MCP, Flow, and Use
-   Runtime Tasks with bounded admission, cancellation, and terminal evidence;
-2. bind typed trust/taint labels and shared idempotency identity at the model
-   and tool value boundaries.
+The next Code-side slice is **P3/KRN-5 trust/taint and idempotency**:
+
+1. bind typed trust/taint labels at model/tool value boundaries and enforce
+   egress/redaction at one value boundary;
+2. add shared idempotency identity across model calls, Tool calls, workflow
+   steps, and evaluator dispatches while preserving replay/fencing;
 3. route repair, compaction, and auxiliary model calls through the typed
-   middleware phases without transferring ownership of caller cancellation.
+   middleware phases with caller-owned cancellation.
 
 This remains an incremental refactor: no second Run store, event journal,
 package manager, or foreign Harness runtime is introduced.


### PR DESCRIPTION
Integrate the merged a3s-code ToolInvocation lifecycle into the monorepo and persist the roadmap update.

- advances crates/code gitlink to 2c72c913
- documents the explicit admission/gate/execution/terminal FSM
- records focused local qualification and the next trust/taint/idempotency slice

Validation: git diff --check; local Code FSM, executor-registry, and nested-governance tests passed.
