### PR TITLE
chore: bump apps/cloud for U0.3 exit-audit CI fail-closed harness

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "f082cd8599a7ca190ac6bdb1d2d6fb626ac91ea8"
+  revision = "1e1cbdbf74c3e50147eea8df0c18a338fd2203a3"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Bump `apps/cloud` gitlink to `1e1cbdbf` (U0.3 exit-audit CI fail-closed harness).
- Align `compat/cloud-stack.acl` cloud revision with the same tip.
- Cloud change adds `run_u0_3_exit_audit_ci.sh` (validator FAIL/PASS self-check + light exit-audit without live host must exit 2 with `EXIT_BLOCKED`; never claims product `EXIT_CERTIFIED`).

## Test plan
- [ ] Cloud: `bash tools/use-conformance/run_u0_3_exit_audit_ci.sh` prints `A3S_CLOUD_U0_3_EXIT_AUDIT_CI_CERTIFIED`
- [ ] Cloud: repository-policy CI runs harness + `bash -n` on the new script
- [ ] Confirm evidence contains `EXIT_BLOCKED` and never `EXIT_CERTIFIED`
- [ ] `just cloud-stack-check` (or CI cloud-stack workflow) against this pin


Made with [Cursor](https://cursor.com)