### PR TITLE
chore: bump Cloud for BX0.5 clean-host CI harness

### DIFF
--- a/compat/cloud-stack.acl
+++ b/compat/cloud-stack.acl
@@ -36,7 +36,7 @@ component "cloud" {
   owner = "A3S-Lab/Cloud"
   path = "apps/cloud"
   repository = "git@github.com:A3S-Lab/Cloud.git"
-  revision = "5fd1abb92f33d89aab1b2dfb5ebf4a6e2022826a"
+  revision = "e5c835594bc1ab8724f0b5df20d8abc73ab52d0f"
   source = "git"
   version = "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Bump `apps/cloud` gitlink to `e5c835594bc1ab8724f0b5df20d8abc73ab52d0f` (BX0.5 clean-host CI fail-closed harness).
- Sync `compat/cloud-stack.acl` component `cloud` revision to the same SHA.
- No Box or other stack component changes.

## Test plan
- [ ] Confirm PR diff is only `apps/cloud` + `compat/cloud-stack.acl` cloud revision
- [ ] Wait for Locked / Check CI to go green
- [ ] Squash-merge to main when required checks pass


Made with [Cursor](https://cursor.com)