### PR TITLE
Add Harbor adapter and Terminal-Bench 4.0 evaluation runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ config.acl
 # Temporary directory
 /temp/
 
+# Harbor / Terminal-Bench local job outputs
+.harbor-smoke/
+.harbor-eval/
+
 # Node.js (root should not have these)
 /node_modules/
 /package.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,9 @@ Rules:
 - Tests must not leave temp files or sockets behind.
 - Rust builds should be validated from the affected crate workspace, not from the monorepo root.
 - Use app-local package scripts (`bun`, `npm`, `pnpm`) for frontend/documentation apps.
+- Terminal-Bench 4.0 / Harbor evaluation of A3S Code: follow
+  [`scripts/harbor/EVALUATION.md`](scripts/harbor/EVALUATION.md) (WSL, wheel
+  prefetch, `.a3s/config.acl` → `.env`, smoke ladder, then full `harbor run`).
 
 ## Pre-Submission Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,9 @@ For every feature:
 4. Remove obsolete content (outdated docs, deprecated examples, completed TODOs)
 5. Verify code examples still work
 
+Terminal-Bench 4.0 evaluation of A3S Code via Harbor is documented in
+[`scripts/harbor/EVALUATION.md`](scripts/harbor/EVALUATION.md).
+
 ---
 
 ## Mandatory Code Design Rules

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ its owning repository before advancing its gitlink here, and read
   [roadmap](docs/retrieval-platform-roadmap.md)
 - [Scientific discovery platform roadmap](docs/scientific-discovery-platform-roadmap.md)
 - [A3S Code Core optimization roadmap](docs/a3s-code-core-optimization-roadmap.md)
