### PR TITLE
chore: sync cloud-stack.acl cloud revision to 162f4ee

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "7c2aae7a8e635473baaddaf04562a858f83f966a"
+  revision = "162f4eecc9ca9da8c5553f67a3ff021732ec4f67"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- `apps/cloud` on main already points at `162f4eecc9ca9da8c5553f67a3ff021732ec4f67`
- `compat/cloud-stack.acl` cloud component revision was still on `7c2aae7a8e635473baaddaf04562a858f83f966a`
- Update only the cloud component revision so Locked stack matches the gitlink

## Test plan
- [ ] CI Locked stack / cloud-stack-check passes
- [ ] Confirm no other component revisions changed


Made with [Cursor](https://cursor.com)