### PR TITLE
chore: bump apps/cloud for U0.3 live-host evidence collector

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "1e1cbdbf74c3e50147eea8df0c18a338fd2203a3"
+  revision = "7c2aae7a8e635473baaddaf04562a858f83f966a"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Bump `apps/cloud` gitlink to `7c2aae7a` (U0.3 live-host evidence collector).
- Align `compat/cloud-stack.acl` cloud revision with the same tip.
- Cloud change adds operator-only `collect_live_host_evidence.sh` (validated `LIVE_HOST_CERTIFIED` + sidecars/checklist; never emits product `EXIT_CERTIFIED`), README/example/docs notes, and CI harness self-check + `bash -n`.

## Test plan
- [ ] Cloud: `bash tools/use-conformance/run_u0_3_exit_audit_ci.sh` prints `A3S_CLOUD_U0_3_EXIT_AUDIT_CI_CERTIFIED` (includes collector PASS + PLACEHOLDER refuse)
- [ ] Cloud: repository-policy CI runs `bash -n` on `collect_live_host_evidence.sh`
- [ ] Confirm collector/harness never claim product `EXIT_CERTIFIED`
- [ ] Locked stack (`cloud-stack` workflow) green against this pin


Made with [Cursor](https://cursor.com)