### PR TITLE
docs: record OCI Runtime v0.3.6 as experimental

### DIFF
--- a/apps/docs/components/home/architecture/runtime.ts
+++ b/apps/docs/components/home/architecture/runtime.ts
@@ -23,7 +23,7 @@ export const runtimeArchitectureProjects: readonly ArchitectureProject[] = [
     role: localized('在 macOS、Linux 和 Windows 上管理 OCI 工作负载与隔离。', 'Manages OCI workloads and isolation on macOS, Linux, and Windows.'),
     href: getProjectPrimaryHref('oci-runtime'),
     nodes: [
-      node('consumers', 'Consumers & SDK', 'surface', 'CLI、RuntimeClient 与未来 shim 使用同一平台中立入口。', 'CLI, RuntimeClient, and future shims use one platform-neutral entrypoint.'),
+      node('consumers', 'Consumers & SDK', 'surface', 'CLI、RuntimeClient 与 containerd shim 使用同一公开 SDK。shim 不是生产就绪路径。', 'CLI, RuntimeClient, and the containerd shim share the public SDK. The shim is not a production-ready path.'),
       node('service', 'OciRuntimeService', 'core', '拥有 OCI schema、语义验证与宿主控制面。', 'Owns OCI schema, semantic validation, and the host control plane.'),
       node('lifecycle', 'Durable Lifecycle', 'contract', '持久化 exact config、operation journal、generation 与 fencing。', 'Persists exact config, operation journals, generations, and fencing.'),
       node('selection', 'RuntimeDriver', 'runtime', '显式选择共享宿主内核或 Utility VM 隔离。', 'Explicitly selects shared-host-kernel or Utility VM isolation.'),

--- a/apps/docs/components/home/ecosystem-status.test.ts
+++ b/apps/docs/components/home/ecosystem-status.test.ts
@@ -48,15 +48,15 @@ describe('ecosystem delivery status', () => {
   });
 
   test('records the verified status snapshot', () => {
-    assert.equal(statusVerifiedAt, '2026-09-05');
-    assert.equal(getProjectDeliveryStatus('cli', 'en').release, 'v0.12.5');
+    assert.equal(statusVerifiedAt, '2026-09-10');
+    assert.equal(getProjectDeliveryStatus('cli', 'en').release, 'v0.15.11');
     assert.equal(getProjectDeliveryStatus('flow', 'en').stage, 'released');
     assert.equal(getProjectDeliveryStatus('flow', 'en').release, 'v1.0.0');
     assert.equal(getProjectDeliveryStatus('power', 'en').stage, 'preview');
     assert.equal(getProjectDeliveryStatus('windhole', 'en').stage, 'preview');
     assert.equal(getProjectDeliveryStatus('gui', 'en').stage, 'preview');
     assert.equal(getProjectDeliveryStatus('oci-runtime', 'en').stage, 'experimental');
-    assert.equal(getProjectDeliveryStatus('oci-runtime', 'en').release, 'v0.2.0');
+    assert.equal(getProjectDeliveryStatus('oci-runtime', 'en').release, 'v0.3.6');
     assert.equal(getProjectDeliveryStatus('updater', 'en').stage, 'released');
     assert.equal(getProjectDeliveryStatus('updater', 'en').release, 'v0.3.0');
   });

--- a/apps/docs/components/home/ecosystem-status.ts
+++ b/apps/docs/components/home/ecosystem-status.ts
@@ -34,7 +34,7 @@ const statusByProject = {
   cloud: { stage: 'experimental', release: 'main' },
   site: { stage: 'released', release: 'live' },
   runtime: { stage: 'preview', release: 'v0.3.0' },
-  'oci-runtime': { stage: 'experimental', release: 'v0.2.0' },
+  'oci-runtime': { stage: 'experimental', release: 'v0.3.6' },
   flow: { stage: 'released', release: 'v1.0.0' },
   event: { stage: 'preview', release: 'v0.3.0' },
   lane: { stage: 'preview', release: 'v0.5.1' },


### PR DESCRIPTION
## Summary
- Point the site status at published OCI Runtime `v0.3.6` and keep the stage `experimental` because fresh-host gates are still open.
- Pin `crates/oci-runtime` to the feature-coverage docs commit. That inventory does not promote readiness.

## Test plan
- [x] `bun test components/home/ecosystem-status.test.ts` in `apps/docs`


Made with [Cursor](https://cursor.com)