### PR TITLE
Pin strict reviewer evidence binding

### DIFF
--- a/docs/a3s-code-core-optimization-roadmap.md
+++ b/docs/a3s-code-core-optimization-roadmap.md
@@ -701,12 +701,13 @@ cross-project Run-id reuse case that the legacy object-only binding cannot
 observe. The qualification fixture covers this rejection alongside the
 provenance checks.
 
-Run-aware review-batch validation landed in Code `883f0fff`
-(`A3S-Lab/Code#117`) and is now pinned here. Hosts can construct or validate a
-`ResearchReviewBatchV1` with the admitted Run and exact evaluator record;
-Code closes the batch project/Run namespace and rejects a batch evidence
-digest that differs from the evaluator record. The legacy digest-only
-constructor remains available for wire compatibility.
+Run-aware review-batch validation landed in Code `1175c8d6`
+(`A3S-Lab/Code#118`, following `A3S-Lab/Code#117`) and is now pinned here.
+Hosts can construct or validate a `ResearchReviewBatchV1` with the admitted
+Run and exact evaluator record; Code closes the batch project/Run namespace,
+requires the evaluator evidence to be the Run's exact snapshot, and rejects a
+batch evidence digest that differs from the evaluator record. The legacy
+digest-only constructor remains available for wire compatibility.
 
 The create-only artifact-store boundary landed in Code `8bf60f34`
 (`A3S-Lab/Code#109`) and is now pinned here. `ArtifactStore::put_content_addressed`


### PR DESCRIPTION
## Summary
- pin crates/code to Code `1175c8d6` (Code #118)
- document that evaluator and batch evidence must match the admitted Run snapshot

## Validation
- Code #118 merged after batch tests, research qualification, fmt, and Clippy
- monorepo diff is limited to the Code gitlink and roadmap documentation