### PR TITLE
chore: bump apps/cloud for U0.3 Postgres role bootstrap

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "162f4eecc9ca9da8c5553f67a3ff021732ec4f67"
+  revision = "7ee7b778b4ee875ad229acb4f24ce4c2ee7cc64b"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Bump `apps/cloud` to `7ee7b778b4ee875ad229acb4f24ce4c2ee7cc64b` (Postgres migration/serving role bootstrap in U0.3 live-host prep)
- Keep `compat/cloud-stack.acl` cloud revision in lockstep with the gitlink

## Test plan
- [x] Cloud: `bash tools/use-conformance/run_u0_3_exit_audit_ci.sh`
- [x] Cloud: prep + migrate against `a3s-u03-pg` reaches control-plane start
- [ ] a3s Locked stack and contracts green

Made with [Cursor](https://cursor.com)