### PR TITLE
chore: integrate artifact store conflict fencing

### DIFF
--- a/docs/a3s-code-core-optimization-roadmap.md
+++ b/docs/a3s-code-core-optimization-roadmap.md
@@ -677,5 +677,13 @@ finding identities; once present, the receipt digest is part of the finding
 identity and cannot drift without producing a new observation. Code still does
 not own reviewer rubrics, thresholds, approval, or publication policy.
 
+The create-only artifact-store boundary landed in Code `8bf60f34`
+(`A3S-Lab/Code#109`) and is now pinned here. `ArtifactStore::put_content_addressed`
+makes immutable replay explicit: exact writes are idempotent, URI/content or
+metadata collisions fail closed, manifest reopen rejects conflicting duplicate
+entries, and the Tool artifact fallback uses the same operation. The mutable
+`put` API remains available for compatibility cache callers; retention and
+eviction policy remain in the store rather than being duplicated in Core.
+
 This remains an incremental refactor: no second Run store, event journal,
 package manager, or foreign Harness runtime is introduced.


### PR DESCRIPTION
## Summary
- pin Code create-only artifact-store conflict fencing
- document immutable replay and manifest/tool fallback boundaries

## Validation
- Code PR #109 merged at 8bf60f34
- Code focused artifact, tool, and clippy checks passed