### PR TITLE
Add just up and just down for a3s-cloud

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,9 +53,22 @@ docs-build:
 # A3S Cloud
 # ============================================================================
 
-# Start the Cloud API and hot-reloading web console
-cloud:
+# Ensure the Cloud submodule is present for local recipes.
+[private]
+cloud-submodule:
+    sh scripts/ensure-dev-submodules.sh apps/cloud:Cargo.toml
+
+# Start the Cloud API in the foreground (deps via a3s-box when URL unset)
+cloud: cloud-submodule
     cd apps/cloud && just cloud
+
+# One-click: start a3s-cloud dependencies + control-plane (detached)
+up: cloud-submodule
+    cd apps/cloud && just up
+
+# One-click: stop detached a3s-cloud API and local dependencies
+down: cloud-submodule
+    cd apps/cloud && just down
 
 # ============================================================================
 # A3S Desktop


### PR DESCRIPTION
## Summary
- Bump `apps/cloud` to include `just up` / `just down` (a3s-box compose or Docker fallback, Postgres role bootstrap, pid-based stop).
- Add root `cloud-submodule` helper and wrap Cloud `up` / `down` / `cloud` recipes through it.

## Test plan
- [x] `just --list` shows `up` and `down`
- [x] `bash -n apps/cloud/tools/dev/cloud_up.sh apps/cloud/tools/dev/cloud_down.sh`
- [ ] Optional: `just up` / `just down` when Docker or a3s-box is available


Made with [Cursor](https://cursor.com)