### PR TITLE
chore: bump apps/cloud for U0.3 live-host certification validation

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "39c00fd82960c1becc25b58262da2f176c801395"
+  revision = "f082cd8599a7ca190ac6bdb1d2d6fb626ac91ea8"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Bump `apps/cloud` gitlink to `f082cd85` (harden U0.3 live-host certification validation).
- Align `compat/cloud-stack.acl` cloud revision with the same tip.
- Cloud change requires typed `A3S_CLOUD_U0_3_LIVE_HOST_CERTIFIED` fields matching `use-revision` and rejects `PLACEHOLDER_*`, so example certs cannot unlock `EXIT_CERTIFIED`.

## Test plan
- [ ] Cloud: `bash -n tools/use-conformance/validate_live_host_certification.sh`
- [ ] Cloud: validator FAIL on `live-host-certification.example.txt`; PASS on temp cert with matching 40hex revision
- [ ] `just cloud-stack-check` (or CI cloud-stack workflow) against this pin
- [ ] Confirm CI shell-syntax job includes the new validator script


Made with [Cursor](https://cursor.com)