+- [Terminal-Bench 4.0 evaluation (Harbor + A3S Code)](scripts/harbor/EVALUATION.md)
 - [CLI releases](https://github.com/A3S-Lab/CLI/releases)
 - [Discord](https://discord.gg/XVg6Hu6H)
 

--- a/scripts/harbor/.env.example
+++ b/scripts/harbor/.env.example
@@ -1,0 +1,12 @@
+# Prefer generating from repo config:
+#   python3 scripts/harbor/materialize_env_from_a3s_config.py
+#
+# Or fill manually:
+DEEPSEEK_API_KEY=
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+A3S_TB_MODEL=deepseek/deepseek-v4-pro
+
+# Optional alternatives:
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+# OPENROUTER_API_KEY=

--- a/scripts/harbor/.gitignore
+++ b/scripts/harbor/.gitignore
@@ -1,0 +1,8 @@
+.env
+wheels/*.whl
+wheels/*.partial
+__pycache__/
+*.pyc
+
+# local smoke/eval outputs live under repo .harbor-smoke/
+

--- a/scripts/harbor/EVALUATION.md
+++ b/scripts/harbor/EVALUATION.md
@@ -1,0 +1,275 @@
+# Terminal-Bench 4.0 evaluation with A3S Code
+
+Canonical runbook for evaluating **A3S Code** on **Terminal-Bench 4.0** via
+**Harbor**. Keep this file updated when the adapter, wheel packaging, or Harbor
+flags change.
+
+> **Status:** Environment and adapter are ready. Full leaderboard-style runs
+> should wait until the next A3S Code release wheel is available. Use smoke
+> scripts only to validate install/config until then.
+
+## Overview
+
+| Piece | Role |
+| --- | --- |
+| Harbor | Official TB 4.0 harness (`harbor run -d terminal-bench/terminal-bench@4.0.0`) |
+| `a3s_code_agent` | Custom `BaseInstalledAgent` that installs A3S Code in the task container and runs headlessly |
+| Prefetched manylinux wheel | Avoids GitHub DNS failures inside task containers |
+| `.a3s/config.acl` → `scripts/harbor/.env` | Model + API key source for Harbor (gitignored `.env`) |
+
+A3S Code is **not** a built-in Harbor agent. Always pass:
+
+```text
+-a a3s_code_agent.agent:A3sCodeAgent
+```
+
+and set `PYTHONPATH` to `scripts/harbor` so Harbor can import the adapter.
+
+## Host requirements
+
+Run everything in **WSL2 Ubuntu** (not the Windows Docker host):
+
+- Python ≥ 3.12 (for host tooling)
+- [`uv`](https://github.com/astral-sh/uv)
+- Harbor with Docker support: `uv tool install 'harbor[modal]'`
+- Docker Engine working inside WSL (`docker ps` succeeds)
+- NVIDIA GPU optional (some TB tasks need GPU; many do not)
+- Network access to the model provider (for example DeepSeek)
+
+Recommended PATH:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Persist that in `~/.bashrc` / `~/.profile` if needed.
+
+## Layout
+
+```text
+scripts/
+├── tb40_env_smoke.sh              # Host tools: python/uv/harbor/docker/gpu
+├── tb40_a3s_install_only.sh       # Harbor --install-only (no model call)
+├── tb40_a3s_agent_smoke.sh        # 1-task agent smoke with model
+└── harbor/
+    ├── README.md                  # Short index → this runbook
+    ├── EVALUATION.md              # This file
+    ├── .env.example
+    ├── .env                       # gitignored; materialized from .a3s/config.acl
+    ├── materialize_env_from_a3s_config.py
+    ├── download_wheel.sh
+    ├── wheels/                    # gitignored *.whl
+    └── a3s_code_agent/
+        ├── agent.py               # Harbor BaseInstalledAgent
+        └── runner.py              # Headless a3s_code session (allow-all)
+
+.harbor-smoke/jobs/                # Smoke job outputs (local)
+```
+
+## One-time setup
+
+### 1. Install host tools (WSL)
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# restart shell or: source "$HOME/.local/bin/env"
+uv tool install 'harbor[modal]'
+harbor --version
+docker ps
+```
+
+### 2. Prefetch the A3S Code manylinux wheel
+
+Task containers often cannot resolve GitHub. Download on the host and let the
+adapter upload the wheel:
+
+```bash
+bash /mnt/d/code/a3s/scripts/harbor/download_wheel.sh 8.2.0
+# → scripts/harbor/wheels/a3s_code-8.2.0-cp310-abi3-manylinux_2_28_x86_64.whl
+```
+
+When a **new A3S Code version** ships, download that version (or place the
+matching `cp310-abi3-manylinux_2_28_x86_64` wheel into `scripts/harbor/wheels/`)
+before full evaluation.
+
+### 3. Materialize model credentials from `.a3s/config.acl`
+
+```bash
+python3 /mnt/d/code/a3s/scripts/harbor/materialize_env_from_a3s_config.py
+```
+
+Writes gitignored `scripts/harbor/.env`:
+
+- `DEEPSEEK_API_KEY`
+- `DEEPSEEK_BASE_URL`
+- `A3S_TB_MODEL` (from `default_model`)
+
+Never commit `.env` or paste keys into git-tracked files. Manual template:
+`scripts/harbor/.env.example`.
+
+Load for a shell session:
+
+```bash
+set -a
+source /mnt/d/code/a3s/scripts/harbor/.env
+set +a
+```
+
+Harbor discovers `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` for model
+`deepseek/<name>` via its provider registry (`passthrough` on the adapter).
+
+## Adapter behavior (method)
+
+1. **Install** (agent setup, timed; default Harbor setup budget ~360s, smoke uses multiplier 3):
+   - Ensure light system deps (`curl`, `ca_certificates`) — avoid `build-essential` when using a binary wheel
+   - Upload prefetched manylinux wheel into `/tmp/a3s-code-harbor/wheels/`
+   - `uv` + Python 3.12 venv + `uv pip install` the wheel
+   - Upload `runner.py`
+2. **Run**:
+   - Build a minimal ACL (`providers "<provider>" { api_key = env(...); base_url? }`)
+   - `PermissionPolicy(default_decision="allow")` + `ConfirmationPolicy(enabled=False)` for unattended TB
+   - Execute `session.send({prompt: instruction})` in `/app`
+   - Stream logs to `/logs/agent/a3s-code.txt` and write `a3s-code-result.json`
+
+Important implementation notes:
+
+- Do **not** use `$HOME/...` paths for Harbor `upload_file` sources; use absolute host paths under `/mnt/d/code/a3s/...` or `/tmp/...`
+- Prefer a host-downloaded manylinux wheel over `pip install` from GitHub inside the container
+- Install into a **venv** (`uv venv`); do not `uv pip install` into uv-managed CPython
+
+## Validation ladder (before full eval)
+
+Always run from WSL with repo paths under `/mnt/d/code/a3s`.
+
+### A. Environment smoke
+
+```bash
+bash /mnt/d/code/a3s/scripts/tb40_env_smoke.sh
+```
+
+Checks: `python3`, `uv`, `harbor`, `docker`, optional GPU.
+
+### B. Install-only smoke (no API key required)
+
+```bash
+bash /mnt/d/code/a3s/scripts/tb40_a3s_install_only.sh
+```
+
+Confirms Harbor can import `A3sCodeAgent` and install the wheel inside a TB task
+container (`--install-only`).
+
+### C. Agent smoke (API key required)
+
+```bash
+python3 /mnt/d/code/a3s/scripts/harbor/materialize_env_from_a3s_config.py
+bash /mnt/d/code/a3s/scripts/tb40_a3s_agent_smoke.sh
+# optional model override:
+# bash /mnt/d/code/a3s/scripts/tb40_a3s_agent_smoke.sh deepseek/deepseek-v4-flash
+```
+
+Runs **1 task × 1 trial**. Harbor may pick a hard task (for example
+`layout-config-recreation2` with a multi-hour agent timeout). That is enough to
+prove install + model wiring; it is **not** a substitute for a planned full
+suite.
+
+Stop a runaway smoke:
+
+```bash
+pkill -f 'harbor run -d terminal-bench/terminal-bench@4.0.0' || true
+docker ps --format '{{.Names}}' | grep -E 'terminal-bench|layout-config' | xargs -r docker stop
+```
+
+## Full evaluation (after new A3S Code release)
+
+### Checklist
+
+1. Place the new manylinux wheel in `scripts/harbor/wheels/` (or `download_wheel.sh <version>`)
+2. Refresh `.env` if `.a3s/config.acl` changed
+3. Re-run install-only smoke once
+4. Launch the Harbor job with explicit task filters / trial counts
+
+### Example: leaderboard-style style parameters
+
+Adjust concurrency and cost deliberately. Full TB 4.0 with high `-k` is
+expensive and long-running.
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+export PYTHONPATH="/mnt/d/code/a3s/scripts/harbor${PYTHONPATH:+:$PYTHONPATH}"
+set -a; source /mnt/d/code/a3s/scripts/harbor/.env; set +a
+
+JOBS="/mnt/d/code/a3s/.harbor-eval/jobs"
+mkdir -p "$JOBS"
+
+harbor run \
+  -d "terminal-bench/terminal-bench@4.0.0" \
+  -a "a3s_code_agent.agent:A3sCodeAgent" \
+  -m "${A3S_TB_MODEL}" \
+  -e docker \
+  -n 4 \
+  -k 5 \
+  --agent-setup-timeout-multiplier 3 \
+  --jobs-dir "$JOBS"
+```
+
+Useful filters:
+
+| Flag | Purpose |
+| --- | --- |
+| `-l N` / `--n-tasks N` | Cap number of tasks |
+| `-i NAME` / `--include-task-name` | Include specific task(s) |
+| `-x NAME` / `--exclude-task-name` | Exclude task(s) |
+| `-k N` | Trials per task (leaderboard-style often uses 5) |
+| `-n N` | Concurrent trials |
+| `--agent-setup-timeout-multiplier` | Raise when install is slow on cold images |
+| `--install-only` | Setup/install only |
+
+Inspect results:
+
+```bash
+harbor view /mnt/d/code/a3s/.harbor-eval/jobs
+# or open the job folder's result.json
+```
+
+## Jobs and artifacts
+
+| Path | Contents |
+| --- | --- |
+| `.harbor-smoke/jobs/<timestamp>/` | Smoke job `result.json`, `job.log`, per-trial dirs |
+| `<trial>/exception.txt` | Harbor/agent setup failures |
+| `<trial>/trial.log` | Executed setup/run commands |
+| Container `/logs/agent/a3s-code.txt` | Agent stdout stream |
+| Container `/logs/agent/a3s-code-result.json` | Runner success/failure payload |
+| Container `/tmp/a3s-code-harbor/agent.acl` | Generated ACL for the trial |
+
+## Known pitfalls
+
+1. **Windows Docker ≠ WSL Docker** — run Harbor inside Ubuntu WSL.
+2. **AgentSetupTimeoutError (~360s)** — usually `apt-get` installing heavy
+   build tools; adapter should stay on light deps + prefetched wheel; raise
+   `--agent-setup-timeout-multiplier` if needed.
+3. **GitHub DNS inside containers** — always prefetch the manylinux wheel.
+4. **Missing API key** — install-only works; full agent runs need provider env
+   vars (materialize from `.a3s/config.acl`).
+5. **PowerShell `$VAR` expansion** — when invoking WSL from PowerShell, put
+   bash logic in `.sh` files; do not rely on `$FOO` inside `wsl bash -c "..."`
+   strings from PowerShell.
+6. **Hard random smoke tasks** — a 1-task smoke may burn hours; stop it after
+   install + first tool activity if you only needed wiring proof.
+
+## Resume when the new A3S Code version is ready
+
+```bash
+# 1) New wheel
+bash /mnt/d/code/a3s/scripts/harbor/download_wheel.sh <NEW_VERSION>
+
+# 2) Model env
+python3 /mnt/d/code/a3s/scripts/harbor/materialize_env_from_a3s_config.py
+
+# 3) Quick gates
+bash /mnt/d/code/a3s/scripts/tb40_env_smoke.sh
+bash /mnt/d/code/a3s/scripts/tb40_a3s_install_only.sh
+bash /mnt/d/code/a3s/scripts/tb40_a3s_agent_smoke.sh   # optional short wiring check
+
+# 4) Full Harbor run (see "Full evaluation" above)
+```

--- a/scripts/harbor/README.md
+++ b/scripts/harbor/README.md
@@ -1,0 +1,27 @@
+# A3S Code Harbor Adapter
+
+Custom Harbor `BaseInstalledAgent` for **Terminal-Bench 4.0** evaluation of A3S Code.
+
+**Full runbook (setup, smoke ladder, full eval, pitfalls):**
+[`EVALUATION.md`](./EVALUATION.md)
+
+## Quick start (WSL)
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+export PYTHONPATH="/mnt/d/code/a3s/scripts/harbor${PYTHONPATH:+:$PYTHONPATH}"
+
+# Wheel (match your A3S Code release)
+bash /mnt/d/code/a3s/scripts/harbor/download_wheel.sh 8.2.0
+
+# Model + key from repo config (writes gitignored .env)
+python3 /mnt/d/code/a3s/scripts/harbor/materialize_env_from_a3s_config.py
+
+# Validation ladder
+bash /mnt/d/code/a3s/scripts/tb40_env_smoke.sh
+bash /mnt/d/code/a3s/scripts/tb40_a3s_install_only.sh
+bash /mnt/d/code/a3s/scripts/tb40_a3s_agent_smoke.sh
+```
+
+Defer full TB 4.0 suites until the next A3S Code wheel is ready; see
+[`EVALUATION.md`](./EVALUATION.md#resume-when-the-new-a3s-code-version-is-ready).

--- a/scripts/harbor/a3s_code_agent/__init__.py
+++ b/scripts/harbor/a3s_code_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Harbor adapter package for A3S Code on Terminal-Bench."""
+
+from .agent import A3sCodeAgent
+
+__all__ = ["A3sCodeAgent"]

--- a/scripts/harbor/a3s_code_agent/agent.py
+++ b/scripts/harbor/a3s_code_agent/agent.py
@@ -1,0 +1,186 @@
+"""Harbor BaseInstalledAgent adapter for A3S Code."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+from typing import Any, override
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.agents.model_connection import ModelConnectionSpec
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from harbor.models.trial.paths import EnvironmentPaths
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_HARBOR_DIR = _PACKAGE_DIR.parent
+_WHEELS_DIR = _HARBOR_DIR / "wheels"
+_RUNNER_HOST_PATH = _PACKAGE_DIR / "runner.py"
+_CONTAINER_HOME = "/tmp/a3s-code-harbor"
+_CONTAINER_RUNNER = f"{_CONTAINER_HOME}/runner.py"
+_CONTAINER_ACL = f"{_CONTAINER_HOME}/agent.acl"
+_CONTAINER_WHEEL_DIR = f"{_CONTAINER_HOME}/wheels"
+_CONTAINER_INSTRUCTION = f"{EnvironmentPaths.agent_dir}/instruction.txt"
+_DEFAULT_WHEEL_VERSION = "8.2.0"
+
+
+def _resolve_host_wheel(version: str | None) -> Path | None:
+    preferred = version or _DEFAULT_WHEEL_VERSION
+    exact = (
+        _WHEELS_DIR
+        / f"a3s_code-{preferred}-cp310-abi3-manylinux_2_28_x86_64.whl"
+    )
+    if exact.exists():
+        return exact
+    matches = sorted(_WHEELS_DIR.glob("a3s_code-*-cp310-abi3-manylinux_2_28_x86_64.whl"))
+    return matches[-1] if matches else None
+
+
+class A3sCodeAgent(BaseInstalledAgent):
+    """Install a3s-code into the task container and run headlessly."""
+
+    MODEL_CONNECTION = ModelConnectionSpec(passthrough=True)
+
+    def __init__(self, *args: Any, version: str | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._version = version
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "a3s-code"
+
+    @override
+    def version(self) -> str | None:
+        return self._version
+
+    @override
+    def get_version_command(self) -> str | None:
+        return (
+            'export PATH="$HOME/.local/bin:$PATH"; '
+            f'"{_CONTAINER_HOME}/venv/bin/python" -c '
+            "\"import a3s_code; print(getattr(a3s_code, '__version__', 'unknown'))\""
+        )
+
+    @override
+    def parse_version(self, stdout: str) -> str:
+        return stdout.strip() or "unknown"
+
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        # Prefer a prebuilt manylinux wheel: skip build-essential/git to keep
+        # agent setup under Harbor's default 360s agent-setup timeout.
+        await self.ensure_system_dependencies(
+            environment,
+            ("curl", "ca_certificates"),
+        )
+
+        version_spec = f"=={self._version}" if self._version else ""
+        venv_dir = f"{_CONTAINER_HOME}/venv"
+        host_wheel = _resolve_host_wheel(self._version)
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                f'mkdir -p "{_CONTAINER_HOME}" "{_CONTAINER_WHEEL_DIR}" "$HOME/.local/bin"'
+            ),
+        )
+
+        if host_wheel is not None:
+            remote_wheel = f"{_CONTAINER_WHEEL_DIR}/{host_wheel.name}"
+            await environment.upload_file(host_wheel, remote_wheel)
+            pip_target = shlex.quote(remote_wheel)
+        else:
+            pip_target = shlex.quote(f"a3s-code{version_spec}")
+
+        install_cmd = (
+            "set -euo pipefail; "
+            "if ! command -v uv >/dev/null 2>&1; then "
+            "curl -LsSf https://astral.sh/uv/install.sh | sh; "
+            "fi; "
+            'if [ -f "$HOME/.local/bin/env" ]; then . "$HOME/.local/bin/env"; fi; '
+            'export PATH="$HOME/.local/bin:$PATH"; '
+            "uv python install 3.12; "
+            f'uv venv "{venv_dir}" --python 3.12; '
+            f'UV_PYTHON="{venv_dir}/bin/python"; '
+            f"uv pip install --python \"$UV_PYTHON\" {pip_target}; "
+            # Native wheel should import without GitHub bootstrap download.
+            "\"$UV_PYTHON\" -c 'import a3s_code; print(\"a3s_code_import_ok\", getattr(a3s_code, \"__version__\", \"unknown\"))'; "
+            'ln -sfn \"$UV_PYTHON\" \"$HOME/.local/bin/a3s-code-python\"'
+        )
+
+        await self.exec_as_agent(environment, command=install_cmd)
+        await environment.upload_file(_RUNNER_HOST_PATH, _CONTAINER_RUNNER)
+
+    @override
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        result_path = self.logs_dir / "a3s-code-result.json"
+        if not result_path.exists():
+            return
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except Exception:
+            return
+        # Keep metadata only; Harbor already tracks reward separately.
+        if isinstance(payload, dict):
+            context.metadata = {
+                **(context.metadata or {}),
+                "a3s_code_result": payload,
+            }
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        if not self.model_name:
+            raise ValueError("A3sCodeAgent requires --model provider/model")
+
+        access = self.model_connection
+        provider = (access.provider or self.model_name.split("/", 1)[0]).lower()
+        api_key_env = {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "google": "GOOGLE_API_KEY",
+            "gemini": "GEMINI_API_KEY",
+            "deepseek": "DEEPSEEK_API_KEY",
+            "openrouter": "OPENROUTER_API_KEY",
+        }.get(provider, f"{provider.upper().replace('-', '_')}_API_KEY")
+
+        if not access.api_key:
+            raise ValueError(
+                f"No API key found for provider {provider!r}. "
+                f"Export {api_key_env} in the Harbor host environment "
+                f"(or pass --ae {api_key_env}=...). "
+                "Install-only succeeds without a key; full TB trials require one."
+            )
+
+        base_url = access.base_url or ""
+        env = dict(access.env or {})
+        escaped_instruction = shlex.quote(instruction)
+        model = shlex.quote(self.model_name)
+        api_key_env_q = shlex.quote(api_key_env)
+        base_url_q = shlex.quote(base_url)
+        command = (
+            "set -euo pipefail; "
+            'if [ -f "$HOME/.local/bin/env" ]; then . "$HOME/.local/bin/env"; fi; '
+            'export PATH="$HOME/.local/bin:$PATH"; '
+            f'PY="{_CONTAINER_HOME}/venv/bin/python"; '
+            f"printf '%s' {escaped_instruction} > {_CONTAINER_INSTRUCTION}; "
+            "\"$PY\" "
+            f"{_CONTAINER_RUNNER} "
+            "--workspace /app "
+            f"--instruction-file {_CONTAINER_INSTRUCTION} "
+            f"--model {model} "
+            f"--acl-path {_CONTAINER_ACL} "
+            f"--log-dir {EnvironmentPaths.agent_dir} "
+            f"--api-key-env {api_key_env_q} "
+            f"--base-url {base_url_q} "
+            f"2>&1 | stdbuf -oL tee {EnvironmentPaths.agent_dir}/a3s-code.txt"
+        )
+
+        await self.exec_as_agent(environment, command=command, env=env)

--- a/scripts/harbor/a3s_code_agent/runner.py
+++ b/scripts/harbor/a3s_code_agent/runner.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Headless A3S Code runner for Harbor Terminal-Bench trials."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _build_acl(model: str, provider: str, api_key_env: str, base_url: str | None = None) -> str:
+    # Keep ACL minimal: one provider block + default model.
+    # Canonical form matches crates/code/agent.example.acl (`providers`).
+    lines = [
+        f'default_model = "{model}"',
+        "",
+        f'providers "{provider}" {{',
+        f'  api_key = env("{api_key_env}")',
+    ]
+    if base_url:
+        lines.append(f'  base_url = "{base_url}"')
+    lines.extend(
+        [
+            f'  models "{model.split("/", 1)[-1]}" {{}}',
+            "}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--instruction-file", required=True)
+    parser.add_argument("--model", required=True, help="provider/model")
+    parser.add_argument("--acl-path", required=True)
+    parser.add_argument("--log-dir", required=True)
+    parser.add_argument("--api-key-env", default="")
+    parser.add_argument("--base-url", default="")
+    args = parser.parse_args()
+
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    result_path = log_dir / "a3s-code-result.json"
+    error_path = log_dir / "a3s-code-error.txt"
+
+    try:
+        if "/" not in args.model:
+            raise ValueError("model must be provider/model")
+        provider, _model_name = args.model.split("/", 1)
+        api_key_env = args.api_key_env or {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "google": "GOOGLE_API_KEY",
+            "gemini": "GEMINI_API_KEY",
+            "deepseek": "DEEPSEEK_API_KEY",
+            "openrouter": "OPENROUTER_API_KEY",
+        }.get(provider, f"{provider.upper()}_API_KEY")
+        base_url = args.base_url or os.environ.get(f"{provider.upper()}_BASE_URL") or None
+
+        acl_path = Path(args.acl_path)
+        acl_path.parent.mkdir(parents=True, exist_ok=True)
+        acl_path.write_text(
+            _build_acl(args.model, provider, api_key_env, base_url=base_url),
+            encoding="utf-8",
+        )
+
+        instruction = Path(args.instruction_file).read_text(encoding="utf-8")
+
+        from a3s_code import Agent, ConfirmationPolicy, PermissionPolicy, SessionOptions
+
+        agent = Agent.create(str(acl_path))
+        opts = SessionOptions()
+        # Unattended TB execution: allow tools and auto-approve Ask.
+        opts.permission_policy = PermissionPolicy(default_decision="allow")
+        opts.confirmation_policy = ConfirmationPolicy(enabled=False)
+
+        session = agent.session(args.workspace, opts)
+        result = session.send({"prompt": instruction})
+        text = getattr(result, "text", None) or str(result)
+        _write_json(
+            result_path,
+            {
+                "ok": True,
+                "model": args.model,
+                "text_preview": text[:4000],
+                "text_len": len(text),
+            },
+        )
+        print(text)
+        return 0
+    except Exception as exc:
+        error_path.write_text(
+            "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            encoding="utf-8",
+        )
+        _write_json(
+            result_path,
+            {
+                "ok": False,
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+        )
+        print(f"a3s-code runner failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/harbor/download_wheel.sh
+++ b/scripts/harbor/download_wheel.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/wheels" && pwd)"
+mkdir -p "$DIR"
+cd "$DIR"
+VERSION="${1:-8.2.0}"
+WHEEL="a3s_code-${VERSION}-cp310-abi3-manylinux_2_28_x86_64.whl"
+URL="https://github.com/A3S-Lab/Code/releases/download/v${VERSION}/${WHEEL}"
+echo "fetching ${URL}"
+if [[ -f "$WHEEL" ]]; then
+  echo "already present: $WHEEL"
+  ls -lh "$WHEEL"
+  exit 0
+fi
+curl -L --fail --retry 5 --retry-delay 2 -o "${WHEEL}.partial" "$URL"
+mv "${WHEEL}.partial" "$WHEEL"
+ls -lh "$WHEEL"

--- a/scripts/harbor/materialize_env_from_a3s_config.py
+++ b/scripts/harbor/materialize_env_from_a3s_config.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Materialize scripts/harbor/.env from .a3s/config.acl without printing secrets."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    root = _repo_root()
+    src_path = root / ".a3s" / "config.acl"
+    if not src_path.exists():
+        print(f"ERROR: missing {src_path}")
+        return 1
+
+    src = src_path.read_text(encoding="utf-8")
+    m_key = re.search(r'api_key\s*=\s*"([^"]+)"', src)
+    m_base = re.search(r'base_url\s*=\s*"([^"]+)"', src)
+    m_model = re.search(r'default_model\s*=\s*"([^"]+)"', src)
+    key = m_key.group(1) if m_key else ""
+    base = m_base.group(1) if m_base else "https://api.deepseek.com"
+    model = m_model.group(1) if m_model else "deepseek/deepseek-v4-pro"
+    if not key:
+        print("ERROR: no api_key in .a3s/config.acl")
+        return 1
+
+    env_path = root / "scripts" / "harbor" / ".env"
+    env_path.write_text(
+        "# Generated from .a3s/config.acl — do not commit\n"
+        f"DEEPSEEK_API_KEY={key}\n"
+        f"DEEPSEEK_BASE_URL={base}\n"
+        f"A3S_TB_MODEL={model}\n",
+        encoding="utf-8",
+    )
+    try:
+        os.chmod(env_path, 0o600)
+    except OSError:
+        pass
+    print(f"wrote={env_path}")
+    print(f"model={model}")
+    print(f"base_url={base}")
+    print(f"key_set={bool(key)}")
+    print(f"key_len={len(key)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/harbor/wheels/.gitignore
+++ b/scripts/harbor/wheels/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/tb40_a3s_agent_smoke.sh
+++ b/scripts/tb40_a3s_agent_smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# 1-task Harbor agent smoke for A3S Code (requires model API key).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$HOME/.local/bin:$PATH"
+export PYTHONPATH="$REPO_ROOT/scripts/harbor${PYTHONPATH:+:$PYTHONPATH}"
+JOB_DIR="${A3S_HARBOR_JOBS_DIR:-$REPO_ROOT/.harbor-smoke}"
+HARBOR_PY="${HARBOR_PY:-$HOME/.local/share/uv/tools/harbor/bin/python}"
+MODEL="${1:-}"
+ENV_FILE="$REPO_ROOT/scripts/harbor/.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+  echo "loaded_env_file=$ENV_FILE"
+else
+  echo "no_env_file=$ENV_FILE"
+fi
+
+if [[ -z "$MODEL" ]]; then
+  MODEL="${A3S_TB_MODEL:-deepseek/deepseek-v4-pro}"
+fi
+echo "using_model=$MODEL"
+
+have_key=0
+for k in OPENAI_API_KEY ANTHROPIC_API_KEY DEEPSEEK_API_KEY OPENROUTER_API_KEY; do
+  if [[ -n "${!k:-}" ]]; then
+    have_key=1
+    echo "detected_key_env=$k"
+  fi
+done
+if [[ "$have_key" -eq 0 ]]; then
+  echo "No model API key detected. Create $ENV_FILE from .env.example and set one key." >&2
+  echo "Or run: python3 $REPO_ROOT/scripts/harbor/materialize_env_from_a3s_config.py" >&2
+  exit 2
+fi
+
+mkdir -p "$JOB_DIR"
+cd "$JOB_DIR"
+
+set +e
+harbor run \
+  -d "terminal-bench/terminal-bench@4.0.0" \
+  -a "a3s_code_agent.agent:A3sCodeAgent" \
+  -m "$MODEL" \
+  -e docker \
+  -n 1 \
+  -l 1 \
+  -k 1 \
+  --agent-setup-timeout-multiplier 3 \
+  --jobs-dir "$JOB_DIR/jobs" 2>&1 | tee "$JOB_DIR/a3s-agent-smoke.log"
+RC=${PIPESTATUS[0]}
+set -e
+
+"$HARBOR_PY" - <<PY
+import json
+from pathlib import Path
+result_dirs = sorted(Path(r"$JOB_DIR/jobs").glob("*"), key=lambda p: p.stat().st_mtime)
+n_errors = None
+result_path = None
+trial_error = None
+if result_dirs:
+    candidate = result_dirs[-1] / "result.json"
+    if candidate.exists():
+        result_path = str(candidate)
+        payload = json.loads(candidate.read_text(encoding="utf-8"))
+        n_errors = payload.get("stats", {}).get("n_errored_trials")
+    exceptions = sorted(result_dirs[-1].glob("*/exception.txt"), key=lambda p: p.stat().st_mtime)
+    if exceptions:
+        trial_error = exceptions[-1].read_text(encoding="utf-8")[-2500:]
+effective_rc = $RC
+if n_errors:
+    effective_rc = 1
+print(f"AGENT_SMOKE_RC={effective_rc}")
+if trial_error:
+    print(trial_error)
+raise SystemExit(effective_rc)
+PY

--- a/scripts/tb40_a3s_install_only.sh
+++ b/scripts/tb40_a3s_install_only.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Harbor --install-only smoke for the A3S Code adapter (no model API key required).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$HOME/.local/bin:$PATH"
+export PYTHONPATH="$REPO_ROOT/scripts/harbor${PYTHONPATH:+:$PYTHONPATH}"
+JOB_DIR="${A3S_HARBOR_JOBS_DIR:-$REPO_ROOT/.harbor-smoke}"
+HARBOR_PY="${HARBOR_PY:-$HOME/.local/share/uv/tools/harbor/bin/python}"
+
+"$HARBOR_PY" - <<PY
+import sys
+sys.path.insert(0, r"$REPO_ROOT/scripts/harbor")
+from a3s_code_agent.agent import A3sCodeAgent
+print("IMPORT_OK", A3sCodeAgent.name())
+PY
+
+mkdir -p "$JOB_DIR"
+cd "$JOB_DIR"
+
+set +e
+harbor run \
+  -d "terminal-bench/terminal-bench@4.0.0" \
+  -a "a3s_code_agent.agent:A3sCodeAgent" \
+  -e docker \
+  -n 1 \
+  -l 1 \
+  -k 1 \
+  --install-only \
+  --jobs-dir "$JOB_DIR/jobs" 2>&1 | tee "$JOB_DIR/a3s-install-only.log"
+RC=${PIPESTATUS[0]}
+set -e
+
+"$HARBOR_PY" - <<PY
+import json
+from pathlib import Path
+result_dirs = sorted(Path(r"$JOB_DIR/jobs").glob("*"), key=lambda p: p.stat().st_mtime)
+n_errors = None
+if result_dirs:
+    candidate = result_dirs[-1] / "result.json"
+    if candidate.exists():
+        payload = json.loads(candidate.read_text(encoding="utf-8"))
+        n_errors = payload.get("stats", {}).get("n_errored_trials")
+effective_rc = $RC
+if n_errors:
+    effective_rc = 1
+print(f"INSTALL_ONLY_RC={effective_rc}")
+raise SystemExit(effective_rc)
+PY

--- a/scripts/tb40_env_smoke.sh
+++ b/scripts/tb40_env_smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Host environment + oracle smoke for Terminal-Bench 4.0 / Harbor.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$HOME/.local/bin:$PATH"
+JOB_DIR="${A3S_HARBOR_JOBS_DIR:-$REPO_ROOT/.harbor-smoke}"
+
+checks_json=$(python3 - <<'PY'
+import json, subprocess
+checks = {}
+cmds = {
+  "python": ["python3", "--version"],
+  "uv": ["uv", "--version"],
+  "harbor": ["harbor", "--version"],
+  "docker": ["docker", "ps"],
+  "gpu": ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv"],
+}
+for key, cmd in cmds.items():
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        checks[key] = {"rc": p.returncode, "out": (p.stdout or p.stderr).strip()[:400]}
+    except Exception as exc:
+        checks[key] = {"rc": -1, "out": str(exc)}
+print(json.dumps(checks))
+PY
+)
+
+echo "PRECHECK=$checks_json"
+
+mkdir -p "$JOB_DIR"
+cd "$JOB_DIR"
+
+set +e
+harbor run \
+  -d "terminal-bench/terminal-bench@4.0.0" \
+  -a oracle \
+  -e docker \
+  -n 1 \
+  -l 1 \
+  -k 1 \
+  --jobs-dir "$JOB_DIR/jobs" 2>&1 | tee "$JOB_DIR/oracle-smoke.log"
+RC=${PIPESTATUS[0]}
+set -e
+
+echo "ORACLE_RC=$RC"
+exit "$RC"


### PR DESCRIPTION
## Summary
- Add A3S Code Harbor `BaseInstalledAgent` adapter and headless runner
- Persist TB 4.0 evaluation runbook (setup, smoke ladder, full `harbor run`)
- Wire smoke scripts and docs links from README / AGENTS / CLAUDE

## Test plan
- [ ] Review `scripts/harbor/EVALUATION.md` for accuracy
- [ ] Optional (WSL): materialize `.env` from `.a3s/config.acl` and run `tb40_a3s_install_only.sh`

Made with [Cursor](https://cursor.com)